### PR TITLE
Adds endpoints to filter attachments by label

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -28,6 +28,8 @@ return [
 		['name' => 'publications#download', 'url' => '/api/publications/{id}/download', 'verb' => 'GET'],
 		// Attachments
 		['name' => 'attachments#create', 'url' => '/api/attachments', 'verb' => 'POST'],
+		['name' => 'attachments#byLabel', 'url' => '/api/attachments-by-label/{label}', 'verb' => 'GET'],
+		['name' => 'attachments#withoutLabel', 'url' => '/api/attachments-without-label', 'verb' => 'GET'],
 		// user Settings & Global Configuration
 		['name' => 'settings#index', 'url' => '/settings', 'verb' => 'GET'],
 		['name' => 'settings#create', 'url' => '/settings', 'verb' => 'POST'],

--- a/lib/Controller/AttachmentsController.php
+++ b/lib/Controller/AttachmentsController.php
@@ -128,4 +128,55 @@ class AttachmentsController extends Controller
 
         return new JSONResponse($object);
     }
+
+    /**
+     * Get attachments by label.
+     *
+     * @param ObjectService $objectService The service to handle object operations.
+     * @param string $label The label to filter attachments by.
+     *
+     * @return JSONResponse The response containing the attachments with the specified label.
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     */
+    public function byLabel(ObjectService $objectService, string $label): JSONResponse
+    {
+        // Create request parameters with the label as a filter and no pagination
+        $requestParams = [
+            'labels' => $label,
+            '_limit' => null // No limit to get all results
+        ];
+        
+        // Get all attachments with the specified label
+        $result = $objectService->getResultArrayForRequest('attachment', $requestParams);
+        
+        // Return only the results array without pagination info
+        return new JSONResponse($result['results']);
+    }
+
+    /**
+     * Get attachments without any label.
+     *
+     * @param ObjectService $objectService The service to handle object operations.
+     *
+     * @return JSONResponse The response containing attachments that don't have any label.
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     */
+    public function withoutLabel(ObjectService $objectService): JSONResponse
+    {
+        // Create request parameters with a filter for empty labels and no pagination
+        $requestParams = [
+            'labels' => [], // Empty array to filter for attachments without labels
+            '_limit' => null // No limit to get all results
+        ];
+        
+        // Get all attachments without labels
+        $result = $objectService->getResultArrayForRequest('attachment', $requestParams);
+        
+        // Return only the results array without pagination info
+        return new JSONResponse($result['results']);
+    }
 }


### PR DESCRIPTION
Adds two new API endpoints: one to retrieve attachments
associated with a specific label, and another to retrieve
attachments that have no labels. This allows clients to
easily filter and retrieve attachments based on their
labeling status.
