### PR TITLE
Closing modal redirects user to viewObject

### DIFF
--- a/src/modals/generic/UploadFiles.vue
+++ b/src/modals/generic/UploadFiles.vue
@@ -355,10 +355,13 @@ export default {
 	},
 	methods: {
 		closeModal() {
+			navigationStore.setModal(null)
+			setTimeout(() => {
+				navigationStore.setModal('viewObject')
+			}, 10)
 			this.success = null
 			this.error = null
 			reset()
-			navigationStore.setModal(false)
 		},
 		bytesToSize(bytes) {
 			const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB']


### PR DESCRIPTION
Great example of "If it works, don't touch it"
