### PR TITLE
hotfix: database source slug searching with syntax fix

### DIFF
--- a/lib/Controller/PagesController.php
+++ b/lib/Controller/PagesController.php
@@ -234,7 +234,7 @@ class PagesController extends Controller
         // Build search query to find page by slug
         $searchQuery = [
             'slug' => $slug,
-            '_limit' => 1  // We only need one result,
+            '_limit' => 1,  // We only need one result
             '_source' => 'database'  // We only need one result, and is should always be true
         ];
 


### PR DESCRIPTION
## Summary
This pull request contains the hotfix for slug searching to ensure database source is used, along with the syntax fix that resolves API 500 errors.

## Changes
- **Database Source**: Added `'_source' => 'database'` parameter to slug search query
- **Syntax Fix**: Corrected missing comma in PHP array syntax that was causing ParseError
- **API Fix**: Resolves 500 errors on `/api/pages` and `/api/menus` endpoints

## Commits Included
1. `hotfix: force slug searching to use database source`
2. `fix: correct array syntax in PagesController slug search`

## Type of Change
- [x] Bug fix (hotfix)
- [x] Critical fix for API endpoints
- [x] Database query optimization

## Testing
- Slug-based page lookups now consistently use database source
- API endpoints return proper responses instead of 500 errors
- Eliminates search index synchronization issues

## Impact
- **Before**: API calls resulted in 500 ParseError due to syntax issue
- **After**: Clean API responses with reliable database-sourced slug searches