### PR TITLE
fix: Remove hardcoded _source=database

### DIFF
--- a/lib/Controller/GlossaryController.php
+++ b/lib/Controller/GlossaryController.php
@@ -190,9 +190,6 @@ class GlossaryController extends Controller
             $searchQuery['@self']['register'] = $glossaryConfig['register'];
         }
 
-        // Use database source (SOLR index may not be available in all environments).
-        $searchQuery['_source'] = 'database';
-
         // Use searchObjectsPaginated for better performance and pagination support.
         // Set rbac=false, multi=false for public glossary access.
         // Glossary terms do not use the publishing workflow, so published=false.
@@ -271,7 +268,6 @@ class GlossaryController extends Controller
         $searchQuery = [
             '_ids'    => [$id],
             '_limit'  => 1,
-            '_source' => 'database',
         ];
         // Glossary terms do not use the publishing workflow, so published=false.
         $result = $this->getObjectService()->searchObjectsPaginated(

--- a/lib/Controller/MenusController.php
+++ b/lib/Controller/MenusController.php
@@ -272,7 +272,6 @@ class MenusController extends Controller
         $searchQuery = [
             '_ids'    => [$id],
             '_limit'  => 1,
-            '_source' => 'database',
         ];
         $result      = $this->getObjectService()->searchObjectsPaginated(
             $searchQuery,

--- a/lib/Controller/PagesController.php
+++ b/lib/Controller/PagesController.php
@@ -269,8 +269,6 @@ class PagesController extends Controller
         $searchQuery = [
             'slug'    => $slug,
             '_limit'  => 1,
-        // We only need one result.
-            '_source' => 'database',
         ];
 
         // Add schema filter if configured - use _schema for magic mapper routing.

--- a/src/store/modules/object.js
+++ b/src/store/modules/object.js
@@ -771,13 +771,6 @@ export const useObjectStore = defineStore('object', {
 					_extend: params?._extend || params?.extend || '@self.schema',
 				}
 
-				// Add _source=database for types that aren't indexed in Solr
-				// This includes: menu, page, glossary, theme, organization, listing, catalog, audit-trails, uses, used, files
-				const nonIndexedTypes = ['menu', 'page', 'glossary', 'theme', 'organization', 'listing', 'catalog', 'audit-trails', 'uses', 'used', 'files']
-				if (nonIndexedTypes.includes(type) && !params?._source && !params?.source) {
-					queryParams._source = 'database'
-				}
-
 				const response = await fetch(this._constructApiUrl(type, null, null, queryParams))
 				if (!response.ok) throw new Error(`Failed to fetch ${type} collection`)
 


### PR DESCRIPTION
## Summary
- Remove hardcoded `_source = 'database'` from GlossaryController, MenusController, and PagesController
- Remove frontend workaround in `object.js` that forced `_source=database` for non-indexed types
- Let the backend decide which search source to use based on configuration

## Test plan
- [ ] Verify glossary, menus, and pages endpoints still return results
- [ ] Verify frontend object fetching works without forced database source
- [ ] Run SWC API test suite to confirm no regressions