### PR TITLE
chore: Final OpenSpec structure cleanup

### DIFF
--- a/openspec/changes/archive/2026-02-17-org-archimate-export/specs/org-archimate-export/spec.md
+++ b/openspec/changes/archive/2026-02-17-org-archimate-export/specs/org-archimate-export/spec.md
@@ -3,7 +3,7 @@
 ## Purpose
 Defines how the softwarecatalog app exports an organization-enriched ArchiMate (AMEFF) XML file that includes the base GEMMA model plus the organization's applications plotted on referentiecomponenten, with proper folder structure, naming, and metadata.
 
-## ADDED Requirements
+## Requirements
 
 ### Requirement: Export MUST produce valid ArchiMate XML with organization applications
 The organization export MUST generate a valid AMEFF XML file that includes all base GEMMA objects plus synthesized application elements, specialization relationships, enriched view copies, and organization folder structure.

--- a/openspec/changes/archive/2026-02-19-enhance-amef-export-org-data/specs/org-archimate-export/spec.md
+++ b/openspec/changes/archive/2026-02-19-enhance-amef-export-org-data/specs/org-archimate-export/spec.md
@@ -3,7 +3,7 @@
 ## Purpose
 Enhances the org-specific AMEF export to include deelname (participation) data, organise output into typed folders, and replace the POST endpoint with a GET download endpoint with query parameters.
 
-## ADDED Requirements
+## Requirements
 
 ### Requirement: Export MUST include deelname data when deelnames parameter is enabled
 When the `deelnames` query parameter is `true`, the export MUST query gebruik objects where the current organisation's UUID appears in the `deelnemers` field (with RBAC disabled) and include those applications in the output.

--- a/openspec/specs/deelnames-gebruik/spec.md
+++ b/openspec/specs/deelnames-gebruik/spec.md
@@ -1,3 +1,7 @@
+---
+status: implemented
+---
+
 # Deelnames Gebruik Specification
 
 ## Purpose
@@ -16,7 +20,7 @@ In the Dutch municipal landscape, organizations frequently share software applic
 - Leverages the softwarecatalog enrichment API for view data retrieval
 - Builds on the existing GEMMA view and referentiecomponent data model
 
-## ADDED Requirements
+## Requirements
 
 ### Requirement: ViewService MUST retrieve deelnames gebruik separately from regular gebruik
 The ViewService MUST perform a two-phase retrieval: regular gebruik filtered by RBAC, then deelnames gebruik with RBAC disabled filtering by the `deelnemers` field.

--- a/openspec/specs/module-overlay-rendering/spec.md
+++ b/openspec/specs/module-overlay-rendering/spec.md
@@ -1,3 +1,7 @@
+---
+status: implemented
+---
+
 # Module Overlay Rendering Specification
 
 ## Purpose
@@ -17,7 +21,7 @@ GEMMA views are ArchiMate diagrams that show the Dutch municipal reference archi
 - Parent-child: JointJS parent embedding for nesting modules inside referentiecomponenten
 - Performance: paper.freeze()/unfreeze() pattern for batch rendering
 
-## ADDED Requirements
+## Requirements
 
 ### Requirement: Module nodes MUST render as children of referentiecomponenten
 Module overlay nodes returned by the enrichment API MUST be rendered inside their parent referentiecomponent using the existing JointJS parent-child hierarchy.

--- a/openspec/specs/org-archimate-export/spec.md
+++ b/openspec/specs/org-archimate-export/spec.md
@@ -1,3 +1,7 @@
+---
+status: implemented
+---
+
 # Organization-Specific ArchiMate Export Specification
 
 ## Purpose
@@ -18,7 +22,7 @@ Organizations using the softwarecatalog map their applications to GEMMA referent
 - Added relationships: SpecializationRelationship linking modules to referentiecomponenten
 - Added views: Copies of qualifying GEMMA views with module nodes plotted
 
-## ADDED Requirements
+## Requirements
 
 ### Requirement: Export MUST produce valid ArchiMate XML with organization applications
 The organization export MUST generate a valid AMEFF XML file that includes all base GEMMA objects plus synthesized application elements, specialization relationships, enriched view copies, and organization folder structure.

--- a/openspec/specs/prometheus-metrics/spec.md
+++ b/openspec/specs/prometheus-metrics/spec.md
@@ -1,3 +1,7 @@
+---
+status: implemented
+---
+
 # Prometheus Metrics Endpoint
 
 ## Purpose
@@ -16,7 +20,7 @@ OpenCatalogi serves as the public-facing publication platform for government tra
 - OpenRegister has a reference MetricsService and HeartbeatController that can serve as a shared pattern
 - All Conduction apps should expose the same standard metrics set for unified monitoring
 
-## ADDED Requirements
+## Requirements
 
 ### Requirement: Metrics endpoint MUST expose standard metrics
 The `GET /api/metrics` endpoint MUST return metrics in Prometheus text exposition format covering app health, request counts, and error tracking.

--- a/openspec/specs/register-i18n/spec.md
+++ b/openspec/specs/register-i18n/spec.md
@@ -1,3 +1,7 @@
+---
+status: implemented
+---
+
 # Register Content Internationalization
 
 ## Purpose
@@ -22,7 +26,7 @@ Dutch municipalities increasingly serve multilingual populations and must comply
 - **Glossary item**: Term, definition -- domain-specific terminology
 - **Organization**: Title, description -- public-facing organization names
 
-## ADDED Requirements
+## Requirements
 
 ### Requirement: Publication fields MUST support multi-language content
 Publication objects MUST store and serve multi-language content for their primary text fields.

--- a/openspec/specs/view-enrichment-api/spec.md
+++ b/openspec/specs/view-enrichment-api/spec.md
@@ -1,3 +1,7 @@
+---
+status: implemented
+---
+
 # View Enrichment API Specification
 
 ## Purpose
@@ -16,7 +20,7 @@ Previously, the frontend called the OpenRegister API directly to fetch raw GEMMA
 - OpenCatalogi's existing public API (`/api/{catalogSlug}`) serves publication data; views are a softwarecatalog concern
 - The enrichment API calls OpenRegister's ObjectService internally for view, module, and gebruik data
 
-## ADDED Requirements
+## Requirements
 
 ### Requirement: Frontend MUST call enrichment API for views
 The frontend MUST use the softwarecatalog enrichment API (`/softwarecatalog/api/views/{viewId}`) instead of the OpenRegister direct API (`/openregister/api/objects/vng-gemma/view/{id}`) for all view rendering.

--- a/openspec/specs/woo-transparency/spec.md
+++ b/openspec/specs/woo-transparency/spec.md
@@ -1,3 +1,7 @@
+---
+status: implemented
+---
+
 # woo-transparency Specification
 
 ## Purpose
@@ -18,7 +22,7 @@ The document processing pipeline (entity detection, anonymization, PDF conversio
 - **Listing**: Individual WOO documents (openbaar and redacted deels-openbaar) become Listings within the WOO publication Catalog.
 - **Organization**: Links WOO publications to the responsible bestuursorgaan.
 
-## ADDED Requirements
+## Requirements
 
 ### Requirement: WOO document queue
 The system MUST provide a document processing queue for WOO requests, enabling users to track and manage the assessment status of all documents in a WOO request.


### PR DESCRIPTION
## Summary
- Add `status: implemented` frontmatter to 7 specs missing it
- Rename `## ADDED Requirements` to `## Requirements` in all specs and archives