### PR TITLE
chore: Harmonize .gitignore with org standard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,28 +1,47 @@
+# IDE
 /.idea/
 /*.iml
 *.Identifier
 
+# Dependencies
 /vendor/
 /vendor-bin/*/vendor/
-
-/.php-cs-fixer.cache
-/tests/.phpunit.cache
-
 /node_modules/
-/js/
-/custom_apps/
-/custom-apps/
-/config/
 
-/coverage/
-/coverage-frontend/
+# Build artifacts
+/js/
+
+# Documentation
+/docs/node_modules/
+/docs/build/
+/docs/.docusaurus/
 /website/node_modules/
 /website/.docusaurus/
 /website/build/
 
+# Testing & Quality
+/.php-cs-fixer.cache
+/tests/.phpunit.cache
+/.phpunit.cache/
+.phpunit.cache/
+.phpunit.result.cache
+/coverage/
+/coverage-frontend/
+/phpmetrics/
+/quality-reports/
+/phpqa/
+
+# Nextcloud
+/custom_apps/
+/custom-apps/
+/config/
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Claude Code
+.claude/worktrees/
+
+# Repo-specific
 /.nextcloud/certificates/opencatalogi.key
-
-/website/.docusaurus/
-/website/node_modules/
-
-phpqa/


### PR DESCRIPTION
## Summary
- Replaces the ad-hoc `.gitignore` with the organization-wide harmonized template
- Adds structured sections: IDE, Dependencies, Build artifacts, Documentation, Testing & Quality, Nextcloud, OS, Claude Code
- Keeps repo-specific entry for `/.nextcloud/certificates/opencatalogi.key`
- Removes duplicate entries (website/.docusaurus and website/node_modules were listed twice)

## Test plan
- [ ] Verify no tracked files are accidentally ignored by the new patterns
- [ ] Confirm build artifacts (`/js/`, `/vendor/`, `/node_modules/`) remain ignored