### PR TITLE
chore: resolve all PHPCS violations across lib/

### DIFF
--- a/lib/Controller/DashboardController.php
+++ b/lib/Controller/DashboardController.php
@@ -72,5 +72,4 @@ class DashboardController extends Controller
         }//end try
 
     }//end page()
-
 }//end class

--- a/lib/Controller/PublicationsController.php
+++ b/lib/Controller/PublicationsController.php
@@ -315,8 +315,15 @@ class PublicationsController extends Controller
                     // _name, _description, _summary are metadata columns in every magic table.
                     // _relevance is computed dynamically from search terms via pg_trgm similarity().
                     $universalOrderFields = [
-                        '_uuid', '_created', '_updated', '_published', '_depublished',
-                        '_name', '_description', '_summary', '_relevance',
+                        '_uuid',
+                        '_created',
+                        '_updated',
+                        '_published',
+                        '_depublished',
+                        '_name',
+                        '_description',
+                        '_summary',
+                        '_relevance',
                     ];
                     if (empty($searchQuery['_order']) === false && is_array($searchQuery['_order']) === true) {
                         foreach (array_keys($searchQuery['_order']) as $orderField) {
@@ -351,11 +358,17 @@ class PublicationsController extends Controller
                 $result['results'] = array_map(
                     callback: function ($item) {
                         // Serialize ObjectEntity instances to arrays before stripping empty values.
-                        if (is_array($item) === false && method_exists(object_or_class: $item, method: 'jsonSerialize') === true) {
+                        if (is_array($item) === false
+                            && method_exists(object_or_class: $item, method: 'jsonSerialize') === true
+                        ) {
                             $item = $item->jsonSerialize();
                         }
 
-                        return is_array($item) === true ? $this->stripEmptyValues(data: $item) : $item;
+                        if (is_array($item) === true) {
+                            return $this->stripEmptyValues(data: $item);
+                        }
+
+                        return $item;
                     },
                     array: $result['results']
                 );
@@ -1077,6 +1090,4 @@ class PublicationsController extends Controller
 
         return $result;
     }//end stripEmptyValues()
-
-
 }//end class

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -32,7 +32,6 @@ use RuntimeException;
  */
 class SettingsController extends Controller
 {
-
     /**
      * SettingsController constructor.
      *

--- a/lib/Listener/CatalogSchemaEventListener.php
+++ b/lib/Listener/CatalogSchemaEventListener.php
@@ -38,13 +38,16 @@ class CatalogSchemaEventListener implements IEventListener
 {
     /**
      * CatalogCacheEventListener constructor.
+     *
+     * @param CatalogiService $catalogiService Service used to invalidate and warm the catalog cache.
+     * @param LoggerInterface $logger          Logger for event-handling diagnostics.
+     * @param IAppConfig      $appConfig       App configuration for feature flags.
      */
     public function __construct(
         private readonly CatalogiService $catalogiService,
         private readonly LoggerInterface $logger,
         private readonly IAppConfig $appConfig
-    )
-    {
+    ) {
 
     }//end __construct()
 
@@ -85,6 +88,7 @@ class CatalogSchemaEventListener implements IEventListener
             if ($objectEntity->getSchema() !== $catalogSchema || $objectEntity->getRegister() !== $catalogRegister) {
                 return;
             }
+
             $this->catalogiService->rewriteSchemasAndRegisters($objectEntity);
         } catch (\Exception $e) {
             // Log unexpected errors and continue gracefully.

--- a/lib/Service/CatalogiService.php
+++ b/lib/Service/CatalogiService.php
@@ -197,32 +197,40 @@ class CatalogiService
         $schemas   = $object['schemas'];
 
         // First, attempt to rewrite the registers.
-        $registers = array_map(function ($register) {
-            if (preg_match("/^\d+$/", $register)) {
-                return $register;
-            }
-            try {
-                $registerObject = $this->getRegisterMapper()->find($register);
+        $registers = array_map(
+                function ($register) {
+                    if (preg_match("/^\d+$/", $register) === 1) {
+                        return $register;
+                    }
 
-                return $registerObject->getId();
-            } catch (NotFoundException $e) {
-                throw new \RuntimeException('Register ' . $register . ' not found.');
-            }
-        }, $registers);
+                    try {
+                        $registerObject = $this->getRegisterMapper()->find($register);
+
+                        return $registerObject->getId();
+                    } catch (NotFoundException $e) {
+                        throw new \RuntimeException('Register '.$register.' not found.');
+                    }
+                },
+                $registers
+                );
 
         // Then, attempt to rewrite the schemas.
-        $schemas = array_map(function ($schema) {
-            if (preg_match("/^\d+$/", $schema)) {
-                return $schema;
-            }
-            try {
-                $schemaObject = $this->getSchemaMapper()->find($schema);
+        $schemas = array_map(
+                function ($schema) {
+                    if (preg_match("/^\d+$/", $schema) === 1) {
+                        return $schema;
+                    }
 
-                return $schemaObject->getId();
-            } catch (NotFoundException $e) {
-                throw new \RuntimeException('Register ' . $schema . ' not found.');
-            }
-        }, $schemas);
+                    try {
+                        $schemaObject = $this->getSchemaMapper()->find($schema);
+
+                        return $schemaObject->getId();
+                    } catch (NotFoundException $e) {
+                        throw new \RuntimeException('Register '.$schema.' not found.');
+                    }
+                },
+                $schemas
+                );
 
         // Set the registers and schemas in the object and update the object.
         $object['registers'] = $registers;
@@ -264,7 +272,7 @@ class CatalogiService
         // UUIDs are matched on @self.uuid; anything else (e.g. a slug) is matched
         // on the object's own 'slug' field.
         if ($catalogId !== null) {
-              if (Uuid::isValid($catalogId) === true) {
+            if (Uuid::isValid($catalogId) === true) {
                 $query['@self']['uuid'] = $catalogId;
             } else {
                 $query['slug'] = $catalogId;

--- a/lib/Service/DirectoryService.php
+++ b/lib/Service/DirectoryService.php
@@ -713,7 +713,7 @@ class DirectoryService
             // different UUIDs for the same logical catalog.
             $existingListings = $objectService->searchObjects(
                 query: [
-                    '@self' => [
+                    '@self'       => [
                         'register' => $listingRegister,
                         'schema'   => $listingSchema,
                     ],
@@ -1812,8 +1812,8 @@ class DirectoryService
                         $listingData = $object;
                     }
 
-                    $objectData  = ($listingData['object'] ?? $listingData);
-                    $listingDir  = ($objectData['directory'] ?? '');
+                    $objectData = ($listingData['object'] ?? $listingData);
+                    $listingDir = ($objectData['directory'] ?? '');
 
                     // Skip listings that were synced from other directories.
                     if (empty($listingDir) === false && $listingDir !== $ourDirectoryUrl) {
@@ -1922,7 +1922,7 @@ class DirectoryService
 
         // Create listing object from catalog - only core API fields.
         $catalogId = ($catalog['id'] ?? $catalogData['id'] ?? '');
-        $listing = [
+        $listing   = [
             // Required fields for listing.
             'id'           => $catalogId,
             'catalog'      => $catalogId,

--- a/lib/Service/PublicationService.php
+++ b/lib/Service/PublicationService.php
@@ -136,7 +136,7 @@ class PublicationService
      * then sets that context on the ObjectService so subsequent operations can find the object.
      *
      * @param \OCA\OpenRegister\Service\ObjectService $objectService The object service instance
-     * @param string                                   $objectId     The UUID of the object to locate
+     * @param string                                  $objectId      The UUID of the object to locate
      *
      * @return void
      */
@@ -146,27 +146,47 @@ class PublicationService
             $db = $this->container->get(\OCP\IDBConnection::class);
 
             $result = $db->executeQuery(
-                "SELECT table_name FROM information_schema.tables WHERE table_name LIKE 'oc_openregister_table_%' ORDER BY table_name"
+                <<<'SQL'
+                SELECT table_name FROM information_schema.tables
+                WHERE table_name LIKE 'oc_openregister_table_%'
+                ORDER BY table_name
+                SQL
             );
 
             $unionParts = [];
             $quotedUuid = $db->quote($objectId);
-            while ($row = $result->fetch()) {
-                if (preg_match('/^oc_openregister_table_(\d+)_(\d+)$/', $row['table_name'], $matches)) {
-                    $register = (int) $matches[1];
-                    $schema   = (int) $matches[2];
-                    $unionParts[] = "(SELECT {$register} AS register_id, {$schema} AS schema_id FROM {$row['table_name']} WHERE _uuid = {$quotedUuid})";
+            $row        = $result->fetch();
+            while ($row !== false) {
+                $match = preg_match(
+                    pattern: '/^oc_openregister_table_(\d+)_(\d+)$/',
+                    subject: $row['table_name'],
+                    matches: $matches
+                );
+                if ($match === 1) {
+                    $register     = (int) $matches[1];
+                    $schema       = (int) $matches[2];
+                    $tableName    = $row['table_name'];
+                    $unionParts[] = sprintf(
+                        '(SELECT %d AS register_id, %d AS schema_id FROM %s WHERE _uuid = %s)',
+                        $register,
+                        $schema,
+                        $tableName,
+                        $quotedUuid
+                    );
                 }
-            }
+
+                $row = $result->fetch();
+            }//end while
+
             $result->closeCursor();
 
-            if (empty($unionParts)) {
+            if (empty($unionParts) === true) {
                 return;
             }
 
-            $sql = implode(' UNION ALL ', $unionParts) . ' LIMIT 1';
+            $sql    = implode(' UNION ALL ', $unionParts).' LIMIT 1';
             $result = $db->executeQuery($sql);
-            $row = $result->fetch();
+            $row    = $result->fetch();
             $result->closeCursor();
 
             if ($row !== false) {
@@ -175,9 +195,8 @@ class PublicationService
             }
         } catch (\Exception $e) {
             // Silently fail — worst case we fall back to the old behavior.
-        }
+        }//end try
     }//end setObjectServiceContext()
-
 
     /**
      * Attempts to retrieve the OpenRegister service from the container.

--- a/sbom.cdx.json
+++ b/sbom.cdx.json
@@ -2,10 +2,10 @@
   "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.5",
-  "serialNumber": "urn:uuid:c7c3d78c-db10-4b93-a935-240d021a2ceb",
+  "serialNumber": "urn:uuid:d5e256c0-504e-44de-ba49-f140c2cd42c8",
   "version": 1,
   "metadata": {
-    "timestamp": "2026-04-24T09:16:09Z",
+    "timestamp": "2026-04-24T09:30:34Z",
     "tools": [
       {
         "name": "composer",
@@ -82,10 +82,10 @@
       }
     ],
     "component": {
-      "bom-ref": "conductionnl/opencatalogi-dev-fix/consistent-rbac",
+      "bom-ref": "conductionnl/opencatalogi-dev-chore/phpcs-cleanup",
       "type": "application",
       "name": "opencatalogi",
-      "version": "dev-fix/consistent-rbac",
+      "version": "dev-chore/phpcs-cleanup",
       "group": "conductionnl",
       "description": "This is a DSO Nextcloud project for the municipality Buren and is done by ConductionNL",
       "author": "Conduction b.v., Remko Huisman (Conduction), Ruben van der Linde (Conduction)",
@@ -96,15 +96,15 @@
           }
         }
       ],
-      "purl": "pkg:composer/conductionnl/opencatalogi@dev-fix/consistent-rbac",
+      "purl": "pkg:composer/conductionnl/opencatalogi@dev-chore/phpcs-cleanup",
       "properties": [
         {
           "name": "cdx:composer:package:distReference",
-          "value": "e1af1af9b5b141eb03a9747b4a54d04db06a3224"
+          "value": "0add706b02083d1fe443ef83fff2de6ad53a0460"
         },
         {
           "name": "cdx:composer:package:sourceReference",
-          "value": "e1af1af9b5b141eb03a9747b4a54d04db06a3224"
+          "value": "0add706b02083d1fe443ef83fff2de6ad53a0460"
         },
         {
           "name": "cdx:composer:package:type",
@@ -48819,7 +48819,7 @@
       ]
     },
     {
-      "ref": "conductionnl/opencatalogi-dev-fix/consistent-rbac",
+      "ref": "conductionnl/opencatalogi-dev-chore/phpcs-cleanup",
       "dependsOn": [
         "adbario/php-dot-notation-3.3.0.0",
         "guzzlehttp/guzzle-7.10.0.0",


### PR DESCRIPTION
## Summary

- Clean sweep of PHPCS violations across `lib/`: `composer phpcs` now reports **0 errors / 0 warnings** across all 48 files (was 51 errors + 2 warnings in 7 files).
- `phpcbf` auto-fixed 40 of the violations; the remaining 11 errors + 2 warnings were resolved manually per the notes below.
- No functional changes — only style, comparison strictness, indentation, and one minor structural change to a `while` loop.

## Files changed

| File | Fixes |
|---|---|
| `lib/Controller/DashboardController.php` | 1 auto-fix |
| `lib/Controller/SettingsController.php` | 1 auto-fix |
| `lib/Controller/PublicationsController.php` | 8 auto-fix + 1 manual (inline IF split) + 1 warning (long line) |
| `lib/Listener/CatalogSchemaEventListener.php` | 2 auto-fix + 3 manual (`@param` docblocks) |
| `lib/Service/CatalogiService.php` | 14 auto-fix + 2 manual (`preg_match === 1`) |
| `lib/Service/DirectoryService.php` | 4 auto-fix |
| `lib/Service/PublicationService.php` | 10 auto-fix + 5 manual (see notes) |

## Manual-fix notes

- **`CatalogSchemaEventListener`** — constructor promoted its three params but the docblock was empty. Added `@param` lines for `$catalogiService`, `$logger`, `$appConfig`.
- **`CatalogiService`** — two `if (preg_match(...))` call sites changed to `if (preg_match(...) === 1)`. `preg_match` returns `int|false`, not `bool`, so the sniff's suggestion of `=== TRUE` is wrong; `=== 1` matches PHP semantics exactly.
- **`PublicationsController`** — inline ternary in a callback split into a full `if` + `return`/`return` pair (sniff: "Inline IF statements are not allowed"). Long line reformatted.
- **`PublicationService`** — several related fixes in one method:
  - `while ($row = $result->fetch())` restructured into an explicit priming fetch + `while ($row !== false)` loop (sniff: "Implicit true comparisons prohibited").
  - `preg_match` result compared with `=== 1` and called via named parameters (ADR-compliant — Conduction's custom PHPCS sniff requires named parameters for internal calls with more than one scalar argument).
  - Long `"(SELECT {$register} ...)"` string moved to `sprintf(...)` for readability and to avoid the string-concat sniff that forbids `"a" . "b"`.
  - Tables-lookup SQL moved to an indented heredoc to stay under the 125-character line-length warning without using concat.
  - `if (empty($unionParts))` made explicit: `=== true`.
  - Added `//end while` comment at the closing brace.

## Test plan

- [x] `docker exec nextcloud composer phpcs` — 0 errors / 0 warnings in `opencatalogi/`.
- [x] `php -l` clean on all 7 touched files.
- [ ] Full CI run on this PR (composer check:strict + Newman + JS lint).
- [ ] Smoke: hit a publications catalog endpoint to confirm the `PublicationService` restructuring (priming-fetch + named-parameter `preg_match`) produces identical SQL and results as before.

Based on the recently-merged `fix/consistent-rbac` → `development` (PR #481), so no interaction with that work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
