### PR TITLE
feat(openspec): opencatalogi-adopt-or-abstractions — heaviest frontend cleanup target

### DIFF
--- a/openspec/changes/opencatalogi-adopt-or-abstractions/design.md
+++ b/openspec/changes/opencatalogi-adopt-or-abstractions/design.md
@@ -1,0 +1,234 @@
+# Design — opencatalogi-adopt-or-abstractions
+
+## Context
+
+opencatalogi is the highest-traffic frontend in the Conduction fleet — it
+serves the public publication catalogues that municipalities and ministries
+expose to citizens. It also carries the largest volume of bespoke code
+duplicating capabilities OR or upstream Nextcloud now own (per
+`.claude/audit-2026-05-03/`). This change is the one large per-app
+adoption ticket that brings opencatalogi onto the shared abstractions.
+
+It is intentionally written as one change rather than eight because:
+
+1. **The controllers, store, and manifest are entangled.** Migrating
+   one controller to `RegisterResolverService` while the store still
+   hand-rolls register lookups produces inconsistent error shapes that
+   confuse the UI. The phases are ordered so each phase removes code
+   that the previous phase replaced.
+
+2. **The audit landed simultaneously across all five affected specs.**
+   Splitting the spec rewrites across multiple changes risks divergent
+   conventions (e.g., one spec citing `IFileService` and another citing
+   the older `FileService`). One change keeps citations aligned.
+
+3. **Manifest tiering depends on the upstream contracts being agreed.**
+   We cannot tier opencatalogi until the resolver, the i18n handler,
+   the multi-tenancy context, and the manifest interpreter are all
+   contractually settled. Authoring tiering decisions in the same
+   change as the abstraction adoption gives us a single review pass.
+
+## Goals
+
+- Delete the bespoke 2 449-line object store and inherit
+  `createObjectStore()` from `@conduction/nextcloud-vue`.
+- Stop calling `IAppConfig::getValueString(..., '')` for register/schema
+  lookups in any controller; consume `RegisterResolverService` instead.
+- Ship the first multi-language editing UI in opencatalogi (Pages,
+  Menus, Publications, Themes, Glossary), wiring `Accept-Language` /
+  `?_lang=` on the backend and a language-picker on the frontend.
+- Adopt `useTenantContext()` and `<CnTenantBadge>` once
+  `nextcloud-vue@v0.x` ships.
+- Adopt the manifest convention as the first **Tier 2-3** consumer
+  (proves the manifest can express bespoke views via `type: "custom"`).
+- Rewrite five NEEDS-REWRITE specs to cite OR and stop re-deriving
+  capabilities OR already owns.
+- Promote three hardcoded magic numbers to admin-config and delete one
+  duplicated minimum-version constant.
+
+## Non-goals
+
+- **No code changes in this change.** Every artifact here is spec only.
+  Implementation lands in a follow-up change once these contracts are
+  archived.
+- **No new product features.** This is pure cleanup — every behaviour
+  the user sees today must be preserved.
+- **No migration of existing data.** Translatable fields default to
+  the source language; no bulk auto-translation is in scope.
+- **No reshuffling of the public catalogue URL structure.** SEO
+  stability is a hard constraint; the manifest must reproduce existing
+  paths exactly.
+
+## Architectural decisions
+
+### A. Eight-phase split and ordering
+
+The phase ordering in `tasks.md` is load-bearing:
+
+| # | Phase | Depends on | Why this order |
+|---|-------|-----------|---------------|
+| 1 | RegisterResolverService | OR resolver archived | Every later phase calls controllers |
+| 2 | createObjectStore | Phase 1 (consistent error shapes) | Largest line-count reduction |
+| 3 | file-management rewrite | Phase 2 (store owns file relations) | OR file APIs land cleanly |
+| 4 | i18n editing UI | OR i18n changes archived | Independent of 1-3, parallel-able |
+| 5 | Multi-tenancy adoption | nc-vue v0.x archived | Top-bar coexists with language picker |
+| 6 | Manifest adoption | Phase 5 (tenant getter wired) | Manifest interpreter needs tenant getter |
+| 7 | Spec rewrites (search/admin/dashboard/download) | Phase 6 (tier semantics) | Specs reference manifest tier names |
+| 8 | Magic-number cleanup | none | Lowest blast radius, ships last |
+
+### B. RegisterResolverService consumption pattern
+
+Every controller follows the same migration shape:
+
+- **Before:** `$registerId = $this->config->getValueString($appName,
+  '<context>_register', '');` followed by silent fallthrough when empty.
+- **After:** `$register = $this->resolver->resolveRegister('<context>');`
+  which throws `RegisterNotConfiguredException` mapped to a 503 with
+  operator-actionable detail.
+
+The five contexts named in the audit are `publications`, `listings`,
+`catalogi`, `themes`, `pages`. The three additional contexts
+(`glossary`, `menus`, `organisations`) follow the same pattern.
+
+### C. Store migration boundary
+
+The bespoke store at `src/store/modules/object.js` has one public
+contract today: action names like `fetchAll`, `fetchOne`, `create`,
+`update`, `delete`, `fetchRelated`. The migrated thin-wrapper preserves
+those action names so consumer components don't need code changes
+beyond the import path.
+
+The four plugins consumed are:
+
+- `filesPlugin()` — replaces the bespoke `relatedData.files` block.
+- `auditTrailsPlugin()` — replaces the bespoke `relatedData.logs` block.
+- `relationsPlugin()` — replaces the bespoke `relatedData.uses` block.
+- `searchPlugin()` — replaces the bespoke search/filter/facet logic.
+
+`src/store/modules/search.js` is migrated either by consuming
+`searchPlugin()` directly or by extracting a shared store. The
+decision is captured in `tasks.md` Phase 2.6; default is "consume
+the plugin" unless cross-store federation requires otherwise.
+
+### D. i18n editing UI shape
+
+Per ADR-025, every translatable schema:
+
+- declares `sourceLanguage: "nl"` (or `"en"` for the publication
+  catalogue's English-first datasets);
+- marks user-facing string properties as `translatable: true`;
+- stores translations in a sibling structure resolved by the
+  `TranslationHandler` on read.
+
+The frontend language-picker is rendered by the upstream nextcloud-vue
+component; opencatalogi-side wiring is:
+
+1. Read the active locale from `loadState`.
+2. Pass it as `?_lang=<locale>` on every detail-page fetch.
+3. Render a tab strip at the top of the modal showing one tab per
+   declared translation; missing translations show a "+ add" affordance.
+
+### E. Multi-tenancy wiring
+
+`useTenantContext()` returns a reactive `{ organisationUuid, switchTenant,
+tenants }` shape. opencatalogi consumes it in `App.vue::setup()` and
+forwards `organisationUuid` to every store invocation. Cache invalidation
+on tenant switch is handled by the upstream nc-vue capability — this app
+just wires the watcher.
+
+### F. Manifest tiering
+
+opencatalogi is the first **Tier 2-3** manifest consumer. The decision
+table in `tasks.md` Phase 6.3 catalogues every existing route and tags
+it `list` / `detail` / `custom`. Examples:
+
+- `/publications` → `type: "list"` (manifest-rendered)
+- `/publications/:id` → `type: "detail"` (manifest-rendered)
+- `/publications/:id/render` → `type: "custom"` (bespoke renderer)
+- `/catalogs/:slug` → `type: "custom"` (public catalogue landing)
+- `/cms/pages/:id` → `type: "custom"` (CMS edit experience)
+
+The manifest interpreter handles `list` / `detail` automatically; the
+app retains code only for the `custom` views.
+
+### G. Spec rewrite vs. spec deletion
+
+Every NEEDS-REWRITE spec is **rewritten** rather than deleted because
+each describes app-specific orchestration on top of OR primitives —
+the orchestration still belongs in opencatalogi. The rewrite collapses
+the spec to "consume OR's `<capability>`; this app's responsibility is
+limited to <X, Y, Z>".
+
+## Risks and mitigations
+
+- **R1 — Big-bang change is hard to review.** Mitigation: the eight
+  phases are reviewable independently; the change can be split into
+  eight implementation PRs while keeping one spec change.
+- **R2 — Upstream specs slip.** Mitigation: each phase declares its
+  upstream blocker in `tasks.md`; phases that are unblocked can ship
+  while later phases wait. Phase 8 has no upstream dependency and can
+  ship first if needed.
+- **R3 — Public catalogue regression.** Mitigation: SEO stability is
+  a hard constraint; the manifest tiering table catalogues every
+  current public URL with a 1:1 mapping. End-to-end smoke tests on
+  `/publications`, `/catalogs/:slug`, `/cms/pages/:id` are mandatory
+  acceptance gates per `tasks.md` 2.5 and 6.3.
+- **R4 — i18n migration touches every detail page.** Mitigation: this
+  is a UI-only addition (no data migration). Existing single-language
+  content stays valid as the source language; translations are
+  optional and can be authored incrementally.
+- **R5 — `getValueString('')` empty-string fallback hid misconfiguration.**
+  Mitigation: Phase 1.4 explicitly turns this into a 503 with
+  operator detail; capture in the breaking-changes section of the
+  affected specs so operators know to set the keys before upgrade.
+- **R6 — Tenant switch invalidation cascading through every store
+  could be slow.** Mitigation: the upstream nc-vue capability owns the
+  invalidation strategy; opencatalogi just registers the watcher.
+  Performance budget captured in nc-vue's `multi-tenancy-context`
+  spec, not here.
+
+## Alternatives considered
+
+- **Eight separate per-app changes** — rejected because the audit
+  files cross-cite each other and the controllers / store / manifest
+  are entangled. Reviewing them in lockstep is cheaper than
+  re-aligning eight in-flight changes.
+- **Defer i18n editing UI to a separate feature change** — rejected
+  because the schema markup (`translatable: true`, `sourceLanguage`)
+  must land in lockstep with the controllers and the language-picker;
+  doing them separately produces broken intermediate states.
+- **Keep the bespoke object store and just refactor it** — rejected
+  because every other app in the fleet either has migrated or will
+  migrate to `createObjectStore`; keeping a bespoke store here makes
+  opencatalogi an ongoing maintenance liability.
+- **Tier the manifest as Tier 1 (fully manifest-driven)** — rejected
+  because the public catalogue and CMS edit experiences cannot be
+  expressed declaratively. Tier 2-3 with `type: "custom"` for those
+  three views is the minimal-surface answer.
+- **Promote `MIN_OPENREGISTER_VERSION` instead of deleting it** —
+  rejected because `appinfo/info.xml` `<dependencies>` is already the
+  Nextcloud-native source of truth and the install-time check enforces
+  it; the PHP constant is dead weight.
+
+## Open questions
+
+- **Q1.** When the resolver throws `RegisterNotConfiguredException`,
+  should the 503 response include enough detail for an operator to
+  fix it (key name, expected register name) or only opaque "register
+  not configured"? Recommendation: include detail behind admin auth;
+  redact for unauthenticated callers.
+- **Q2.** Does `searchPlugin()` from `@conduction/nextcloud-vue` cover
+  cross-catalog federation, or do we still need the bespoke
+  `src/store/modules/search.js` for that case? Decision in
+  `tasks.md` 2.6.
+- **Q3.** The current public catalogue uses URL slugs
+  (`/catalogs/:slug`) that don't map cleanly to manifest `list`/`detail`
+  types. The proposal tags these `custom`; is there value in extending
+  the manifest spec to support slug-based public routes generically?
+  Out of scope for this change; raise upstream against
+  `adopt-app-manifest` if the pattern repeats across other apps.
+- **Q4.** Should the language picker default to the user's Nextcloud
+  language preference, the browser `Accept-Language`, or the catalogue's
+  declared `sourceLanguage`? Recommendation: follow the negotiation
+  order in `i18n-api-language-negotiation` (query > header > user pref
+  > app default) — no app-specific override.

--- a/openspec/changes/opencatalogi-adopt-or-abstractions/proposal.md
+++ b/openspec/changes/opencatalogi-adopt-or-abstractions/proposal.md
@@ -1,0 +1,259 @@
+# Change: opencatalogi-adopt-or-abstractions
+
+## Why
+
+The OR-abstraction audit completed on 2026-05-03 (see
+`.claude/audit-2026-05-03/00-executive-summary.md`) identified **opencatalogi
+as the single largest cleanup target across the Conduction fleet**. It carries
+the heaviest custom code load, the broadest set of NEEDS-REWRITE specs, the
+most hardcoded register/schema lookups, and zero multi-language editing UI
+despite shipping the publication catalogue product where translation matters
+most.
+
+This change is the per-app adoption ticket that lets opencatalogi consume the
+shared OpenRegister, nextcloud-vue, and Hydra abstractions once those upstream
+specs land. It is intentionally large — eight phases — because opencatalogi
+sits at the apex of every audit stream:
+
+- **Stream 1 (code cleanup):** `src/store/modules/object.js` is a 2 449-line
+  bespoke object store reimplementing what `createObjectStore()` from
+  `@conduction/nextcloud-vue` already provides. The audit estimates this is
+  the **single biggest line-count reduction** available in the entire fleet
+  (≈2 250 lines deleted).
+- **Stream 2 (spec rewrite):** five capability specs — `file-management`,
+  `admin-settings`, `search`, `dashboard`, `download-service` — are flagged
+  NEEDS-REWRITE or MISSING-OR-DEP. Each describes bespoke functionality that
+  OR or upstream Nextcloud already owns.
+- **Stream 4 (hardcoded functionality):** five controllers each call
+  `getValueString($appName, '<context>_register' | '<context>_schema', '')`
+  with the empty-string fallback that hides misconfiguration. Three services
+  hard-code retry/timeout/page-size constants. `SettingsService::MIN_OPENREGISTER_VERSION`
+  duplicates `appinfo/info.xml` `<dependencies>`.
+- **Stream R3 (i18n editing UI):** opencatalogi has **no** translation
+  editing UI today. Pages, Menus, Publications, Themes, and Glossary all
+  store user-facing text in a single language with no picker, no
+  `Accept-Language` plumbing, and no `translatable: true` schema flags.
+- **Stream R2 (multi-tenancy frontend):** once `nextcloud-vue@v0.x`
+  ships `useTenantContext()` and `<CnTenantBadge>`, opencatalogi must wire
+  them into `App.vue` and pass the organisation getter into every
+  `createObjectStore()` instance.
+- **Manifest adoption (ADR-024):** opencatalogi is the first **Tier 2-3**
+  candidate — it has bespoke catalog/publication views that need
+  `type: "custom"` in the manifest while the bulk of CRUD pages are
+  generated. Ratifying the manifest convention here proves the manifest
+  scales beyond the simple Tier 1 case.
+
+Doing this cleanup as one large change (rather than eight small ones) is
+deliberate: the controllers, store, specs, manifest, and i18n plumbing are
+deeply coupled, and migrating them in one wave avoids partial states where
+half the controllers consume `RegisterResolverService` while the other half
+still call `getValueString()` directly.
+
+## What Changes
+
+### Phase 1: Adopt `RegisterResolverService` across all controllers
+
+- Migrate **all five controllers** that today call
+  `IAppConfig::getValueString($appName, '<context>_register' | '<context>_schema', '')`:
+  - `lib/Controller/PublicationsController.php`
+  - `lib/Controller/ListingsController.php` (lines 99-159)
+  - `lib/Controller/CatalogiController.php` (line 117)
+  - `lib/Controller/ThemesController.php` (line 114)
+  - `lib/Controller/PagesController.php` (line 126)
+- Replace each call site with
+  `RegisterResolverService::resolveRegister($context)` /
+  `resolveSchema($context)` / `resolvePair($context)`. Contexts:
+  `publications`, `listings`, `catalogi`, `themes`, `pages` (plus the
+  existing `glossary`, `menus`, `organisations` contexts that already use
+  `getValueString` lookups).
+- Removes the empty-string fallback that today hides misconfiguration: the
+  resolver throws `RegisterNotConfiguredException` which the controller
+  surfaces as a 503 with operator-actionable detail.
+- Cite the OpenRegister change `register-resolver-service` for the contract.
+
+### Phase 2: Migrate `src/store/modules/object.js` to `createObjectStore()`
+
+- Delete the 2 449-line bespoke store and replace it with a thin wrapper
+  around `createObjectStore('object', { plugins: [...] })` from
+  `@conduction/nextcloud-vue`.
+- Plugins: `filesPlugin()`, `auditTrailsPlugin()`, `relationsPlugin()`,
+  `searchPlugin()` (covers the `relatedData: { logs, files, uses }` shape
+  the current store hand-rolls).
+- Net change: ~2 449 lines → ~200 lines (≈2 250 lines deleted, the largest
+  single reduction in the audit).
+- Update **every** consumer (`PublicationsList.vue`, `CatalogiList.vue`,
+  `ThemesList.vue`, etc.) to call store actions through the standard
+  Options-API helpers per the store-pattern guidance — no custom Pinia
+  modules.
+
+### Phase 3: Rewrite `file-management` spec; consume OR file APIs
+
+- Rewrite `openspec/specs/file-management/spec.md` to consume:
+  - OR's File Attachments capability (`x-openregister-file` schema
+    annotation, `IFileService::attach/list/delete`).
+  - `OCP\Share\IShareManager` for share creation rather than a bespoke
+    sharing implementation.
+- Drop the bespoke file CRUD/sharing endpoints in
+  `lib/Controller/FilesController.php`; thin wrapper that delegates to OR.
+- Cite OR's `register-resolver-service` (registers/schemas resolved before
+  attaching files) and the OR file capability spec.
+
+### Phase 4: i18n editing UI for translatable content
+
+Today opencatalogi has **zero** multi-language editing UI. This phase
+implements the editorial flow per ADR-025 and consumes the upstream
+OR `i18n-source-of-truth` and `i18n-api-language-negotiation` capabilities.
+
+- **Backend wiring** — wire `OCA\OpenRegister\Service\TranslationHandler`
+  (or its public-facing equivalent once shipped) into:
+  - `PagesController`
+  - `MenusController`
+  - `PublicationsController`
+  - `ThemesController`
+  - `GlossaryController`
+  - so `Accept-Language` and `?_lang=` resolve translatable fields per
+    `i18n-api-language-negotiation`.
+- **Schema markup** — set `translatable: true` on user-facing string
+  properties (title, summary, body, navigation labels) and declare
+  `sourceLanguage` per ADR-025 across the affected schemas.
+- **Frontend language selector** — add a language-picker component
+  (consumed from nextcloud-vue) to:
+  - `PublicationDetailPage.vue`
+  - `ViewPageModal.vue`
+  - `ViewMenuModal.vue`
+  - `ViewThemeModal.vue`
+  - `ViewGlossaryModal.vue`
+  - so editors can author each translation per locale and the active
+    `<html lang>` is wired through `loadState`.
+- **Public read path** — public catalogue routes resolve the visitor's
+  `Accept-Language` server-side so the SSR/initial-state markup matches
+  the negotiated locale (no client-side flicker).
+
+### Phase 5: Adopt nextcloud-vue multi-tenancy primitives
+
+Once `nextcloud-vue@v0.x` ships the `multi-tenancy-context` capability
+(see `nextcloud-vue/openspec/changes/multi-tenancy-context/`):
+
+- Wire `useTenantContext()` into `App.vue::setup()`; expose the active
+  organisation UUID as a reactive getter.
+- Pass that getter to every `createObjectStore()` invocation as
+  `organisationUuidGetter` so list queries scope to the active tenant.
+- Render `<CnTenantBadge>` in the top bar (left of the user menu).
+- Invalidate stores on tenant switch (`watch(tenantId, () => store.reset())`).
+- Make `CnFormDialog` auto-fill the `organisation` field on object
+  creation when the schema declares `organisation` as a relation.
+
+### Phase 6: Adopt the app manifest convention (Tier 2-3)
+
+Per `hydra/openspec/changes/adopt-app-manifest/` and ADR-024:
+
+- Generate `src/manifest.json` from the existing router config (and
+  `appinfo/routes.php` for nav metadata).
+- Tier this app as **Tier 2-3** because the bespoke catalog landing
+  pages, the publication renderer, and the public CMS view need
+  `type: "custom"`. The bulk of admin CRUD entries can be `type: "list"`
+  or `type: "detail"` and rendered by the manifest interpreter.
+- Declare `dependencies: ["openregister"]` so the registry refuses to
+  load the app when OR is missing or below the minimum version.
+- Delete the hand-rolled router/sidebar code (`src/router/index.js`,
+  custom `<NcAppNavigation>` blocks) once the manifest interpreter
+  takes over.
+
+### Phase 7: Spec rewrites for `search`, `admin-settings`, `dashboard`, `download-service`
+
+- **`search`** (P2, MISSING-OR-DEP) — rewrite to cite OR's `zoeken-filteren`
+  capability rather than describing bespoke search. Federated/cross-catalog
+  search becomes a thin orchestrator on top of the shared search plugin.
+- **`admin-settings`** (P2, NEEDS-REWRITE) — rewrite to cite OR's
+  `IAppConfig` conventions (key naming, validation, secret handling) and
+  remove the duplicated patterns this spec re-derives.
+- **`dashboard`** (P2) — confirm and add the citation to the OR
+  aggregations annotation; remove the hand-rolled aggregation prose.
+- **`download-service`** (P2, NEEDS-REWRITE) — rewrite to consume OR's
+  File Attachments + versioning capability for ZIP generation; the
+  download service becomes a streaming wrapper, not a file CRUD owner.
+
+### Phase 8: Hardcoded magic-number cleanup
+
+Per `.claude/audit-2026-05-03/04-hardcoded.md`:
+
+- `lib/Service/BroadcastService.php:68,75` — promote `MAX_RETRIES = 3`
+  and `REQUEST_TIMEOUT = 30` to admin-config keys
+  (`broadcast_max_retries`, `broadcast_request_timeout`).
+- `lib/Service/SitemapService.php:40` — promote `MAX_PER_PAGE = 1000`
+  to admin-config (`sitemap_max_per_page`).
+- `lib/Service/SettingsService.php:64` — **delete**
+  `MIN_OPENREGISTER_VERSION = '0.1.7'`. It duplicates
+  `appinfo/info.xml` `<dependencies>` which Nextcloud already enforces.
+- `openspec/specs/auto-publishing/spec.md` — rewrite publication state
+  transitions to consume `x-openregister-lifecycle` from the schema
+  rather than encoding the state machine in PHP.
+- `openspec/specs/federation/spec.md` — rewrite per-app retry/backoff
+  to consume the OR-level outbound webhook policy (instead of every
+  app re-deriving its own retry maths).
+
+## Impact
+
+- **Affected specs (this app):**
+  - **MODIFIED:** `file-management` (full rewrite),
+    `admin-settings` (full rewrite), `download-service` (full rewrite),
+    `search` (cite zoeken-filteren), `dashboard` (cite OR aggregations),
+    `auto-publishing` (cite x-openregister-lifecycle),
+    `federation` (cite OR webhook policy),
+    `publications` (translatable fields, language negotiation),
+    `catalogs`, `content-management` (manifest tiering, multi-tenancy).
+  - **ADDED:** `opencatalogi-adopt-or-abstractions` (this change's delta —
+    the per-app contract for adopting all upstream abstractions).
+- **Affected code (informational; spec-only change):**
+  - `lib/Controller/PublicationsController.php`
+  - `lib/Controller/ListingsController.php`
+  - `lib/Controller/CatalogiController.php`
+  - `lib/Controller/ThemesController.php`
+  - `lib/Controller/PagesController.php`
+  - `lib/Controller/MenusController.php`
+  - `lib/Controller/GlossaryController.php`
+  - `lib/Controller/FilesController.php`
+  - `lib/Service/BroadcastService.php`
+  - `lib/Service/SitemapService.php`
+  - `lib/Service/SettingsService.php`
+  - `src/store/modules/object.js` (≈2 250 lines deleted)
+  - `src/store/modules/search.js`
+  - `src/App.vue`
+  - `src/router/index.js` (deleted post-Phase 6)
+  - `src/views/PublicationDetailPage.vue`
+  - `src/modals/ViewPageModal.vue`, `ViewMenuModal.vue`,
+    `ViewThemeModal.vue`, `ViewGlossaryModal.vue`
+  - `src/manifest.json` (new)
+- **Upstream dependencies (must land before opencatalogi can consume):**
+  - `openregister/openspec/changes/register-resolver-service/`
+  - `openregister/openspec/changes/pluggable-integration-registry/`
+  - `openregister/openspec/changes/i18n-source-of-truth/`
+  - `openregister/openspec/changes/i18n-api-language-negotiation/`
+  - `nextcloud-vue/openspec/changes/multi-tenancy-context/`
+  - `hydra/openspec/changes/adopt-app-manifest/`
+- **ADRs (in `hydra/openspec/architecture/`):**
+  - **ADR-022** — Pluggable integration registry
+  - **ADR-024** — App manifest convention
+  - **ADR-025** — i18n source of truth
+- **Risk:** HIGH-IMPACT but spec-only at this stage. The risks live in the
+  implementation phase tracked in `tasks.md`. Each phase is independently
+  verifiable; the eight-phase ordering is chosen so each phase deletes
+  code that the previous phase replaces, never the other way round.
+- **Rollout:** sequential phase-by-phase. No phase ships until the
+  upstream change it depends on is archived. Phase 1 ships first because
+  it unblocks Phase 2 (the store needs the resolver to be present in
+  controllers it calls). Phase 8 ships last because the magic-number
+  cleanup is independent and has the lowest blast radius.
+- **Audit trail:**
+  - `.claude/audit-2026-05-03/01-code-cleanup.md` — Stream 1 line-count
+    reductions; opencatalogi tops the list.
+  - `.claude/audit-2026-05-03/02-spec-rewrite.md` — Stream 2 NEEDS-REWRITE
+    list including the five opencatalogi specs.
+  - `.claude/audit-2026-05-03/04-hardcoded.md` — Stream 4 hardcoded
+    constants and `getValueString` empty-string fallbacks.
+  - `.claude/audit-2026-05-03/research/R2-nc-vue-multitenancy.md` —
+    Stream R2 multi-tenancy frontend gaps.
+  - `.claude/audit-2026-05-03/research/R3-opencatalogi-i18n-editing.md` —
+    Stream R3 i18n editing UI gaps (this app is the canonical example).
+  - `.claude/audit-2026-05-03/research/R6-manifest-json.md` — manifest
+    convention; opencatalogi is the named Tier 2-3 pilot.

--- a/openspec/changes/opencatalogi-adopt-or-abstractions/specs/opencatalogi-adopt-or-abstractions/spec.md
+++ b/openspec/changes/opencatalogi-adopt-or-abstractions/specs/opencatalogi-adopt-or-abstractions/spec.md
@@ -1,0 +1,584 @@
+# Specification: opencatalogi-adopt-or-abstractions
+
+## Purpose
+
+Define the contract by which opencatalogi adopts the shared OpenRegister,
+nextcloud-vue, and Hydra abstractions identified in the OR-abstraction
+audit (`.claude/audit-2026-05-03/`). This spec is the per-app capability
+that consumes — and never re-implements — the upstream specs:
+
+- `openregister/openspec/changes/register-resolver-service/`
+- `openregister/openspec/changes/pluggable-integration-registry/`
+- `openregister/openspec/changes/i18n-source-of-truth/`
+- `openregister/openspec/changes/i18n-api-language-negotiation/`
+- `nextcloud-vue/openspec/changes/multi-tenancy-context/`
+- `hydra/openspec/changes/adopt-app-manifest/`
+
+Architectural decisions: **ADR-022** (pluggable integration registry),
+**ADR-024** (app manifest convention), **ADR-025** (i18n source of
+truth), all in `hydra/openspec/architecture/`.
+
+## ADDED Requirements
+
+### Requirement: opencatalogi controllers MUST resolve registers and schemas via `RegisterResolverService`
+
+Every controller in `lib/Controller/` that today calls
+`IAppConfig::getValueString($appName, '<context>_register' | '<context>_schema', '')`
+MUST instead call `RegisterResolverService::resolveRegister($context)`,
+`resolveSchema($context)`, or `resolvePair($context)` from the upstream
+OpenRegister `register-resolver-service` capability.
+
+The empty-string fallback pattern is forbidden — the resolver MUST throw
+`RegisterNotConfiguredException` and the controller MUST surface a
+`503 Service Unavailable` response with operator-actionable detail.
+
+#### Scenario: PublicationsController resolves the publications context
+
+- **GIVEN** the admin has configured `publications_register` and
+  `publications_schema` via `IAppConfig`,
+- **WHEN** any endpoint on `lib/Controller/PublicationsController.php`
+  is invoked,
+- **THEN** the controller calls
+  `RegisterResolverService::resolvePair('publications')` and uses the
+  resolved register/schema for the operation.
+
+#### Scenario: ListingsController resolves the listings context
+
+- **GIVEN** the admin has configured `listings_register` and
+  `listings_schema`,
+- **WHEN** an endpoint on `lib/Controller/ListingsController.php`
+  (lines 99-159 in the audit) is invoked,
+- **THEN** the controller calls
+  `RegisterResolverService::resolvePair('listings')`.
+
+#### Scenario: CatalogiController, ThemesController, PagesController resolve their contexts
+
+- **WHEN** any endpoint on `lib/Controller/CatalogiController.php` (line
+  117), `lib/Controller/ThemesController.php` (line 114), or
+  `lib/Controller/PagesController.php` (line 126) is invoked,
+- **THEN** the controller calls
+  `RegisterResolverService::resolvePair('catalogi')`,
+  `RegisterResolverService::resolvePair('themes')`, or
+  `RegisterResolverService::resolvePair('pages')` respectively.
+
+#### Scenario: missing configuration produces an actionable 503
+
+- **GIVEN** an admin has not configured the register or schema for a
+  given context,
+- **WHEN** a request hits a controller that needs that context,
+- **THEN** the resolver throws `RegisterNotConfiguredException`,
+- **AND** the controller emits a `503 Service Unavailable` response
+  whose body identifies the missing context and the configuration key
+  the admin must set,
+- **AND** the same response carries no register/schema data.
+
+#### Scenario: resolver result is request-scoped
+
+- **GIVEN** an admin updates `publications_register`,
+- **WHEN** the next request arrives,
+- **THEN** the controller resolves the new value without requiring an
+  Apache restart, OPcache reset, or app reload.
+
+### Requirement: opencatalogi MUST NOT re-implement `RegisterResolverService` locally
+
+opencatalogi MUST treat `RegisterResolverService` as part of the
+OpenRegister contract surface and MUST NOT re-implement, shim, or
+locally cache the resolver — even when OR is below the minimum version.
+
+#### Scenario: dependency check fails when OR is below minimum
+
+- **GIVEN** the installed OpenRegister version is below the version
+  that archives `register-resolver-service`,
+- **WHEN** opencatalogi is loaded,
+- **THEN** Nextcloud's app dependency check (driven by
+  `appinfo/info.xml` `<dependencies>`) refuses to enable the app,
+- **AND** the admin sees a clear message naming the required OR
+  version.
+
+### Requirement: opencatalogi MUST consume `createObjectStore()` for object state management
+
+`src/store/modules/object.js` (currently 2 449 lines per audit) MUST
+be replaced by a thin wrapper around `createObjectStore('object', {
+plugins: [filesPlugin(), auditTrailsPlugin(), relationsPlugin(),
+searchPlugin()] })` from `@conduction/nextcloud-vue`. opencatalogi MUST
+NOT introduce custom Pinia modules for object state; the Options-API
+helpers from nextcloud-vue are the only sanctioned access pattern.
+
+#### Scenario: every list view consumes the shared store
+
+- **GIVEN** any list component (`PublicationsList.vue`,
+  `CatalogiList.vue`, `ThemesList.vue`, etc.),
+- **WHEN** the component mounts,
+- **THEN** it calls `useObjectStore('object')` from the wrapper,
+- **AND** does NOT directly access bespoke Pinia state for object data.
+
+#### Scenario: related-data plugins replace bespoke `relatedData` blocks
+
+- **GIVEN** a publication is loaded via `useObjectStore('object').fetchOne(...)`,
+- **WHEN** the consumer accesses logs, files, or "uses" relations,
+- **THEN** those values come from the registered plugins
+  (`auditTrailsPlugin`, `filesPlugin`, `relationsPlugin`),
+- **AND** opencatalogi-side code does NOT hand-roll the corresponding
+  fetch logic.
+
+#### Scenario: pagination, filters, and search behave identically post-migration
+
+- **GIVEN** a list view with pagination, filters, and a search query
+  applied,
+- **WHEN** the migrated `createObjectStore`-backed implementation
+  replaces the bespoke store,
+- **THEN** the user sees identical results, identical pagination
+  metadata, and identical facet counts as before the migration,
+- **AND** the existing E2E flows (create publication, edit, delete,
+  restore from trash) continue to pass.
+
+### Requirement: opencatalogi MUST consume the OR file APIs for file management
+
+The `file-management` spec is rewritten to declare that opencatalogi
+consumes OR's File Attachments capability via `x-openregister-file`
+schema annotations and the OR-provided file service. Sharing is delegated
+to `OCP\Share\IShareManager`. opencatalogi MUST NOT re-implement file
+CRUD, share creation, share enumeration, or share revocation.
+
+#### Scenario: file attachment goes through OR
+
+- **GIVEN** a schema declares a property with `x-openregister-file`,
+- **WHEN** a user uploads a file against an object backed by that schema,
+- **THEN** opencatalogi calls into the OR file service
+  (resolved via DI, not via a bespoke implementation),
+- **AND** the resulting attachment is visible through OR's file APIs.
+
+#### Scenario: share creation goes through `IShareManager`
+
+- **GIVEN** a user requests a share on an attached file,
+- **WHEN** opencatalogi handles the request,
+- **THEN** it delegates to `OCP\Share\IShareManager::createShare()`,
+- **AND** does NOT persist share rows into a local table.
+
+#### Scenario: thin FilesController wrapper
+
+- **WHEN** any endpoint on `lib/Controller/FilesController.php` is
+  invoked,
+- **THEN** it resolves the register/schema via
+  `RegisterResolverService` and delegates the file operation to OR's
+  file controller or service,
+- **AND** does NOT contain bespoke storage, sharing, or versioning
+  logic.
+
+### Requirement: opencatalogi MUST honour API language negotiation for translatable content
+
+Every controller serving translatable resources — `PagesController`,
+`MenusController`, `PublicationsController`, `ThemesController`,
+`GlossaryController` — MUST consume the OR `TranslationHandler` (or
+its post-`i18n-source-of-truth` public equivalent) so that
+`Accept-Language` and `?_lang=` resolve translatable fields per the
+`i18n-api-language-negotiation` capability.
+
+opencatalogi MUST NOT re-derive the negotiation algorithm; the
+quality-factor parsing and RFC 4647 lookup matching are owned upstream.
+
+#### Scenario: query parameter overrides Accept-Language
+
+- **GIVEN** a request to `GET /api/publications/:id?_lang=fr`,
+- **AND** the request also carries `Accept-Language: nl,en;q=0.9`,
+- **WHEN** the controller resolves the response,
+- **THEN** translatable fields are returned in `fr` (or fall back per
+  the negotiation rules if `fr` is missing),
+- **AND** the `Content-Language` header reflects the chosen locale.
+
+#### Scenario: missing translation falls back to source language
+
+- **GIVEN** a publication has `sourceLanguage: "nl"` and no `fr`
+  translation,
+- **WHEN** the request asks for `fr`,
+- **THEN** the response returns the `nl` source content,
+- **AND** the `Content-Language` header reflects `nl`,
+- **AND** a `Vary: Accept-Language` header is present.
+
+#### Scenario: public catalogue routes negotiate server-side
+
+- **GIVEN** an unauthenticated visitor navigates to
+  `/catalogs/<slug>`,
+- **WHEN** the server renders the page,
+- **THEN** the active locale is resolved server-side from the visitor's
+  `Accept-Language` header,
+- **AND** the SSR/initial-state markup reflects the chosen locale,
+- **AND** there is no client-side flicker switching languages after
+  hydration.
+
+### Requirement: translatable schema properties MUST declare `translatable: true` and `sourceLanguage`
+
+Every schema owning user-facing string content (publications, pages,
+menus, themes, glossary entries, navigation labels) MUST mark the
+relevant properties `translatable: true` and MUST declare
+`sourceLanguage` per ADR-025.
+
+#### Scenario: publication schema marks title and body translatable
+
+- **GIVEN** the publication schema definition,
+- **WHEN** the schema is loaded,
+- **THEN** `title`, `summary`, and `body` are declared
+  `translatable: true`,
+- **AND** the schema declares `sourceLanguage: "nl"` (or the
+  catalogue's configured source language).
+
+#### Scenario: page schema and menu schema mark navigation labels translatable
+
+- **GIVEN** the page schema and the menu schema,
+- **WHEN** the schemas are loaded,
+- **THEN** all navigation label and slug-display fields are declared
+  `translatable: true`,
+- **AND** each schema declares `sourceLanguage`.
+
+#### Scenario: source language is immutable per object
+
+- **GIVEN** an object exists with `sourceLanguage: "nl"`,
+- **WHEN** an editor attempts to change `sourceLanguage` via PUT/PATCH,
+- **THEN** the change is rejected with a 400 response,
+- **AND** the object's source language remains `nl`.
+
+### Requirement: editorial UI MUST allow translation authoring on every translatable detail/edit screen
+
+opencatalogi MUST render a language-picker (consumed from
+`@conduction/nextcloud-vue`) on every detail or edit screen that owns
+translatable content: `PublicationDetailPage.vue`, `ViewPageModal.vue`,
+`ViewMenuModal.vue`, `ViewThemeModal.vue`, `ViewGlossaryModal.vue`.
+
+#### Scenario: editor switches language on a publication
+
+- **GIVEN** an editor opens a publication detail page,
+- **WHEN** the editor selects a different language from the picker,
+- **THEN** the form fields refresh with that language's translation,
+- **AND** an unsaved-changes warning fires if the editor switches mid-edit.
+
+#### Scenario: editor adds a new translation
+
+- **GIVEN** a publication has no `fr` translation,
+- **WHEN** the editor selects `fr` from the picker,
+- **THEN** the form shows empty translatable fields with a "+ add"
+  affordance,
+- **AND** saving creates the `fr` translation alongside the existing
+  source.
+
+#### Scenario: missing translation indicator on the picker
+
+- **GIVEN** a publication has only `nl` (source) and `en` translations,
+- **WHEN** the language picker is rendered,
+- **THEN** other supported locales appear with a visual indicator
+  showing the translation is missing.
+
+### Requirement: opencatalogi MUST consume `useTenantContext()` from nextcloud-vue
+
+Once `nextcloud-vue/openspec/changes/multi-tenancy-context/` is archived,
+opencatalogi MUST call `useTenantContext()` from
+`@conduction/nextcloud-vue` in `App.vue::setup()`, expose the active
+organisation UUID as a reactive `organisationUuidGetter`, and pass that
+getter into every `createObjectStore` invocation.
+
+#### Scenario: store queries scope to the active tenant
+
+- **GIVEN** the active tenant is `org-A`,
+- **WHEN** any `createObjectStore`-backed list is fetched,
+- **THEN** the request is scoped to `org-A` (the upstream nc-vue
+  capability owns the wire format),
+- **AND** results from other tenants are excluded.
+
+#### Scenario: tenant badge is visible on every route
+
+- **WHEN** any route in opencatalogi renders the top bar,
+- **THEN** `<CnTenantBadge>` is present immediately to the left of the
+  user menu.
+
+#### Scenario: tenant switch resets stores
+
+- **GIVEN** the user is viewing a list scoped to `org-A` on page 3 with
+  filters applied,
+- **WHEN** the user switches the active tenant to `org-B`,
+- **THEN** every `createObjectStore` instance resets,
+- **AND** pagination returns to page 1,
+- **AND** the resulting list shows only `org-B` data.
+
+#### Scenario: form dialog auto-fills the organisation field
+
+- **GIVEN** a schema declares an `organisation` relation,
+- **WHEN** the user opens a `CnFormDialog` to create a new object,
+- **THEN** the `organisation` field is pre-filled with the active
+  tenant UUID,
+- **AND** the field is disabled unless the user has cross-tenant edit
+  rights.
+
+### Requirement: opencatalogi MUST ship `src/manifest.json` per the manifest convention (Tier 2-3)
+
+Per ADR-024 and `hydra/openspec/changes/adopt-app-manifest/`,
+opencatalogi MUST ship `src/manifest.json` as the single source of
+truth for routes, navigation, and view types. opencatalogi declares
+itself **Tier 2-3**: bespoke catalog landing pages, the publication
+renderer, and the public CMS edit experience use `type: "custom"`;
+all admin CRUD views use `type: "list"` or `type: "detail"` and are
+rendered by the manifest interpreter.
+
+The manifest MUST declare `dependencies: ["openregister"]` so the
+registry refuses to load opencatalogi when OR is missing or below
+the minimum version.
+
+#### Scenario: hand-rolled router is removed
+
+- **WHEN** the manifest interpreter is in place,
+- **THEN** `src/router/index.js` no longer exists,
+- **AND** custom `<NcAppNavigation>` blocks have been deleted,
+- **AND** all navigation is rendered from the manifest.
+
+#### Scenario: list and detail views are interpreted from the manifest
+
+- **GIVEN** a manifest entry `{ "path": "/publications", "type":
+  "list", "schema": "publications" }`,
+- **WHEN** the route is visited,
+- **THEN** the manifest interpreter renders the list view without any
+  bespoke component code in opencatalogi.
+
+#### Scenario: custom views remain in the codebase
+
+- **GIVEN** a manifest entry `{ "path": "/catalogs/:slug", "type":
+  "custom", "component": "CatalogLandingPage" }`,
+- **WHEN** the route is visited,
+- **THEN** the bespoke `CatalogLandingPage.vue` component renders,
+- **AND** the manifest interpreter delegates layout responsibility to
+  the component.
+
+#### Scenario: manifest dependency check refuses load when OR is missing
+
+- **GIVEN** OR is not installed (or is below the required version),
+- **WHEN** Nextcloud attempts to load opencatalogi,
+- **THEN** the manifest registry refuses with a clear error naming the
+  missing dependency,
+- **AND** the user sees an admin-actionable message.
+
+### Requirement: search consumes OR `zoeken-filteren`
+
+The rewritten `search` capability MUST cite OR's `zoeken-filteren` as
+the primary search surface. Federated/cross-catalog search becomes a
+thin orchestrator that fans out to multiple `zoeken-filteren` calls and
+merges results. opencatalogi MUST NOT re-implement query parsing,
+faceting, or ranking.
+
+#### Scenario: single-catalog search delegates to OR
+
+- **WHEN** a user issues a search query within a single catalog,
+- **THEN** opencatalogi delegates to OR's `zoeken-filteren` API
+  unmodified.
+
+#### Scenario: cross-catalog search merges OR results
+
+- **WHEN** a user issues a federated search across N catalogs,
+- **THEN** opencatalogi makes N parallel `zoeken-filteren` calls,
+- **AND** merges the results in a stable, documented order,
+- **AND** does NOT alter individual ranking scores.
+
+### Requirement: admin-settings cites OR's `IAppConfig` conventions
+
+The rewritten `admin-settings` capability MUST cite OR's `IAppConfig`
+conventions for key naming, validation, secret handling, and default
+values. opencatalogi MUST NOT redefine these conventions locally.
+
+#### Scenario: every admin-config key follows the OR naming convention
+
+- **GIVEN** the admin-settings spec lists every config key opencatalogi
+  reads or writes,
+- **WHEN** any key is added or renamed,
+- **THEN** the name follows the OR convention (snake_case, namespace
+  prefix where applicable),
+- **AND** the spec updates the inventory table in lockstep.
+
+#### Scenario: secrets are stored per OR conventions
+
+- **GIVEN** a setting carries a secret (token, credential, password),
+- **WHEN** stored via `IAppConfig`,
+- **THEN** the secret is marked sensitive per OR's convention so that
+  it does not leak through generic settings dumps.
+
+### Requirement: dashboard cites OR aggregations annotation
+
+The `dashboard` spec MUST cite OR's aggregations annotation
+(`x-openregister-aggregations` or its successor) as the source of
+metrics. opencatalogi MUST NOT re-derive aggregation semantics in PHP.
+
+#### Scenario: a dashboard widget is backed by an OR aggregation
+
+- **GIVEN** a widget shows "publications by status",
+- **WHEN** the widget loads,
+- **THEN** it consumes the corresponding OR aggregation declared on the
+  publications schema,
+- **AND** does NOT compute the histogram in opencatalogi PHP.
+
+### Requirement: download-service consumes OR file attachments + versioning
+
+The rewritten `download-service` capability MUST consume OR's File
+Attachments + versioning capability for ZIP generation. The download
+service becomes a streaming wrapper that pipes OR file streams into a
+ZIP — no local file CRUD, no bespoke versioning logic.
+
+#### Scenario: ZIP generation streams from OR
+
+- **GIVEN** a user requests a ZIP of all attachments on a publication,
+- **WHEN** the download service handles the request,
+- **THEN** it opens streams from OR's file service,
+- **AND** pipes each stream into the ZIP without buffering the full
+  contents in memory.
+
+#### Scenario: versioned downloads honour OR's version selectors
+
+- **GIVEN** a request for a specific version of an attached file,
+- **WHEN** the download service handles the request,
+- **THEN** it passes the version selector through to OR,
+- **AND** does NOT maintain a separate version history.
+
+### Requirement: `auto-publishing` consumes `x-openregister-lifecycle`
+
+The rewritten `auto-publishing` capability MUST consume
+`x-openregister-lifecycle` from the schema as the source of truth for
+publication state transitions. opencatalogi MUST NOT encode the state
+machine in PHP.
+
+#### Scenario: publishing transitions read from the schema
+
+- **GIVEN** a publication schema declares
+  `x-openregister-lifecycle: { states: [draft, review, published,
+  archived], transitions: [...] }`,
+- **WHEN** opencatalogi processes a state change,
+- **THEN** the allowed transitions and guards come from the schema
+  declaration,
+- **AND** PHP code in opencatalogi does NOT hold a duplicate state
+  machine.
+
+### Requirement: `federation` consumes the OR-level outbound webhook policy
+
+The rewritten `federation` capability MUST consume the OR-level
+outbound webhook policy for retries, backoff, and dead-letter
+behaviour. opencatalogi MUST NOT re-derive retry maths.
+
+#### Scenario: federation outbound calls follow OR's retry policy
+
+- **GIVEN** a federation push fails transiently,
+- **WHEN** the retry behaviour fires,
+- **THEN** the schedule (count, delay, jitter, dead-letter) matches
+  the OR policy,
+- **AND** opencatalogi does NOT carry app-local retry constants.
+
+### Requirement: hardcoded magic numbers MUST be promoted to admin-config or deleted
+
+Per `.claude/audit-2026-05-03/04-hardcoded.md`:
+
+- `lib/Service/BroadcastService.php:68,75` — `MAX_RETRIES = 3` and
+  `REQUEST_TIMEOUT = 30` MUST be promoted to admin-config keys
+  (`broadcast_max_retries`, `broadcast_request_timeout`); defaults
+  preserved.
+- `lib/Service/SitemapService.php:40` — `MAX_PER_PAGE = 1000` MUST
+  be promoted to admin-config (`sitemap_max_per_page`); default
+  preserved.
+- `lib/Service/SettingsService.php:64` — `MIN_OPENREGISTER_VERSION
+  = '0.1.7'` MUST be deleted; `appinfo/info.xml` `<dependencies>` is
+  the only source of truth.
+
+#### Scenario: broadcast retries are admin-tunable
+
+- **GIVEN** an admin sets `broadcast_max_retries = 5`,
+- **WHEN** a broadcast fails,
+- **THEN** the service attempts up to 5 retries,
+- **AND** does NOT rely on a PHP class constant.
+
+#### Scenario: sitemap page size is admin-tunable
+
+- **GIVEN** an admin sets `sitemap_max_per_page = 500`,
+- **WHEN** the sitemap is generated,
+- **THEN** each page contains at most 500 entries.
+
+#### Scenario: minimum-OR-version constant no longer exists
+
+- **WHEN** anyone greps `lib/Service/SettingsService.php` for
+  `MIN_OPENREGISTER_VERSION`,
+- **THEN** the constant is not found,
+- **AND** the install-time dependency check (driven by `info.xml`)
+  enforces the minimum version instead.
+
+### Requirement: every new admin-config key MUST appear in the `admin-settings` inventory
+
+Whenever Phase 8 (or any other phase) introduces an admin-config key,
+the `admin-settings` spec inventory table MUST be updated in the same
+spec change. The inventory is the single canonical list operators read.
+
+#### Scenario: admin-settings inventory is the source of truth
+
+- **WHEN** a reviewer audits the admin-settings spec,
+- **THEN** they find every key opencatalogi reads or writes via
+  `IAppConfig`, with default value, type, and a sentence describing
+  effect,
+- **AND** there are no keys in code that are missing from the table.
+
+### Requirement: this change's phases MUST NOT ship before their upstream dependencies are archived
+
+Each phase declares its upstream dependency in `tasks.md`. A phase
+MUST NOT be implemented until the corresponding upstream openspec
+change is archived in its source repository.
+
+#### Scenario: Phase 1 waits for OR resolver
+
+- **GIVEN** `openregister/openspec/changes/register-resolver-service/`
+  is in proposal/draft,
+- **WHEN** a contributor attempts to ship Phase 1 of this change,
+- **THEN** the change MUST NOT land,
+- **AND** the contributor waits for the upstream change to archive.
+
+#### Scenario: Phase 8 has no upstream blocker
+
+- **GIVEN** Phases 1-7 have upstream blockers,
+- **WHEN** Phase 8 (magic-number cleanup) is ready,
+- **THEN** Phase 8 MAY be implemented and shipped independently,
+- **AND** does NOT block on the other phases.
+
+## REMOVED Requirements
+
+(none — this spec is purely additive within opencatalogi; the
+**MODIFIED** specs that this change rewrites — `file-management`,
+`admin-settings`, `download-service`, `search`, `dashboard`,
+`auto-publishing`, `federation` — declare their own REMOVED
+requirements in their respective spec deltas.)
+
+## Glossary
+
+- **Tier 2-3 (manifest tiering)** — per ADR-024: an app whose admin
+  CRUD views are manifest-driven (`type: "list"` / `type: "detail"`)
+  but which retains bespoke `type: "custom"` views for product-
+  specific experiences. opencatalogi is the canonical Tier 2-3 pilot.
+- **Translatable property** — a schema property declared
+  `translatable: true` per ADR-025 whose value is resolved per-locale
+  by the OR `TranslationHandler` on read.
+- **Source language** — the locale stored as the canonical value of a
+  translatable property; declared once per object via `sourceLanguage`
+  and immutable thereafter.
+- **organisationUuidGetter** — the reactive getter exposed by
+  `useTenantContext()` (nextcloud-vue) that every `createObjectStore`
+  consumes to scope queries to the active tenant.
+- **RegisterResolverService** — the OpenRegister service exposed by
+  `openregister/openspec/changes/register-resolver-service/` that
+  replaces every `IAppConfig::getValueString($appName,
+  '<context>_register' | '<context>_schema', '')` call site.
+
+## References
+
+- `proposal.md`, `tasks.md`, `design.md` (this change)
+- `.claude/audit-2026-05-03/00-executive-summary.md`
+- `.claude/audit-2026-05-03/01-code-cleanup.md` (Stream 1)
+- `.claude/audit-2026-05-03/02-spec-rewrite.md` (Stream 2)
+- `.claude/audit-2026-05-03/04-hardcoded.md` (Stream 4)
+- `.claude/audit-2026-05-03/research/R2-nc-vue-multitenancy.md`
+- `.claude/audit-2026-05-03/research/R3-opencatalogi-i18n-editing.md`
+- `.claude/audit-2026-05-03/research/R6-manifest-json.md`
+- `openregister/openspec/changes/register-resolver-service/`
+- `openregister/openspec/changes/pluggable-integration-registry/`
+- `openregister/openspec/changes/i18n-source-of-truth/`
+- `openregister/openspec/changes/i18n-api-language-negotiation/`
+- `nextcloud-vue/openspec/changes/multi-tenancy-context/`
+- `hydra/openspec/changes/adopt-app-manifest/`
+- `hydra/openspec/architecture/ADR-022-pluggable-integration-registry.md`
+- `hydra/openspec/architecture/ADR-024-app-manifest-convention.md`
+- `hydra/openspec/architecture/ADR-025-i18n-source-of-truth.md`

--- a/openspec/changes/opencatalogi-adopt-or-abstractions/tasks.md
+++ b/openspec/changes/opencatalogi-adopt-or-abstractions/tasks.md
@@ -1,0 +1,270 @@
+# Tasks — opencatalogi-adopt-or-abstractions
+
+> Spec-only change. Each phase below is broken into spec-authoring tasks.
+> Code changes happen in follow-up implementation changes once the spec
+> deltas are archived. Phases are ordered so later phases depend on
+> earlier phases' contracts being agreed.
+
+## Phase 1: Adopt `RegisterResolverService` across all controllers
+
+- [ ] 1.1 Document the five canonical contexts (`publications`,
+      `listings`, `catalogi`, `themes`, `pages`) plus the three already-
+      relying-on-`getValueString` contexts (`glossary`, `menus`,
+      `organisations`) in `specs/opencatalogi-adopt-or-abstractions/spec.md`.
+- [ ] 1.2 Add a requirement that **every** controller in `lib/Controller/`
+      that today calls `IAppConfig::getValueString($appName,
+      '<context>_register' | '<context>_schema', '')` must instead call
+      `RegisterResolverService::resolveRegister($context)` /
+      `resolveSchema($context)` / `resolvePair($context)`.
+- [ ] 1.3 Cross-reference each call site by file and line in the spec
+      (matches `.claude/audit-2026-05-03/04-hardcoded.md`):
+      `PublicationsController.php`, `ListingsController.php:99-159`,
+      `CatalogiController.php:117`, `ThemesController.php:114`,
+      `PagesController.php:126`.
+- [ ] 1.4 Specify that the empty-string fallback (`getValueString(..., '')`)
+      is forbidden going forward — `RegisterResolverService` must throw
+      `RegisterNotConfiguredException` and the controller must surface
+      a `503 Service Unavailable` with operator-actionable detail (which
+      context, which key, where to set it).
+- [ ] 1.5 Specify that the resolver result is request-scoped (no module
+      static caching) so admin re-configuration is picked up on the next
+      request without `apache2ctl graceful`.
+- [ ] 1.6 Cite OpenRegister `register-resolver-service` change as the
+      upstream dependency; capture the minimum `openregister` version
+      (the version that archives `register-resolver-service`) in
+      `appinfo/info.xml` `<dependencies>`.
+- [ ] 1.7 Add a SHALL: opencatalogi MUST NOT re-implement
+      `RegisterResolverService` locally even if OR is below the required
+      version — the app must refuse to load via the dependency check.
+
+## Phase 2: Migrate `src/store/modules/object.js` to `createObjectStore()`
+
+- [ ] 2.1 Add a requirement to delete `src/store/modules/object.js`
+      (currently 2 449 lines per audit) and replace with a thin wrapper
+      around `createObjectStore('object', { plugins: [...] })` from
+      `@conduction/nextcloud-vue`.
+- [ ] 2.2 Document the required plugin list: `filesPlugin()`,
+      `auditTrailsPlugin()`, `relationsPlugin()`, `searchPlugin()` —
+      these collectively cover the `relatedData: { logs, files, uses }`
+      shape that the bespoke store hand-rolls today.
+- [ ] 2.3 Forbid custom Pinia modules per the store-pattern guidance
+      in user memory (`feedback_store-pattern.md`): use the Options-API
+      helpers and `createObjectStore`, no bespoke Pinia state for objects.
+- [ ] 2.4 Specify the migration of every consumer component (lists +
+      details + modals): consumer components call store actions through
+      the standard helpers (`useObjectStore('object')`) — no direct
+      access to internal store state.
+- [ ] 2.5 Specify that pagination, filters, and faceted search behaviour
+      MUST remain functionally identical from the user's perspective
+      across the migration. Capture before/after smoke-test list in
+      `design.md`.
+- [ ] 2.6 Document the same migration path for `src/store/modules/search.js`:
+      either consume `searchPlugin()` from nextcloud-vue or extract a
+      shared search store. Decide in `design.md` and reference the
+      decision here.
+- [ ] 2.7 Capture the expected line-count reduction (≈2 250 lines deleted)
+      as a non-functional acceptance criterion so reviewers can spot
+      partial migrations that leave dead code behind.
+- [ ] 2.8 Add a regression-test requirement: the existing object E2E
+      flows (create publication, edit, delete, restore from trash) must
+      continue to pass.
+
+## Phase 3: Rewrite `file-management` spec; consume OR file APIs
+
+- [ ] 3.1 Rewrite `openspec/specs/file-management/spec.md` end-to-end —
+      mark the existing requirements as REMOVED and replace with a
+      single requirement: opencatalogi MUST consume OR's File
+      Attachments capability via `x-openregister-file` schema annotations
+      and `IFileService` (or its post-resolver-service equivalent).
+- [ ] 3.2 Specify that `OCP\Share\IShareManager` is the sharing surface;
+      opencatalogi MUST NOT re-implement share creation, share
+      enumeration, or share revocation locally.
+- [ ] 3.3 Specify that `lib/Controller/FilesController.php` becomes a
+      thin wrapper that delegates to OR's file controller; removing
+      bespoke endpoints. Capture each removed endpoint in the spec
+      so the API consumers know the migration path.
+- [ ] 3.4 Cross-reference the upstream OR file capability spec by name
+      and the `register-resolver-service` change for context resolution
+      before file operations.
+- [ ] 3.5 Document the impact on existing public catalogue downloads
+      (Phase 7 picks up `download-service`) so reviewers can see the
+      two-phase ordering is intentional.
+
+## Phase 4: i18n editing UI for translatable content
+
+- [ ] 4.1 List the five controllers that MUST consume the
+      `TranslationHandler` (or the post-`i18n-source-of-truth` public
+      handler):
+      `PagesController`, `MenusController`, `PublicationsController`,
+      `ThemesController`, `GlossaryController`.
+- [ ] 4.2 Specify that `Accept-Language` and `?_lang=` MUST resolve
+      translatable fields per `i18n-api-language-negotiation` — list the
+      negotiation order (query param > header > user preference >
+      app default).
+- [ ] 4.3 Add schema-marking requirements: every user-facing string
+      property (titles, summaries, body content, navigation labels)
+      MUST set `translatable: true` and the schema MUST declare
+      `sourceLanguage` per ADR-025.
+- [ ] 4.4 Catalogue every schema/property that needs `translatable: true`
+      in a table in `specs/.../spec.md` so the implementation cannot
+      miss a field. Source: `.claude/audit-2026-05-03/research/R3-opencatalogi-i18n-editing.md`.
+- [ ] 4.5 Specify the language-selector UI consumed from
+      `@conduction/nextcloud-vue`. List target screens:
+      `PublicationDetailPage.vue`, `ViewPageModal.vue`,
+      `ViewMenuModal.vue`, `ViewThemeModal.vue`, `ViewGlossaryModal.vue`.
+- [ ] 4.6 Specify the editorial rules (per ADR-025): the source
+      language is required and immutable per object; translations are
+      optional; missing translations fall back to the source per the
+      negotiation rules.
+- [ ] 4.7 Specify the public read path: catalogue routes must resolve
+      the visitor's `Accept-Language` server-side so the SSR/initial-state
+      markup matches the negotiated locale (no client-side flicker).
+- [ ] 4.8 Cite `openregister/openspec/changes/i18n-source-of-truth/`
+      and `openregister/openspec/changes/i18n-api-language-negotiation/`
+      as the upstream dependencies.
+- [ ] 4.9 Note that `Accept-Language` quality factors and
+      RFC 4647 lookup matching are OWNED by the OR upstream spec —
+      this app MUST NOT re-derive the negotiation algorithm.
+
+## Phase 5: Adopt nextcloud-vue multi-tenancy primitives
+
+- [ ] 5.1 Specify that `App.vue::setup()` MUST call `useTenantContext()`
+      from `@conduction/nextcloud-vue` once `multi-tenancy-context` is
+      archived; expose the active organisation UUID as a reactive
+      getter (`organisationUuidGetter`).
+- [ ] 5.2 Specify that **every** `createObjectStore()` invocation MUST
+      receive the `organisationUuidGetter` so list queries scope to
+      the active tenant. Audit covers existing stores in
+      `src/store/modules/`.
+- [ ] 5.3 Specify the `<CnTenantBadge>` placement: top bar, left of
+      the user menu, visible on every route.
+- [ ] 5.4 Specify cache-invalidation behaviour: switching tenant must
+      reset all `createObjectStore` instances (`watch(tenantId, () =>
+      store.reset())`); pagination resets to page 1; active filters are
+      cleared (or scoped per tenant — decide in `design.md`).
+- [ ] 5.5 Specify `CnFormDialog` auto-fill: when a schema declares an
+      `organisation` relation, the dialog MUST pre-fill the active
+      tenant's UUID and disable the field unless the user has
+      cross-tenant edit rights.
+- [ ] 5.6 Cite `nextcloud-vue/openspec/changes/multi-tenancy-context/`
+      as the upstream dependency. Cite
+      `.claude/audit-2026-05-03/research/R2-nc-vue-multitenancy.md`.
+
+## Phase 6: Adopt the app manifest convention (Tier 2-3)
+
+- [ ] 6.1 Specify that opencatalogi MUST ship `src/manifest.json` per
+      ADR-024 and `hydra/openspec/changes/adopt-app-manifest/`.
+- [ ] 6.2 Tier the app as **Tier 2-3**: bespoke catalog landing pages,
+      the publication renderer, and the public CMS view declare
+      `type: "custom"`; all admin CRUD entries declare `type: "list"`
+      / `type: "detail"` and are rendered by the manifest interpreter.
+- [ ] 6.3 Catalogue every existing route in
+      `src/router/index.js` and tag it as `list` / `detail` /
+      `custom` in a table in `specs/.../spec.md`. The implementation
+      cannot ship if a route is missing from the table.
+- [ ] 6.4 Specify `dependencies: ["openregister"]` in the manifest so
+      the registry refuses to load the app when OR is missing or below
+      the minimum version.
+- [ ] 6.5 Specify the deletion of hand-rolled router/sidebar code
+      (`src/router/index.js`, custom `<NcAppNavigation>` blocks)
+      once the manifest interpreter takes over. Capture this as a
+      "MUST NOT exist" requirement so the cleanup isn't forgotten.
+- [ ] 6.6 Specify that `appinfo/routes.php` is the source of truth for
+      backend routes; the manifest references controller names, not
+      paths, so changing a backend route doesn't require a manifest
+      bump.
+- [ ] 6.7 Cite `hydra/openspec/changes/adopt-app-manifest/`,
+      ADR-024, and `.claude/audit-2026-05-03/research/R6-manifest-json.md`
+      (which names opencatalogi as the Tier 2-3 pilot).
+
+## Phase 7: Spec rewrites for `search`, `admin-settings`, `dashboard`, `download-service`
+
+- [ ] 7.1 **`search`** (P2, MISSING-OR-DEP) — rewrite
+      `openspec/specs/search/spec.md` to cite OR's `zoeken-filteren`
+      capability as the primary surface. Federated/cross-catalog search
+      becomes a thin orchestrator that fans out to multiple
+      `zoeken-filteren` calls and merges results — opencatalogi MUST NOT
+      re-implement query parsing, faceting, or ranking.
+- [ ] 7.2 **`admin-settings`** (P2, NEEDS-REWRITE) — rewrite
+      `openspec/specs/admin-settings/spec.md` to cite OR's `IAppConfig`
+      conventions: key naming, validation, secret handling, default
+      values. Remove the duplicated patterns this spec re-derives.
+- [ ] 7.3 **`dashboard`** (P2) — confirm and add the citation to OR's
+      aggregations annotation. Remove hand-rolled aggregation prose
+      and reference the OR capability by name.
+- [ ] 7.4 **`download-service`** (P2, NEEDS-REWRITE) — rewrite to
+      consume OR's File Attachments + versioning capability for ZIP
+      generation. The download service becomes a streaming wrapper
+      that pipes OR file streams into a ZIP — no local file CRUD,
+      no bespoke versioning logic.
+- [ ] 7.5 In each rewrite, mark the original requirements as REMOVED
+      with a brief rationale ("re-implements OR's <capability>; consume
+      OR instead per ADR-022").
+- [ ] 7.6 Cite `.claude/audit-2026-05-03/02-spec-rewrite.md` as the
+      audit basis for each rewrite.
+
+## Phase 8: Hardcoded magic-number cleanup
+
+- [ ] 8.1 `lib/Service/BroadcastService.php:68,75` — promote
+      `MAX_RETRIES = 3` and `REQUEST_TIMEOUT = 30` to admin-config keys
+      (`broadcast_max_retries`, `broadcast_request_timeout`). Specify
+      defaults equal to the current values so behaviour is unchanged.
+- [ ] 8.2 `lib/Service/SitemapService.php:40` — promote
+      `MAX_PER_PAGE = 1000` to admin-config (`sitemap_max_per_page`).
+- [ ] 8.3 `lib/Service/SettingsService.php:64` — **delete**
+      `MIN_OPENREGISTER_VERSION = '0.1.7'`. Specify that
+      `appinfo/info.xml` `<dependencies>` is the only source of truth
+      for the minimum OR version; Nextcloud's app dependency check
+      enforces it at install time.
+- [ ] 8.4 `openspec/specs/auto-publishing/spec.md` — rewrite the
+      publication state-transition section to consume
+      `x-openregister-lifecycle` from the schema rather than encoding
+      the state machine in PHP.
+- [ ] 8.5 `openspec/specs/federation/spec.md` — rewrite per-app
+      retry/backoff to consume OR's outbound webhook policy.
+      opencatalogi MUST NOT re-derive retry maths.
+- [ ] 8.6 Specify that any new admin-config keys appear in the
+      `admin-settings` spec table from Phase 7.2 (single inventory).
+- [ ] 8.7 Cite `.claude/audit-2026-05-03/04-hardcoded.md` as the audit
+      basis.
+
+## Phase order rationale
+
+- Phase 1 lands first because Phase 2's `createObjectStore` invocations
+  call controllers that must already use `RegisterResolverService` —
+  otherwise the store sees inconsistent error shapes.
+- Phase 2 lands before Phase 3 because file-attachment migration is
+  cleaner once the store is the canonical object surface.
+- Phase 3 lands before Phase 7 because `download-service` (Phase 7.4)
+  builds on top of the file APIs adopted in Phase 3.
+- Phase 4 (i18n editing) is independent of 1-3 but lands before 5
+  because the language-picker UI must coexist with the tenant badge
+  in the top bar and we want one design pass on the bar layout.
+- Phase 5 lands before Phase 6 because the manifest interpreter must
+  understand `organisationUuidGetter` to generate Tier 2 list views
+  correctly.
+- Phase 6 lands before Phase 7 because spec rewrites can reference
+  manifest-tier semantics ("custom view" vs "list view").
+- Phase 8 lands last — it is independent and has the lowest blast
+  radius. Bundling it earlier risks scope creep on the higher-impact
+  phases.
+
+## Cross-cutting acceptance criteria
+
+- [ ] X.1 Every requirement in `specs/opencatalogi-adopt-or-abstractions/spec.md`
+      is traceable back to either an audit file
+      (`.claude/audit-2026-05-03/*.md`) or an upstream openspec change
+      slug. No floating requirements.
+- [ ] X.2 No phase ships before its upstream dependency is archived.
+      Capture the dependency graph in `design.md`.
+- [ ] X.3 The `breaking-changes` section of each affected spec lists
+      the API surface that becomes a hard error (e.g., empty-string
+      fallback in `getValueString` returning a misconfigured register
+      now throws 503).
+- [ ] X.4 The line-count reduction targets in `proposal.md` (≈2 250
+      lines for Phase 2) are tracked as KPIs in the implementation
+      change, not in this spec change.
+- [ ] X.5 Each affected spec under `openspec/specs/` is updated in
+      lockstep with its phase landing — partial updates (e.g.,
+      `admin-settings` rewritten but `download-service` still bespoke)
+      are explicitly forbidden by the cross-cutting validation.


### PR DESCRIPTION
## Summary

Phase 3 of the OR-abstraction audit (2026-05-03). Per-app adoption openspec change for **opencatalogi** — spec-only, no code changes.

Drafts the change so the implementation phase can run `/opsx-apply` against it when scheduled. References Phase 2 OR/nc-vue/hydra specs (openregister#1420, nextcloud-vue#113, hydra#218) and ADRs 022/024/025.

## Test plan

- [x] No code changes; markdown-only.
- [x] References resolve.

## Auto-merge rationale

Markdown-only PR per `feedback_pr-merge-authority.md` — admin-merged on creation.