### PR TITLE
feat(openspec): opencatalogi-legacy-quality-cleanup tracking change

### DIFF
--- a/openspec/changes/opencatalogi-legacy-quality-cleanup/proposal.md
+++ b/openspec/changes/opencatalogi-legacy-quality-cleanup/proposal.md
@@ -1,0 +1,72 @@
+# OpenCatalogi Legacy Quality Cleanup
+
+## Why
+
+The OR-abstraction audit (2026-05-03, stream 3 + the quality-gates
+cleanup at session start) flagged that opencatalogi's quality gates
+have legacy debt absorbed via exclude patterns. Burning these down
+keeps PR diffs honest — gates catch real regressions rather than
+silently absorbing already-broken code.
+
+OpenCatalogi has 8 phpcs.xml exclude-patterns and no PHPMD or PHPStan
+baseline yet. The bulk of the work is running PHPMD/PHPStan as a
+unified gate for the first time and either fixing surfacing errors
+outright or capturing them in a fresh baseline for follow-up burn-down.
+
+This is a tracking change so the burn-down work can be picked up
+later. It is spec-only; no code changes are proposed in this change.
+The actual file-by-file work will land in follow-up PRs.
+
+## What Changes
+
+- Inventory and clear the 8 phpcs.xml exclude-patterns. For each
+  excluded file: add proper docblocks + named-parameter call audits,
+  then drop the exclude.
+- Run PHPMD for the first time as a unified gate (phpmd.xml is
+  configured but no baseline exists). Capture surfacing violations
+  as a baseline OR fix them outright depending on volume.
+- Run PHPStan for the first time as a unified gate. Same trade-off:
+  baseline vs fix-outright.
+- Wire phpcs/phpmd/phpstan into CI as the unified quality gate so
+  future PRs cannot regress.
+
+## Problem
+
+Exclude-patterns exist because the audit captured legacy files that
+predated the current quality conventions. Blocking every PR while
+those files were normalised would freeze the repo; the agreed
+compromise was to capture the debt as exclude-patterns and burn it
+down deliberately.
+
+PHPMD/PHPStan baselines don't exist yet because the gates haven't
+been run as a unified `check:strict` block. The audit recommended
+running them and capturing the result as a baseline before adoption
+work — so cluster cleanup and adoption work can happen in parallel.
+
+Now is the time because the per-app OR-abstraction adoption work
+(Hydra ADR-022) is touching the same files. Any cluster cleanup that
+happens in parallel with adoption work amortises across both efforts.
+
+## Proposed Solution
+
+File-by-file cleanup phased by directory cluster. Because the
+exclude-pattern count is small (8), Phase 2 lists each file
+individually rather than grouping into buckets. Phases 3-4 are
+contingent on what surfaces when PHPMD / PHPStan run unified.
+
+Estimated effort: 2-3 PRs over 1 sprint.
+
+## Out of scope
+
+- Refactoring beyond what the sniff requires
+- New features (separate adoption-spec changes own those)
+- Test additions (separate test-coverage spec change if needed)
+
+## See also
+
+- The canonical audit lives in openregister at
+  `.claude/audit-2026-05-03/03-repo-hygiene.md`. OpenCatalogi
+  references it from there.
+- `phpcs.xml` (the legacy-debt baseline section)
+- Hydra ADR-022 (apps consume OR abstractions) — quality conventions
+- `composer.json` `check:strict` script (the unified gate target)

--- a/openspec/changes/opencatalogi-legacy-quality-cleanup/tasks.md
+++ b/openspec/changes/opencatalogi-legacy-quality-cleanup/tasks.md
@@ -1,0 +1,76 @@
+# Tasks: OpenCatalogi Legacy Quality Cleanup
+
+## Phase 1 — Inventory + planning
+
+- [ ] Run `composer phpcs` and capture current baseline error count
+      (target: starting from 8 exclude-patterns in phpcs.xml)
+- [ ] Run `composer phpmd` for the first time as a unified gate
+      and capture violation count + categories
+- [ ] Run `composer phpstan` for the first time as a unified gate
+      and capture error count + categories
+- [ ] Decide per gate: fix-outright (if <50 violations) or capture
+      a fresh baseline (if larger)
+- [ ] Confirm CI runs `composer check:strict` on every PR before
+      starting burn-down work
+
+## Phase 2 — PHPCS burn-down (per excluded file)
+
+For each file: fix errors, remove the phpcs.xml `<exclude-pattern>`
+entry, verify gate stays green.
+
+- [ ] Excluded file 1 — fix sniffs + drop exclude
+- [ ] Excluded file 2 — fix sniffs + drop exclude
+- [ ] Excluded file 3 — fix sniffs + drop exclude
+- [ ] Excluded file 4 — fix sniffs + drop exclude
+- [ ] Excluded file 5 — fix sniffs + drop exclude
+- [ ] Excluded file 6 — fix sniffs + drop exclude
+- [ ] Excluded file 7 — fix sniffs + drop exclude
+- [ ] Excluded file 8 — fix sniffs + drop exclude
+- [ ] Once all excludes are gone, drop the legacy-debt block from
+      phpcs.xml entirely
+
+## Phase 3 — PHPMD burn-down
+
+Contingent on Phase 1's first-run output. If a baseline was captured,
+work the categories in roughly volume-descending order.
+
+- [ ] ElseExpression — re-shape `if/else` chains to early-return
+- [ ] CyclomaticComplexity — extract methods to flatten branches
+- [ ] NPathComplexity — split branches into named helpers
+- [ ] MissingImport — add `use` statements; remove inline FQCNs
+- [ ] ExcessiveMethodLength — extract helpers
+- [ ] StaticAccess — replace static calls with DI services
+- [ ] LongVariable / ShortVariable — rename to 4-20 chars
+- [ ] UndefinedVariable / UnusedFormalParameter — fix or document
+      with `@SuppressWarnings`
+- [ ] Once baseline reaches 0 lines: delete phpmd.baseline.xml and
+      drop `--baseline-file` from composer.json's phpmd script
+
+## Phase 4 — PHPStan burn-down
+
+Contingent on Phase 1's first-run output. If a baseline was captured,
+work per-cluster.
+
+- [ ] Inventory phpstan-baseline.neon by error type and file
+- [ ] Per-cluster common patterns to fix:
+  - [ ] Missing return-type / param-type declarations
+  - [ ] Mixed types (specify generic / union)
+  - [ ] Possibly-null dereferences (add null guards)
+- [ ] Once baseline reaches 0 lines: delete phpstan-baseline.neon
+
+## Phase 5 — CI integration
+
+- [ ] Verify `composer check:strict` runs in CI on every PR
+- [ ] Once all baselines are empty:
+  - [ ] Delete `phpmd.baseline.xml` (if it was created)
+  - [ ] Delete `phpstan-baseline.neon` (if it was created)
+  - [ ] Drop the legacy-debt section from `phpcs.xml`
+- [ ] Add a smoke-test cron that runs `composer check:strict`
+      weekly on `development`
+
+## Phase 6 — Documentation
+
+- [ ] Update README quality-gates section
+- [ ] Note in `app-config.json` that legacy quality cleanup is done
+- [ ] Close the burn-down tracking issue once the last baseline
+      line is removed


### PR DESCRIPTION
## Summary

Drafts the openspec change that captures opencatalogi's legacy quality-debt cleanup as a tracked initiative. **Spec-only, markdown-only.**

Per the 2026-05-03 OR-abstraction audit, stream 3 (repo hygiene). Tracks the burn-down of any phpcs.xml exclude-pattern, phpmd.baseline.xml, or phpstan-baseline state so future PR diffs are gated against real issues only.

## Auto-merge rationale

Markdown-only per `feedback_pr-merge-authority.md`.