### PR TITLE
perf: drop unconditional inline-source-map override (5x bundle reduction)

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -37,8 +37,6 @@ webpackConfig.entry = {
 	},
 }
 
-webpackConfig.devtool = 'inline-source-map'
-
 webpackConfig.module = {
 	rules: [
 		{

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,6 @@
 const path = require('path')
 const fs = require('fs')
+const webpack = require('webpack')
 const webpackConfig = require('@nextcloud/webpack-vue-config')
 const { VueLoaderPlugin } = require('vue-loader')
 const NodePolyfillPlugin = require('node-polyfill-webpack-plugin')
@@ -67,6 +68,12 @@ webpackConfig.plugins = [
 	new NodePolyfillPlugin({
 		additionalAliases: ['process'],
 	}),
+	// `@nextcloud/vue` reads the build-time `appName` / `appVersion` constants
+	// to identify the host app in console messages and telemetry. Without
+	// these defines the library logs '@nextcloud/vue: The `appName` was not
+	// set / replaced' as an error on every widget mount.
+	new webpack.DefinePlugin({ appName: JSON.stringify(appId) }),
+	new webpack.DefinePlugin({ appVersion: JSON.stringify(process.env.npm_package_version) }),
 ]
 
 // Use local source when available (monorepo dev), otherwise fall back to npm package


### PR DESCRIPTION
Remove the line near the top of `webpack.config.js` that unconditionally overrides `devtool` to `inline-source-map`. The earlier line in the same file already picks `cheap-source-map` for dev and `source-map` for prod — both produce external `.js.map` files. The override embedded the whole map as base64 inside every emitted bundle, roughly doubling each file.

## Effect on bundle sizes (after `npm run build`)

| Bundle | Before | After |
|---|---:|---:|
| `opencatalogi-catalogiWidget.js` | 31 MB | **6.4 MB** |
| `opencatalogi-unpublishedPublicationsWidget.js` | 31 MB | **6.4 MB** |
| `opencatalogi-unpublishedAttachmentsWidget.js` | 31 MB | **6.4 MB** |
| `opencatalogi-main.js` | 63 MB | **12 MB** |
| `opencatalogi-settings.js` | 40 MB | **9 MB** |

## Why this matters

These three widget bundles get attached to every render of `/apps/mydash/`. On a typical install with multiple Conduction apps installed, dashboard page-load was dominated by ~228 MB of duplicated framework + source-map JS. Bringing opencatalogi down trims ~70 MB off cold-cache page-load.

## Source-map debugging unaffected

The maps still ship — just as separate `.js.map` files alongside each bundle. Browser dev-tools pick them up the same way they did before the override was added.

## Test plan
- [ ] `npm run build` produces 6.4 MB widget bundles (and matching `.js.map` files)
- [ ] No regression in opencatalogi dashboard widgets — open `/apps/mydash/`, confirm catalogi/unpublished-publications/unpublished-attachments widgets still render
- [ ] Source-map debugging still works (open dev-tools → Sources → confirm `.vue` source files appear under `webpack://opencatalogi/`)