### PR TITLE
docs: align development docs with the documentation branch

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -10,4 +10,4 @@ jobs:
   deploy:
     uses: ConductionNL/.github/.github/workflows/documentation.yml@main
     with:
-      cname: documentatie.opencatalogi.nl
+      cname: opencatalogi.conduction.nl

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -1,23 +1,32 @@
 // @ts-check
-// Note: type annotations allow type checking and IDEs autocompletion
 
-/** @type {import('@docusaurus/types').Config} */
-const config = {
+/**
+ * OpenCatalogi documentation site.
+ *
+ * Built on @conduction/docusaurus-preset for brand defaults (tokens,
+ * theme swizzles for Navbar / Footer, KvK / BTW copyright). Site-specific
+ * overrides — locales, sidebar path, mermaid theme, redocusaurus, custom
+ * navbar items — are passed through createConfig() opts.
+ */
+
+const { createConfig, baseFooterLinks } = require('@conduction/docusaurus-preset');
+
+/* createConfig replaces themes wholesale when `themes:` is passed, so
+   we re-include the brand theme plugin alongside @docusaurus/theme-mermaid.
+   Without the brand theme entry the Navbar/Footer swizzles and
+   brand.css auto-load would silently drop. */
+const BRAND_THEME = require.resolve('@conduction/docusaurus-preset/theme');
+
+const config = createConfig({
   title: 'Open Catalogi',
   tagline: 'Open source catalog management for government organizations',
-  url: 'https://documentatie.opencatalogi.nl',
+  url: 'https://opencatalogi.conduction.nl',
   baseUrl: '/',
-  
-  // GitHub pages deployment config
-  organizationName: 'conductionnl', 
+
+  organizationName: 'ConductionNL',
   projectName: 'opencatalogi',
   trailingSlash: false,
 
-  onBrokenLinks: 'warn',
-  onBrokenMarkdownLinks: 'warn',
-
-  // Even if you don't use internalization, you can use this field to set useful
-  // metadata like html lang
   i18n: {
     defaultLocale: 'en',
     locales: ['en', 'nl'],
@@ -27,117 +36,116 @@ const config = {
     },
   },
 
-  // Add markdown support for mermaid diagrams
-  markdown: {
-    mermaid: true,
-  },
-
-  // Add mermaid theme to the list of themes
-  themes: ['@docusaurus/theme-mermaid'],
+  /* The opencatalogi docs source lives at the repo root of `docs/`
+     rather than under a `docs/` subfolder, so we override the preset's
+     default `presets:` block to point `docs.path` at './' and disable
+     the blog plugin. customCss carries opencatalogi-specific CSS only —
+     brand tokens and the theme swizzles are auto-loaded by the brand
+     theme entry in `themes:` below. */
   presets: [
     [
       'classic',
-      /** @type {import('@docusaurus/preset-classic').Options} */
-      ({
+      {
         docs: {
           path: './',
-          exclude: ['**/node_modules/**'],
+          /* docs.path: './' makes plugin-content-docs scan every file
+             in docs/, which collides with plugin-content-pages's own
+             scan of docs/src/pages/. Exclude src/ (pages live there)
+             plus the standard node_modules bucket. */
+          exclude: ['**/node_modules/**', 'src/**'],
           sidebarPath: require.resolve('./sidebars.js'),
-          editUrl:
-            'https://github.com/conductionnl/opencatalogi/tree/main/docs/',
+          editUrl: 'https://github.com/ConductionNL/opencatalogi/tree/main/docs/',
         },
         blog: false,
         theme: {
           customCss: require.resolve('./src/css/custom.css'),
         },
-      }),
+      },
     ],
     [
       'redocusaurus',
       {
-        // Plugin Options for loading OpenAPI files
         specs: [
-          // Pass it a path to a local OpenAPI YAML file
           {
-            // Redocusaurus will automatically bundle your spec into a single file during the build
             spec: 'static/oas/open-catalogi.yaml',
             route: '/api',
           },
         ],
-        // Theme Options for modifying how redoc renders them
         theme: {
-          // Change with your site colors
           primaryColor: '#1890ff',
         },
       },
-    ]
+    ],
   ],
 
-  themeConfig:
-    /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
-    ({
-      // Add mermaid configuration to themeConfig
-      mermaid: {
-        theme: { light: 'default', dark: 'dark' },
+  themes: [BRAND_THEME, '@docusaurus/theme-mermaid'],
+
+  /* Brand navbar provides locale dropdown + GitHub by default; we
+     replace items[] with opencatalogi's own (Documentation sidebar
+     link, API docs, GitHub link, locale dropdown). */
+  navbar: {
+    title: 'Open Catalogi',
+    logo: {
+      alt: 'Open Catalogi Logo',
+      src: 'img/logo.svg',
+    },
+    items: [
+      {
+        type: 'docSidebar',
+        sidebarId: 'tutorialSidebar',
+        position: 'left',
+        label: 'Documentation',
       },
-      navbar: {
-        title: 'Open Catalogi',
-        logo: {
-          alt: 'Open Catalogi Logo',
-          src: 'img/logo.svg',
-        },
-        items: [
-          {
-            type: 'docSidebar',
-            sidebarId: 'tutorialSidebar',
-            position: 'left',
-            label: 'Documentation',
-          },
-          {
-            href: '/api',
-            label: 'API Documentation',
-            position: 'right',
-          },
-          {
-            href: 'https://github.com/conductionnl/opencatalogi',
-            label: 'GitHub',
-            position: 'right',
-          },
-          {
-            type: 'localeDropdown',
-            position: 'right',
-          },
-        ],
+      {
+        href: '/api',
+        label: 'API Documentation',
+        position: 'right',
       },
-      footer: {
-        style: 'dark',
-        links: [
-          {
-            title: 'Docs',
-            items: [
-              {
-                label: 'Documentation',
-                to: '/docs',
-              },
-            ],
-          },
-          {
-            title: 'Community',
-            items: [
-              {
-                label: 'GitHub',
-                href: 'https://github.com/conductionnl/opencatalogi',
-              },
-            ],
-          },
-        ],
-        copyright: `Copyright © ${new Date().getFullYear()} for <a href="https://openwebconcept.nl">Open Webconcept</a> by <a href="https://conduction.nl">Conduction B.V.</a>`,
+      {
+        href: 'https://github.com/ConductionNL/opencatalogi',
+        label: 'GitHub',
+        position: 'right',
       },
-      prism: {
-        theme: require('prism-react-renderer/themes/github'),
-        darkTheme: require('prism-react-renderer/themes/dracula'),
-      },
-    }),
+      { type: 'localeDropdown', position: 'right' },
+    ],
+  },
+
+  /* Per-property footer override (preset 1.2.0+): we pass `links` only,
+     so the brand `style: 'dark'` and the brand KvK/BTW/IBAN/address
+     copyright string both inherit unchanged. Single Conduction column;
+     no Sendent partner column on this product page. */
+  footer: {
+    links: [
+      ...baseFooterLinks().filter((column) => column.title === 'Conduction'),
+    ],
+  },
+
+  /* Drop the canal-footer's boat-sinking + kade-cyclist mini-games
+     on this product-page footer (preset 1.3.0+). The static skyline +
+     canal decoration are kept; the interactive layer goes away. */
+  minigames: false,
+
+  /* themeConfig is shallow-merged into the preset's defaults
+     (colorMode + navbar + footer). prism + mermaid land alongside. */
+  themeConfig: {
+    prism: {
+      theme: require('prism-react-renderer/themes/github'),
+      darkTheme: require('prism-react-renderer/themes/dracula'),
+    },
+    mermaid: {
+      theme: { light: 'default', dark: 'dark' },
+    },
+  },
+});
+
+/* createConfig doesn't pass-through arbitrary top-level fields; assign
+   markdown + onBroken* directly so they make it into the final
+   Docusaurus config. */
+config.onBrokenLinks = 'warn';
+config.onBrokenMarkdownLinks = 'warn';
+config.onBrokenAnchors = 'warn';
+config.markdown = {
+  mermaid: true,
 };
 
 module.exports = config;

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1,13 +1,14 @@
 {
-  "name": "open-catalogi-docs",
+  "name": "opencatalogi-docs",
   "version": "0.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "open-catalogi-docs",
+      "name": "opencatalogi-docs",
       "version": "0.0.0",
       "dependencies": {
+        "@conduction/docusaurus-preset": "^1.5.1",
         "@docusaurus/core": "^3.7.0",
         "@docusaurus/preset-classic": "^3.7.0",
         "@docusaurus/theme-mermaid": "^3.7.0",
@@ -1886,6 +1887,18 @@
       "optional": true,
       "engines": {
         "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@conduction/docusaurus-preset": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@conduction/docusaurus-preset/-/docusaurus-preset-1.5.1.tgz",
+      "integrity": "sha512-xKcq6OHKvKMHopqP7PzOjviyLe5D91Za9qpY2teMiLN9jOOfbhM1lvv/dK+o7N+kK0ATolM7rOZOHNZwfIIaNQ==",
+      "license": "EUPL-1.2",
+      "peerDependencies": {
+        "@docusaurus/core": "^3.0.0",
+        "@docusaurus/preset-classic": "^3.0.0",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
       }
     },
     "node_modules/@csstools/cascade-layer-name-parser": {
@@ -8775,6 +8788,20 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
@@ -16330,13 +16357,6 @@
         "ajv": "^8.8.2"
       }
     },
-    "node_modules/search-insights": {
-      "version": "2.17.3",
-      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.17.3.tgz",
-      "integrity": "sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==",
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/section-matter": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
@@ -17630,20 +17650,6 @@
         "is-typedarray": "^1.0.0"
       }
     },
-    "node_modules/typescript": {
-      "version": "5.8.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
-      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
     "node_modules/ufo": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.5.4.tgz",
@@ -18793,8 +18799,7 @@
     "@algolia/autocomplete-shared": {
       "version": "1.17.9",
       "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.17.9.tgz",
-      "integrity": "sha512-iDf05JDQ7I0b7JEA/9IektxN/80a2MZ1ToohfmNS3rfeuQnIKI3IJlIafD0xu4StbtQTghx9T3Maa97ytkXenQ==",
-      "requires": {}
+      "integrity": "sha512-iDf05JDQ7I0b7JEA/9IektxN/80a2MZ1ToohfmNS3rfeuQnIKI3IJlIafD0xu4StbtQTghx9T3Maa97ytkXenQ=="
     },
     "@algolia/client-abtesting": {
       "version": "5.21.0",
@@ -19244,8 +19249,7 @@
     "@babel/plugin-proposal-private-property-in-object": {
       "version": "7.21.0-placeholder-for-preset-env.2",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
-      "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
-      "requires": {}
+      "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w=="
     },
     "@babel/plugin-syntax-dynamic-import": {
       "version": "7.8.3",
@@ -20023,11 +20027,15 @@
       "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
       "optional": true
     },
+    "@conduction/docusaurus-preset": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@conduction/docusaurus-preset/-/docusaurus-preset-1.5.1.tgz",
+      "integrity": "sha512-xKcq6OHKvKMHopqP7PzOjviyLe5D91Za9qpY2teMiLN9jOOfbhM1lvv/dK+o7N+kK0ATolM7rOZOHNZwfIIaNQ=="
+    },
     "@csstools/cascade-layer-name-parser": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@csstools/cascade-layer-name-parser/-/cascade-layer-name-parser-2.0.4.tgz",
-      "integrity": "sha512-7DFHlPuIxviKYZrOiwVU/PiHLm3lLUR23OMuEEtfEOQTOp9hzQ2JjdY6X5H18RVuUPJqSCI+qNnD5iOLMVE0bA==",
-      "requires": {}
+      "integrity": "sha512-7DFHlPuIxviKYZrOiwVU/PiHLm3lLUR23OMuEEtfEOQTOp9hzQ2JjdY6X5H18RVuUPJqSCI+qNnD5iOLMVE0bA=="
     },
     "@csstools/color-helpers": {
       "version": "5.0.2",
@@ -20037,8 +20045,7 @@
     "@csstools/css-calc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.2.tgz",
-      "integrity": "sha512-TklMyb3uBB28b5uQdxjReG4L80NxAqgrECqLZFQbyLekwwlcDDS8r3f07DKqeo8C4926Br0gf/ZDe17Zv4wIuw==",
-      "requires": {}
+      "integrity": "sha512-TklMyb3uBB28b5uQdxjReG4L80NxAqgrECqLZFQbyLekwwlcDDS8r3f07DKqeo8C4926Br0gf/ZDe17Zv4wIuw=="
     },
     "@csstools/css-color-parser": {
       "version": "3.0.8",
@@ -20052,8 +20059,7 @@
     "@csstools/css-parser-algorithms": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.4.tgz",
-      "integrity": "sha512-Up7rBoV77rv29d3uKHUIVubz1BTcgyUK72IvCQAbfbMv584xHcGKCKbWh7i8hPrRJ7qU4Y8IO3IY9m+iTB7P3A==",
-      "requires": {}
+      "integrity": "sha512-Up7rBoV77rv29d3uKHUIVubz1BTcgyUK72IvCQAbfbMv584xHcGKCKbWh7i8hPrRJ7qU4Y8IO3IY9m+iTB7P3A=="
     },
     "@csstools/css-tokenizer": {
       "version": "3.0.3",
@@ -20063,8 +20069,7 @@
     "@csstools/media-query-list-parser": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-4.0.2.tgz",
-      "integrity": "sha512-EUos465uvVvMJehckATTlNqGj4UJWkTmdWuDMjqvSUkjGpmOyFZBVwb4knxCm/k2GMTXY+c/5RkdndzFYWeX5A==",
-      "requires": {}
+      "integrity": "sha512-EUos465uvVvMJehckATTlNqGj4UJWkTmdWuDMjqvSUkjGpmOyFZBVwb4knxCm/k2GMTXY+c/5RkdndzFYWeX5A=="
     },
     "@csstools/postcss-cascade-layers": {
       "version": "5.0.1",
@@ -20176,8 +20181,7 @@
     "@csstools/postcss-initial": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@csstools/postcss-initial/-/postcss-initial-2.0.1.tgz",
-      "integrity": "sha512-L1wLVMSAZ4wovznquK0xmC7QSctzO4D0Is590bxpGqhqjboLXYA16dWZpfwImkdOgACdQ9PqXsuRroW6qPlEsg==",
-      "requires": {}
+      "integrity": "sha512-L1wLVMSAZ4wovznquK0xmC7QSctzO4D0Is590bxpGqhqjboLXYA16dWZpfwImkdOgACdQ9PqXsuRroW6qPlEsg=="
     },
     "@csstools/postcss-is-pseudo-class": {
       "version": "5.0.1",
@@ -20202,20 +20206,17 @@
     "@csstools/postcss-logical-float-and-clear": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@csstools/postcss-logical-float-and-clear/-/postcss-logical-float-and-clear-3.0.0.tgz",
-      "integrity": "sha512-SEmaHMszwakI2rqKRJgE+8rpotFfne1ZS6bZqBoQIicFyV+xT1UF42eORPxJkVJVrH9C0ctUgwMSn3BLOIZldQ==",
-      "requires": {}
+      "integrity": "sha512-SEmaHMszwakI2rqKRJgE+8rpotFfne1ZS6bZqBoQIicFyV+xT1UF42eORPxJkVJVrH9C0ctUgwMSn3BLOIZldQ=="
     },
     "@csstools/postcss-logical-overflow": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@csstools/postcss-logical-overflow/-/postcss-logical-overflow-2.0.0.tgz",
-      "integrity": "sha512-spzR1MInxPuXKEX2csMamshR4LRaSZ3UXVaRGjeQxl70ySxOhMpP2252RAFsg8QyyBXBzuVOOdx1+bVO5bPIzA==",
-      "requires": {}
+      "integrity": "sha512-spzR1MInxPuXKEX2csMamshR4LRaSZ3UXVaRGjeQxl70ySxOhMpP2252RAFsg8QyyBXBzuVOOdx1+bVO5bPIzA=="
     },
     "@csstools/postcss-logical-overscroll-behavior": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@csstools/postcss-logical-overscroll-behavior/-/postcss-logical-overscroll-behavior-2.0.0.tgz",
-      "integrity": "sha512-e/webMjoGOSYfqLunyzByZj5KKe5oyVg/YSbie99VEaSDE2kimFm0q1f6t/6Jo+VVCQ/jbe2Xy+uX+C4xzWs4w==",
-      "requires": {}
+      "integrity": "sha512-e/webMjoGOSYfqLunyzByZj5KKe5oyVg/YSbie99VEaSDE2kimFm0q1f6t/6Jo+VVCQ/jbe2Xy+uX+C4xzWs4w=="
     },
     "@csstools/postcss-logical-resize": {
       "version": "3.0.0",
@@ -20364,26 +20365,22 @@
     "@csstools/postcss-unset-value": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@csstools/postcss-unset-value/-/postcss-unset-value-4.0.0.tgz",
-      "integrity": "sha512-cBz3tOCI5Fw6NIFEwU3RiwK6mn3nKegjpJuzCndoGq3BZPkUjnsq7uQmIeMNeMbMk7YD2MfKcgCpZwX5jyXqCA==",
-      "requires": {}
+      "integrity": "sha512-cBz3tOCI5Fw6NIFEwU3RiwK6mn3nKegjpJuzCndoGq3BZPkUjnsq7uQmIeMNeMbMk7YD2MfKcgCpZwX5jyXqCA=="
     },
     "@csstools/selector-resolve-nested": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@csstools/selector-resolve-nested/-/selector-resolve-nested-3.0.0.tgz",
-      "integrity": "sha512-ZoK24Yku6VJU1gS79a5PFmC8yn3wIapiKmPgun0hZgEI5AOqgH2kiPRsPz1qkGv4HL+wuDLH83yQyk6inMYrJQ==",
-      "requires": {}
+      "integrity": "sha512-ZoK24Yku6VJU1gS79a5PFmC8yn3wIapiKmPgun0hZgEI5AOqgH2kiPRsPz1qkGv4HL+wuDLH83yQyk6inMYrJQ=="
     },
     "@csstools/selector-specificity": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-5.0.0.tgz",
-      "integrity": "sha512-PCqQV3c4CoVm3kdPhyeZ07VmBRdH2EpMFA/pd9OASpOEC3aXNGoqPDAZ80D0cLpMBxnmk0+yNhGsEx31hq7Gtw==",
-      "requires": {}
+      "integrity": "sha512-PCqQV3c4CoVm3kdPhyeZ07VmBRdH2EpMFA/pd9OASpOEC3aXNGoqPDAZ80D0cLpMBxnmk0+yNhGsEx31hq7Gtw=="
     },
     "@csstools/utilities": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@csstools/utilities/-/utilities-2.0.0.tgz",
-      "integrity": "sha512-5VdOr0Z71u+Yp3ozOx8T11N703wIFGVRgOWbOZMKgglPJsWA54MRIoMNVMa7shUToIhx5J8vX4sOZgD2XiihiQ==",
-      "requires": {}
+      "integrity": "sha512-5VdOr0Z71u+Yp3ozOx8T11N703wIFGVRgOWbOZMKgglPJsWA54MRIoMNVMa7shUToIhx5J8vX4sOZgD2XiihiQ=="
     },
     "@discoveryjs/json-ext": {
       "version": "0.5.7",
@@ -21310,50 +21307,42 @@
     "@svgr/babel-plugin-add-jsx-attribute": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-8.0.0.tgz",
-      "integrity": "sha512-b9MIk7yhdS1pMCZM8VeNfUlSKVRhsHZNMl5O9SfaX0l0t5wjdgu4IDzGB8bpnGBBOjGST3rRFVsaaEtI4W6f7g==",
-      "requires": {}
+      "integrity": "sha512-b9MIk7yhdS1pMCZM8VeNfUlSKVRhsHZNMl5O9SfaX0l0t5wjdgu4IDzGB8bpnGBBOjGST3rRFVsaaEtI4W6f7g=="
     },
     "@svgr/babel-plugin-remove-jsx-attribute": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-remove-jsx-attribute/-/babel-plugin-remove-jsx-attribute-8.0.0.tgz",
-      "integrity": "sha512-BcCkm/STipKvbCl6b7QFrMh/vx00vIP63k2eM66MfHJzPr6O2U0jYEViXkHJWqXqQYjdeA9cuCl5KWmlwjDvbA==",
-      "requires": {}
+      "integrity": "sha512-BcCkm/STipKvbCl6b7QFrMh/vx00vIP63k2eM66MfHJzPr6O2U0jYEViXkHJWqXqQYjdeA9cuCl5KWmlwjDvbA=="
     },
     "@svgr/babel-plugin-remove-jsx-empty-expression": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-remove-jsx-empty-expression/-/babel-plugin-remove-jsx-empty-expression-8.0.0.tgz",
-      "integrity": "sha512-5BcGCBfBxB5+XSDSWnhTThfI9jcO5f0Ai2V24gZpG+wXF14BzwxxdDb4g6trdOux0rhibGs385BeFMSmxtS3uA==",
-      "requires": {}
+      "integrity": "sha512-5BcGCBfBxB5+XSDSWnhTThfI9jcO5f0Ai2V24gZpG+wXF14BzwxxdDb4g6trdOux0rhibGs385BeFMSmxtS3uA=="
     },
     "@svgr/babel-plugin-replace-jsx-attribute-value": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-replace-jsx-attribute-value/-/babel-plugin-replace-jsx-attribute-value-8.0.0.tgz",
-      "integrity": "sha512-KVQ+PtIjb1BuYT3ht8M5KbzWBhdAjjUPdlMtpuw/VjT8coTrItWX6Qafl9+ji831JaJcu6PJNKCV0bp01lBNzQ==",
-      "requires": {}
+      "integrity": "sha512-KVQ+PtIjb1BuYT3ht8M5KbzWBhdAjjUPdlMtpuw/VjT8coTrItWX6Qafl9+ji831JaJcu6PJNKCV0bp01lBNzQ=="
     },
     "@svgr/babel-plugin-svg-dynamic-title": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-dynamic-title/-/babel-plugin-svg-dynamic-title-8.0.0.tgz",
-      "integrity": "sha512-omNiKqwjNmOQJ2v6ge4SErBbkooV2aAWwaPFs2vUY7p7GhVkzRkJ00kILXQvRhA6miHnNpXv7MRnnSjdRjK8og==",
-      "requires": {}
+      "integrity": "sha512-omNiKqwjNmOQJ2v6ge4SErBbkooV2aAWwaPFs2vUY7p7GhVkzRkJ00kILXQvRhA6miHnNpXv7MRnnSjdRjK8og=="
     },
     "@svgr/babel-plugin-svg-em-dimensions": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-em-dimensions/-/babel-plugin-svg-em-dimensions-8.0.0.tgz",
-      "integrity": "sha512-mURHYnu6Iw3UBTbhGwE/vsngtCIbHE43xCRK7kCw4t01xyGqb2Pd+WXekRRoFOBIY29ZoOhUCTEweDMdrjfi9g==",
-      "requires": {}
+      "integrity": "sha512-mURHYnu6Iw3UBTbhGwE/vsngtCIbHE43xCRK7kCw4t01xyGqb2Pd+WXekRRoFOBIY29ZoOhUCTEweDMdrjfi9g=="
     },
     "@svgr/babel-plugin-transform-react-native-svg": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-react-native-svg/-/babel-plugin-transform-react-native-svg-8.1.0.tgz",
-      "integrity": "sha512-Tx8T58CHo+7nwJ+EhUwx3LfdNSG9R2OKfaIXXs5soiy5HtgoAEkDay9LIimLOcG8dJQH1wPZp/cnAv6S9CrR1Q==",
-      "requires": {}
+      "integrity": "sha512-Tx8T58CHo+7nwJ+EhUwx3LfdNSG9R2OKfaIXXs5soiy5HtgoAEkDay9LIimLOcG8dJQH1wPZp/cnAv6S9CrR1Q=="
     },
     "@svgr/babel-plugin-transform-svg-component": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-svg-component/-/babel-plugin-transform-svg-component-8.0.0.tgz",
-      "integrity": "sha512-DFx8xa3cZXTdb/k3kfPeaixecQLgKh5NVBMwD0AQxOzcZawK4oo1Jh9LbrcACUivsCA7TLG8eeWgrDXjTMhRmw==",
-      "requires": {}
+      "integrity": "sha512-DFx8xa3cZXTdb/k3kfPeaixecQLgKh5NVBMwD0AQxOzcZawK4oo1Jh9LbrcACUivsCA7TLG8eeWgrDXjTMhRmw=="
     },
     "@svgr/babel-preset": {
       "version": "8.1.0",
@@ -22214,8 +22203,7 @@
     "acorn-jsx": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
-      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "requires": {}
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="
     },
     "acorn-walk": {
       "version": "8.3.4",
@@ -22281,8 +22269,7 @@
     "ajv-keywords": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "requires": {}
+      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="
     },
     "algoliasearch": {
       "version": "5.21.0",
@@ -23223,8 +23210,7 @@
     "css-declaration-sorter": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-7.2.0.tgz",
-      "integrity": "sha512-h70rUM+3PNFuaBDTLe8wF/cdWu+dOZmb7pJt8Z2sedYbAcQVQV/tEchueg3GWxwqS0cxtbxmaHEdkNACqcvsow==",
-      "requires": {}
+      "integrity": "sha512-h70rUM+3PNFuaBDTLe8wF/cdWu+dOZmb7pJt8Z2sedYbAcQVQV/tEchueg3GWxwqS0cxtbxmaHEdkNACqcvsow=="
     },
     "css-has-pseudo": {
       "version": "7.0.2",
@@ -23267,8 +23253,7 @@
     "css-prefers-color-scheme": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/css-prefers-color-scheme/-/css-prefers-color-scheme-10.0.0.tgz",
-      "integrity": "sha512-VCtXZAWivRglTZditUfB4StnsWr6YVZ2PRtuxQLKTNRdtAf8tpzaVPE9zXIF3VaSc7O70iK/j1+NXxyQCqdPjQ==",
-      "requires": {}
+      "integrity": "sha512-VCtXZAWivRglTZditUfB4StnsWr6YVZ2PRtuxQLKTNRdtAf8tpzaVPE9zXIF3VaSc7O70iK/j1+NXxyQCqdPjQ=="
     },
     "css-select": {
       "version": "5.1.0",
@@ -23379,8 +23364,7 @@
     "cssnano-utils": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-4.0.2.tgz",
-      "integrity": "sha512-ZR1jHg+wZ8o4c3zqf1SIUSTIvm/9mU343FMR6Obe/unskbvpGhZOo1J6d/r8D1pzkRQYuwbcH3hToOuoA2G7oQ==",
-      "requires": {}
+      "integrity": "sha512-ZR1jHg+wZ8o4c3zqf1SIUSTIvm/9mU343FMR6Obe/unskbvpGhZOo1J6d/r8D1pzkRQYuwbcH3hToOuoA2G7oQ=="
     },
     "csso": {
       "version": "5.0.5",
@@ -24740,6 +24724,12 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
     },
+    "fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "optional": true
+    },
     "function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -25347,8 +25337,7 @@
     "icss-utils": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
-      "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
-      "requires": {}
+      "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA=="
     },
     "ignore": {
       "version": "5.3.2",
@@ -27305,8 +27294,7 @@
     "mobx-react-lite": {
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/mobx-react-lite/-/mobx-react-lite-3.4.3.tgz",
-      "integrity": "sha512-NkJREyFTSUXR772Qaai51BnE1voWx56LOL80xG7qkZr6vo8vEaLF3sz1JNUVh+rxmUzxYaqOhfuxTfqUh0FXUg==",
-      "requires": {}
+      "integrity": "sha512-NkJREyFTSUXR772Qaai51BnE1voWx56LOL80xG7qkZr6vo8vEaLF3sz1JNUVh+rxmUzxYaqOhfuxTfqUh0FXUg=="
     },
     "mrmime": {
       "version": "2.0.1",
@@ -28111,26 +28099,22 @@
     "postcss-discard-comments": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-6.0.2.tgz",
-      "integrity": "sha512-65w/uIqhSBBfQmYnG92FO1mWZjJ4GL5b8atm5Yw2UgrwD7HiNiSSNwJor1eCFGzUgYnN/iIknhNRVqjrrpuglw==",
-      "requires": {}
+      "integrity": "sha512-65w/uIqhSBBfQmYnG92FO1mWZjJ4GL5b8atm5Yw2UgrwD7HiNiSSNwJor1eCFGzUgYnN/iIknhNRVqjrrpuglw=="
     },
     "postcss-discard-duplicates": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-6.0.3.tgz",
-      "integrity": "sha512-+JA0DCvc5XvFAxwx6f/e68gQu/7Z9ud584VLmcgto28eB8FqSFZwtrLwB5Kcp70eIoWP/HXqz4wpo8rD8gpsTw==",
-      "requires": {}
+      "integrity": "sha512-+JA0DCvc5XvFAxwx6f/e68gQu/7Z9ud584VLmcgto28eB8FqSFZwtrLwB5Kcp70eIoWP/HXqz4wpo8rD8gpsTw=="
     },
     "postcss-discard-empty": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-6.0.3.tgz",
-      "integrity": "sha512-znyno9cHKQsK6PtxL5D19Fj9uwSzC2mB74cpT66fhgOadEUPyXFkbgwm5tvc3bt3NAy8ltE5MrghxovZRVnOjQ==",
-      "requires": {}
+      "integrity": "sha512-znyno9cHKQsK6PtxL5D19Fj9uwSzC2mB74cpT66fhgOadEUPyXFkbgwm5tvc3bt3NAy8ltE5MrghxovZRVnOjQ=="
     },
     "postcss-discard-overridden": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-6.0.2.tgz",
-      "integrity": "sha512-j87xzI4LUggC5zND7KdjsI25APtyMuynXZSujByMaav2roV6OZX+8AaCUcZSWqckZpjAjRyFDdpqybgjFO0HJQ==",
-      "requires": {}
+      "integrity": "sha512-j87xzI4LUggC5zND7KdjsI25APtyMuynXZSujByMaav2roV6OZX+8AaCUcZSWqckZpjAjRyFDdpqybgjFO0HJQ=="
     },
     "postcss-discard-unused": {
       "version": "6.0.5",
@@ -28180,14 +28164,12 @@
     "postcss-font-variant": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/postcss-font-variant/-/postcss-font-variant-5.0.0.tgz",
-      "integrity": "sha512-1fmkBaCALD72CK2a9i468mA/+tr9/1cBxRRMXOUaZqO43oWPR5imcyPjXwuv7PXbCid4ndlP5zWhidQVVa3hmA==",
-      "requires": {}
+      "integrity": "sha512-1fmkBaCALD72CK2a9i468mA/+tr9/1cBxRRMXOUaZqO43oWPR5imcyPjXwuv7PXbCid4ndlP5zWhidQVVa3hmA=="
     },
     "postcss-gap-properties": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/postcss-gap-properties/-/postcss-gap-properties-6.0.0.tgz",
-      "integrity": "sha512-Om0WPjEwiM9Ru+VhfEDPZJAKWUd0mV1HmNXqp2C29z80aQ2uP9UVhLc7e3aYMIor/S5cVhoPgYQ7RtfeZpYTRw==",
-      "requires": {}
+      "integrity": "sha512-Om0WPjEwiM9Ru+VhfEDPZJAKWUd0mV1HmNXqp2C29z80aQ2uP9UVhLc7e3aYMIor/S5cVhoPgYQ7RtfeZpYTRw=="
     },
     "postcss-image-set-function": {
       "version": "7.0.0",
@@ -28318,8 +28300,7 @@
     "postcss-modules-extract-imports": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.1.0.tgz",
-      "integrity": "sha512-k3kNe0aNFQDAZGbin48pL2VNidTF0w4/eASDsxlyspobzU3wZQLOGj7L9gfRe0Jo9/4uud09DsjFNH7winGv8Q==",
-      "requires": {}
+      "integrity": "sha512-k3kNe0aNFQDAZGbin48pL2VNidTF0w4/eASDsxlyspobzU3wZQLOGj7L9gfRe0Jo9/4uud09DsjFNH7winGv8Q=="
     },
     "postcss-modules-local-by-default": {
       "version": "4.2.0",
@@ -28360,8 +28341,7 @@
     "postcss-normalize-charset": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-6.0.2.tgz",
-      "integrity": "sha512-a8N9czmdnrjPHa3DeFlwqst5eaL5W8jYu3EBbTTkI5FHkfMhFZh1EGbku6jhHhIzTA6tquI2P42NtZ59M/H/kQ==",
-      "requires": {}
+      "integrity": "sha512-a8N9czmdnrjPHa3DeFlwqst5eaL5W8jYu3EBbTTkI5FHkfMhFZh1EGbku6jhHhIzTA6tquI2P42NtZ59M/H/kQ=="
     },
     "postcss-normalize-display-values": {
       "version": "6.0.2",
@@ -28431,8 +28411,7 @@
     "postcss-opacity-percentage": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/postcss-opacity-percentage/-/postcss-opacity-percentage-3.0.0.tgz",
-      "integrity": "sha512-K6HGVzyxUxd/VgZdX04DCtdwWJ4NGLG212US4/LA1TLAbHgmAsTWVR86o+gGIbFtnTkfOpb9sCRBx8K7HO66qQ==",
-      "requires": {}
+      "integrity": "sha512-K6HGVzyxUxd/VgZdX04DCtdwWJ4NGLG212US4/LA1TLAbHgmAsTWVR86o+gGIbFtnTkfOpb9sCRBx8K7HO66qQ=="
     },
     "postcss-ordered-values": {
       "version": "6.0.2",
@@ -28454,8 +28433,7 @@
     "postcss-page-break": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/postcss-page-break/-/postcss-page-break-3.0.4.tgz",
-      "integrity": "sha512-1JGu8oCjVXLa9q9rFTo4MbeeA5FMe00/9C7lN4va606Rdb+HkxXtXsmEDrIraQ11fGz/WvKWa8gMuCKkrXpTsQ==",
-      "requires": {}
+      "integrity": "sha512-1JGu8oCjVXLa9q9rFTo4MbeeA5FMe00/9C7lN4va606Rdb+HkxXtXsmEDrIraQ11fGz/WvKWa8gMuCKkrXpTsQ=="
     },
     "postcss-place": {
       "version": "10.0.0",
@@ -28571,8 +28549,7 @@
     "postcss-replace-overflow-wrap": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/postcss-replace-overflow-wrap/-/postcss-replace-overflow-wrap-4.0.0.tgz",
-      "integrity": "sha512-KmF7SBPphT4gPPcKZc7aDkweHiKEEO8cla/GjcBK+ckKxiZslIu3C4GCRW3DNfL0o7yW7kMQu9xlZ1kXRXLXtw==",
-      "requires": {}
+      "integrity": "sha512-KmF7SBPphT4gPPcKZc7aDkweHiKEEO8cla/GjcBK+ckKxiZslIu3C4GCRW3DNfL0o7yW7kMQu9xlZ1kXRXLXtw=="
     },
     "postcss-selector-not": {
       "version": "8.0.1",
@@ -28635,8 +28612,7 @@
     "postcss-zindex": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-6.0.2.tgz",
-      "integrity": "sha512-5BxW9l1evPB/4ZIc+2GobEBoKC+h8gPGCMi+jxsYvd2x0mjq7wazk6DrP71pStqxE9Foxh5TVnonbWpFZzXaYg==",
-      "requires": {}
+      "integrity": "sha512-5BxW9l1evPB/4ZIc+2GobEBoKC+h8gPGCMi+jxsYvd2x0mjq7wazk6DrP71pStqxE9Foxh5TVnonbWpFZzXaYg=="
     },
     "pretty-error": {
       "version": "4.0.0",
@@ -28655,8 +28631,7 @@
     "prism-react-renderer": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/prism-react-renderer/-/prism-react-renderer-1.3.5.tgz",
-      "integrity": "sha512-IJ+MSwBWKG+SM3b2SUfdrhC+gu01QkV2KmRQgREThBfSQRoufqRfxfHUxpG1WcaFjP+kojcFyO9Qqtpgt3qLCg==",
-      "requires": {}
+      "integrity": "sha512-IJ+MSwBWKG+SM3b2SUfdrhC+gu01QkV2KmRQgREThBfSQRoufqRfxfHUxpG1WcaFjP+kojcFyO9Qqtpgt3qLCg=="
     },
     "prismjs": {
       "version": "1.29.0",
@@ -28932,8 +28907,7 @@
     "react-json-view-lite": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/react-json-view-lite/-/react-json-view-lite-1.5.0.tgz",
-      "integrity": "sha512-nWqA1E4jKPklL2jvHWs6s+7Na0qNgw9HCP6xehdQJeg6nPBTFZgGwyko9Q0oj+jQWKTTVRS30u0toM5wiuL3iw==",
-      "requires": {}
+      "integrity": "sha512-nWqA1E4jKPklL2jvHWs6s+7Na0qNgw9HCP6xehdQJeg6nPBTFZgGwyko9Q0oj+jQWKTTVRS30u0toM5wiuL3iw=="
     },
     "react-loadable": {
       "version": "npm:@docusaurus/react-loadable@6.0.0",
@@ -29553,12 +29527,6 @@
           }
         }
       }
-    },
-    "search-insights": {
-      "version": "2.17.3",
-      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.17.3.tgz",
-      "integrity": "sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==",
-      "peer": true
     },
     "section-matter": {
       "version": "1.0.0",
@@ -30540,12 +30508,6 @@
         "is-typedarray": "^1.0.0"
       }
     },
-    "typescript": {
-      "version": "5.8.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
-      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
-      "peer": true
-    },
     "ufo": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.5.4.tgz",
@@ -31062,8 +31024,7 @@
         "ws": {
           "version": "8.18.1",
           "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.1.tgz",
-          "integrity": "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==",
-          "requires": {}
+          "integrity": "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w=="
         }
       }
     },
@@ -31226,8 +31187,7 @@
     "ws": {
       "version": "7.5.10",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
-      "requires": {}
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="
     },
     "xdg-basedir": {
       "version": "5.1.0",

--- a/docs/package.json
+++ b/docs/package.json
@@ -15,6 +15,7 @@
     "ci": "npm ci --legacy-peer-deps && npm run build"
   },
   "dependencies": {
+    "@conduction/docusaurus-preset": "^1.5.1",
     "@docusaurus/core": "^3.7.0",
     "@docusaurus/preset-classic": "^3.7.0",
     "@docusaurus/theme-mermaid": "^3.7.0",

--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -1,45 +1,247 @@
+/**
+ * OpenCatalogi landing page.
+ *
+ * Composes the brand <DetailHero> + <WidgetShelf> from
+ * @conduction/docusaurus-preset/components, mirroring the connext page
+ * at sites/www/src/pages/apps/opencatalogi.mdx.
+ *
+ * Written as .js (not .mdx) because the docs site has the docs plugin
+ * pointed at `path: './'`, and an MDX file in src/pages/ trips the
+ * MDX-ESM parser even with the docs plugin's `src/**` exclude.
+ * Authoring the page in JSX keeps the same component composition.
+ */
+
 import React from 'react';
-import clsx from 'clsx';
-import Link from '@docusaurus/Link';
-import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import Layout from '@theme/Layout';
-import HomepageFeatures from '@site/src/components/HomepageFeatures';
+import {
+  DetailHero,
+  WidgetShelf,
+  AppMock,
+} from '@conduction/docusaurus-preset/components';
 
-import styles from './index.module.css';
+const OPENCATALOGI_ICON = (
+  <svg viewBox="0 0 24 24">
+    <path d="M3 7l9-4 9 4-9 4-9-4z" />
+    <path d="M3 12l9 4 9-4M3 17l9 4 9-4" />
+  </svg>
+);
 
-function HomepageHeader() {
-  const {siteConfig} = useDocusaurusContext();
+const TAGLINE = (
+  <>
+    The public-facing software, dataset, and API catalogue. Drops into your{' '}
+    <span className="next-blue">Nextcloud</span>, surfaces every register as a
+    searchable entry, federates to data.overheid.nl out of the box.
+  </>
+);
+
+function RecentPublicationsPanel() {
+  const tones = [
+    'var(--c-blue-cobalt)',
+    'var(--c-forest-500)',
+    'var(--c-lavender-500)',
+    'var(--c-terracotta-500)',
+    'var(--c-mint-500)',
+  ];
   return (
-    <header className={clsx('hero hero--primary', styles.heroBanner)}>
-      <div className="container">
-        <h1 className="hero__title">{siteConfig.title}</h1>
-        <p className="hero__subtitle">{siteConfig.tagline}</p>
-        <div className={styles.buttons}>
-          <Link
-            className="button button--secondary button--lg"
-            to="/docs">
-            Documentation
-          </Link>
-          <Link
-            className="button button--secondary button--lg margin-left--md"
-            to="https://github.com/OpenCatalogi/OpenCatalogiBundle">
-            GitHub
-          </Link>
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+      {tones.map((tone, i) => (
+        <div
+          key={i}
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 8,
+            padding: '4px 0',
+            borderBottom:
+              i < tones.length - 1 ? '1px solid var(--c-cobalt-50)' : 'none',
+          }}
+        >
+          <span
+            style={{
+              width: 14,
+              height: 16,
+              clipPath: 'var(--hex-pointy-top)',
+              background: tone,
+              flexShrink: 0,
+            }}
+          />
+          <div
+            style={{
+              flex: 1,
+              height: 4,
+              background: 'var(--c-cobalt-200)',
+              borderRadius: 1,
+            }}
+          />
+          <span
+            style={{
+              width: 8,
+              height: 9,
+              clipPath: 'var(--hex-pointy-top)',
+              background: i < 3 ? 'var(--c-mint-500)' : 'var(--c-cobalt-200)',
+            }}
+          />
         </div>
-      </div>
-    </header>
+      ))}
+    </div>
   );
 }
 
+function CatalogueStatsPanel() {
+  const kpis = [
+    { n: '3.4k', l: 'records', tone: 'var(--c-cobalt-900)' },
+    { n: '12', l: 'feeders', tone: 'var(--c-mint-500)' },
+    { n: '847', l: 'queries', tone: 'var(--c-orange-knvb)' },
+  ];
+  return (
+    <div
+      style={{
+        display: 'grid',
+        gridTemplateColumns: 'repeat(3, 1fr)',
+        gap: 6,
+      }}
+    >
+      {kpis.map((kpi, i) => (
+        <div
+          key={i}
+          style={{
+            padding: '8px 6px',
+            background: 'var(--c-cobalt-50)',
+            borderRadius: 'var(--radius-sm)',
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 2,
+          }}
+        >
+          <div
+            style={{
+              fontFamily: 'var(--conduction-typography-font-family-code)',
+              fontSize: 18,
+              fontWeight: 700,
+              color: kpi.tone,
+            }}
+          >
+            {kpi.n}
+          </div>
+          <div
+            style={{
+              fontFamily: 'var(--conduction-typography-font-family-code)',
+              fontSize: 9,
+              letterSpacing: '0.06em',
+              textTransform: 'uppercase',
+              color: 'var(--c-cobalt-400)',
+            }}
+          >
+            {kpi.l}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function FederationStatusPanel() {
+  const rows = [
+    { tone: 'var(--c-mint-500)', label: 'data.overheid.nl' },
+    { tone: 'var(--c-mint-500)', label: 'gemeente Tilburg' },
+    { tone: 'var(--c-orange-knvb)', label: 'gemeente Almere' },
+    { tone: 'var(--c-mint-500)', label: 'Forum Standaardisatie' },
+    { tone: 'var(--c-red-vermillion)', label: 'gemeente Hoorn' },
+  ];
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+      {rows.map((row, i) => (
+        <div
+          key={i}
+          style={{ display: 'flex', alignItems: 'center', gap: 8 }}
+        >
+          <span
+            style={{
+              width: 8,
+              height: 9,
+              clipPath: 'var(--hex-pointy-top)',
+              background: row.tone,
+              flexShrink: 0,
+            }}
+          />
+          <div
+            style={{
+              fontFamily: 'var(--conduction-typography-font-family-code)',
+              fontSize: 11,
+              color: 'var(--c-cobalt-700)',
+              flex: 1,
+            }}
+          >
+            {row.label}
+          </div>
+          <div
+            style={{
+              height: 3,
+              width: 26,
+              background: 'var(--c-cobalt-100)',
+              borderRadius: 1,
+            }}
+          />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+const WIDGETS = [
+  {
+    title: 'Recent publications',
+    desc: 'Last items added to the public catalogue. Category hex, title, federation status.',
+    panel: <RecentPublicationsPanel />,
+  },
+  {
+    title: 'Catalogue stats',
+    desc: 'Three KPIs at a glance: total publications, federated downstream, queries this week.',
+    panel: <CatalogueStatsPanel />,
+  },
+  {
+    title: 'Federation status',
+    desc: 'Who is consuming your catalogue, who is publishing back. Mint = healthy, orange = retry, red = down.',
+    panel: <FederationStatusPanel />,
+  },
+];
+
 export default function Home() {
-  const {siteConfig} = useDocusaurusContext();
   return (
     <Layout
-      title={`${siteConfig.title}`}
-      description="Open Source Component Catalog for Common Ground">
-      <HomepageHeader />
-      <main>
-        <HomepageFeatures />
+      title="OpenCatalogi"
+      description="Federated data catalogue for apps, datasets, APIs. Public-facing search at your Nextcloud, federation to data.overheid.nl out of the box."
+    >
+      <main className="marketing-page">
+        <DetailHero
+          appId="opencatalogi"
+          background="cobalt"
+          status={{ label: 'Stable', color: 'var(--c-mint-500)' }}
+          version="v2.4"
+          locales="NL · EN"
+          title="OpenCatalogi"
+          tagline={TAGLINE}
+          primaryCta={{
+            label: 'Install from app store',
+            href: 'https://apps.nextcloud.com/apps/opencatalogi',
+            tone: 'orange',
+          }}
+          secondaryCta={{ label: 'Read the docs', href: '/docs/intro' }}
+          tertiaryCta={{
+            label: 'View on GitHub',
+            href: 'https://github.com/ConductionNL/opencatalogi',
+          }}
+          iconColor="var(--c-orange-knvb)"
+          icon={OPENCATALOGI_ICON}
+          illustration={<AppMock app="opencatalogi" />}
+        />
+
+        <WidgetShelf
+          eyebrow="Widgets we ship"
+          title="On every Nextcloud dashboard."
+          lede="Install OpenCatalogi and the home screen tracks what got published, what was searched, and what other gemeenten are federating from you."
+          widgets={WIDGETS}
+        />
       </main>
     </Layout>
   );

--- a/docs/static/CNAME
+++ b/docs/static/CNAME
@@ -1,1 +1,1 @@
-documentatie.opencatalogi.nl
+opencatalogi.conduction.nl


### PR DESCRIPTION
The live docs site (opencatalogi.conduction.nl) deploys from the `documentation` branch (on @conduction/docusaurus-preset, brand landing). `development` still carried the old preset-classic / documentatie.opencatalogi.nl / stock-template setup. This syncs `development`'s `docs/` + `documentation.yml` to what's live. Build verified locally.