### PR TITLE
spec(opencatalogi): bring all changes under ADR-032 20-task cap (Wave 2)

### DIFF
--- a/openspec/changes/opencatalogi-adopt-or-abstractions/tasks.md
+++ b/openspec/changes/opencatalogi-adopt-or-abstractions/tasks.md
@@ -1,270 +1,150 @@
 # Tasks — opencatalogi-adopt-or-abstractions
 
-> Spec-only change. Each phase below is broken into spec-authoring tasks.
-> Code changes happen in follow-up implementation changes once the spec
-> deltas are archived. Phases are ordered so later phases depend on
-> earlier phases' contracts being agreed.
+> Spec-only change. Each task below authors a slice of
+> `specs/opencatalogi-adopt-or-abstractions/spec.md` (and adjacent specs
+> in `openspec/specs/`). Code changes happen in follow-up implementation
+> changes. Phase order encodes upstream-dependency order — see
+> "Phase order rationale" at the bottom for the why.
 
-## Phase 1: Adopt `RegisterResolverService` across all controllers
+## Phase 1 — Adopt `RegisterResolverService` across all controllers
 
-- [ ] 1.1 Document the five canonical contexts (`publications`,
-      `listings`, `catalogi`, `themes`, `pages`) plus the three already-
-      relying-on-`getValueString` contexts (`glossary`, `menus`,
-      `organisations`) in `specs/opencatalogi-adopt-or-abstractions/spec.md`.
-- [ ] 1.2 Add a requirement that **every** controller in `lib/Controller/`
-      that today calls `IAppConfig::getValueString($appName,
-      '<context>_register' | '<context>_schema', '')` must instead call
-      `RegisterResolverService::resolveRegister($context)` /
-      `resolveSchema($context)` / `resolvePair($context)`.
-- [ ] 1.3 Cross-reference each call site by file and line in the spec
-      (matches `.claude/audit-2026-05-03/04-hardcoded.md`):
-      `PublicationsController.php`, `ListingsController.php:99-159`,
-      `CatalogiController.php:117`, `ThemesController.php:114`,
-      `PagesController.php:126`.
-- [ ] 1.4 Specify that the empty-string fallback (`getValueString(..., '')`)
-      is forbidden going forward — `RegisterResolverService` must throw
-      `RegisterNotConfiguredException` and the controller must surface
-      a `503 Service Unavailable` with operator-actionable detail (which
-      context, which key, where to set it).
-- [ ] 1.5 Specify that the resolver result is request-scoped (no module
-      static caching) so admin re-configuration is picked up on the next
-      request without `apache2ctl graceful`.
-- [ ] 1.6 Cite OpenRegister `register-resolver-service` change as the
-      upstream dependency; capture the minimum `openregister` version
-      (the version that archives `register-resolver-service`) in
-      `appinfo/info.xml` `<dependencies>`.
-- [ ] 1.7 Add a SHALL: opencatalogi MUST NOT re-implement
-      `RegisterResolverService` locally even if OR is below the required
-      version — the app must refuse to load via the dependency check.
+- [ ] 1. Spec the five canonical contexts (`publications`, `listings`,
+      `catalogi`, `themes`, `pages`) + the three legacy `getValueString`
+      contexts (`glossary`, `menus`, `organisations`); require every
+      controller call site (per `.claude/audit-2026-05-03/04-hardcoded.md`)
+      to use `RegisterResolverService::resolve*`; forbid empty-string
+      fallbacks (throw `RegisterNotConfiguredException` → 503 with
+      operator-actionable detail); resolver result is request-scoped (no
+      static caching); cite OR `register-resolver-service` as upstream and
+      pin minimum OR version in `appinfo/info.xml`; opencatalogi MUST NOT
+      re-implement the resolver locally.
 
-## Phase 2: Migrate `src/store/modules/object.js` to `createObjectStore()`
+## Phase 2 — Migrate object store to `createObjectStore()`
 
-- [ ] 2.1 Add a requirement to delete `src/store/modules/object.js`
-      (currently 2 449 lines per audit) and replace with a thin wrapper
-      around `createObjectStore('object', { plugins: [...] })` from
-      `@conduction/nextcloud-vue`.
-- [ ] 2.2 Document the required plugin list: `filesPlugin()`,
-      `auditTrailsPlugin()`, `relationsPlugin()`, `searchPlugin()` —
-      these collectively cover the `relatedData: { logs, files, uses }`
-      shape that the bespoke store hand-rolls today.
-- [ ] 2.3 Forbid custom Pinia modules per the store-pattern guidance
-      in user memory (`feedback_store-pattern.md`): use the Options-API
-      helpers and `createObjectStore`, no bespoke Pinia state for objects.
-- [ ] 2.4 Specify the migration of every consumer component (lists +
-      details + modals): consumer components call store actions through
-      the standard helpers (`useObjectStore('object')`) — no direct
-      access to internal store state.
-- [ ] 2.5 Specify that pagination, filters, and faceted search behaviour
-      MUST remain functionally identical from the user's perspective
-      across the migration. Capture before/after smoke-test list in
-      `design.md`.
-- [ ] 2.6 Document the same migration path for `src/store/modules/search.js`:
-      either consume `searchPlugin()` from nextcloud-vue or extract a
-      shared search store. Decide in `design.md` and reference the
-      decision here.
-- [ ] 2.7 Capture the expected line-count reduction (≈2 250 lines deleted)
-      as a non-functional acceptance criterion so reviewers can spot
-      partial migrations that leave dead code behind.
-- [ ] 2.8 Add a regression-test requirement: the existing object E2E
-      flows (create publication, edit, delete, restore from trash) must
-      continue to pass.
+- [ ] 2. Spec deletion of `src/store/modules/object.js` (≈2 449 lines)
+      and replacement with `createObjectStore('object', { plugins: [
+      filesPlugin, auditTrailsPlugin, relationsPlugin, searchPlugin ] })`
+      from `@conduction/nextcloud-vue`; forbid bespoke Pinia modules per
+      `feedback_store-pattern.md`; consumer components MUST use
+      `useObjectStore('object')`; pagination/filters/faceted-search MUST
+      stay functionally identical (smoke-test list in `design.md`);
+      document the same migration path for `src/store/modules/search.js`;
+      track ≈2 250-line reduction as a non-functional acceptance criterion;
+      object E2E flows MUST continue to pass.
 
-## Phase 3: Rewrite `file-management` spec; consume OR file APIs
+## Phase 3 — Rewrite `file-management`; consume OR file APIs
 
-- [ ] 3.1 Rewrite `openspec/specs/file-management/spec.md` end-to-end —
-      mark the existing requirements as REMOVED and replace with a
-      single requirement: opencatalogi MUST consume OR's File
-      Attachments capability via `x-openregister-file` schema annotations
-      and `IFileService` (or its post-resolver-service equivalent).
-- [ ] 3.2 Specify that `OCP\Share\IShareManager` is the sharing surface;
-      opencatalogi MUST NOT re-implement share creation, share
-      enumeration, or share revocation locally.
-- [ ] 3.3 Specify that `lib/Controller/FilesController.php` becomes a
-      thin wrapper that delegates to OR's file controller; removing
-      bespoke endpoints. Capture each removed endpoint in the spec
-      so the API consumers know the migration path.
-- [ ] 3.4 Cross-reference the upstream OR file capability spec by name
-      and the `register-resolver-service` change for context resolution
-      before file operations.
-- [ ] 3.5 Document the impact on existing public catalogue downloads
-      (Phase 7 picks up `download-service`) so reviewers can see the
-      two-phase ordering is intentional.
+- [ ] 3. Rewrite `openspec/specs/file-management/spec.md`: mark legacy
+      requirements REMOVED; require consumption of OR File Attachments via
+      `x-openregister-file` schema annotations + `IFileService` (or its
+      post-resolver-service equivalent); sharing goes through
+      `OCP\Share\IShareManager` (no local re-implementation);
+      `FilesController.php` becomes a thin delegate (list every removed
+      endpoint + migration path); cite OR file capability +
+      `register-resolver-service`; flag the Phase 7 `download-service`
+      dependency.
 
-## Phase 4: i18n editing UI for translatable content
+## Phase 4 — i18n editing UI for translatable content
 
-- [ ] 4.1 List the five controllers that MUST consume the
-      `TranslationHandler` (or the post-`i18n-source-of-truth` public
-      handler):
-      `PagesController`, `MenusController`, `PublicationsController`,
-      `ThemesController`, `GlossaryController`.
-- [ ] 4.2 Specify that `Accept-Language` and `?_lang=` MUST resolve
-      translatable fields per `i18n-api-language-negotiation` — list the
-      negotiation order (query param > header > user preference >
-      app default).
-- [ ] 4.3 Add schema-marking requirements: every user-facing string
-      property (titles, summaries, body content, navigation labels)
-      MUST set `translatable: true` and the schema MUST declare
-      `sourceLanguage` per ADR-025.
-- [ ] 4.4 Catalogue every schema/property that needs `translatable: true`
-      in a table in `specs/.../spec.md` so the implementation cannot
-      miss a field. Source: `.claude/audit-2026-05-03/research/R3-opencatalogi-i18n-editing.md`.
-- [ ] 4.5 Specify the language-selector UI consumed from
-      `@conduction/nextcloud-vue`. List target screens:
-      `PublicationDetailPage.vue`, `ViewPageModal.vue`,
-      `ViewMenuModal.vue`, `ViewThemeModal.vue`, `ViewGlossaryModal.vue`.
-- [ ] 4.6 Specify the editorial rules (per ADR-025): the source
-      language is required and immutable per object; translations are
-      optional; missing translations fall back to the source per the
-      negotiation rules.
-- [ ] 4.7 Specify the public read path: catalogue routes must resolve
-      the visitor's `Accept-Language` server-side so the SSR/initial-state
-      markup matches the negotiated locale (no client-side flicker).
-- [ ] 4.8 Cite `openregister/openspec/changes/i18n-source-of-truth/`
-      and `openregister/openspec/changes/i18n-api-language-negotiation/`
-      as the upstream dependencies.
-- [ ] 4.9 Note that `Accept-Language` quality factors and
-      RFC 4647 lookup matching are OWNED by the OR upstream spec —
-      this app MUST NOT re-derive the negotiation algorithm.
+- [ ] 4. List the five controllers consuming `TranslationHandler`
+      (`Pages`, `Menus`, `Publications`, `Themes`, `Glossary`); spec
+      `Accept-Language` + `?_lang=` negotiation order (query > header >
+      user pref > app default) per `i18n-api-language-negotiation`;
+      require `translatable: true` + `sourceLanguage` on every
+      user-facing string property per ADR-025 (catalogue in a table in
+      the spec — implementation cannot ship with missing rows); spec the
+      language-selector UI from `@conduction/nextcloud-vue` on the five
+      detail/modal screens; spec server-side `Accept-Language` resolution
+      on public catalogue routes (no client flicker); cite
+      `i18n-source-of-truth` + `i18n-api-language-negotiation` as upstream
+      (negotiation algorithm is OWNED upstream — MUST NOT re-derive).
 
-## Phase 5: Adopt nextcloud-vue multi-tenancy primitives
+## Phase 5 — Adopt nextcloud-vue multi-tenancy primitives
 
-- [ ] 5.1 Specify that `App.vue::setup()` MUST call `useTenantContext()`
-      from `@conduction/nextcloud-vue` once `multi-tenancy-context` is
-      archived; expose the active organisation UUID as a reactive
-      getter (`organisationUuidGetter`).
-- [ ] 5.2 Specify that **every** `createObjectStore()` invocation MUST
-      receive the `organisationUuidGetter` so list queries scope to
-      the active tenant. Audit covers existing stores in
-      `src/store/modules/`.
-- [ ] 5.3 Specify the `<CnTenantBadge>` placement: top bar, left of
-      the user menu, visible on every route.
-- [ ] 5.4 Specify cache-invalidation behaviour: switching tenant must
-      reset all `createObjectStore` instances (`watch(tenantId, () =>
-      store.reset())`); pagination resets to page 1; active filters are
-      cleared (or scoped per tenant — decide in `design.md`).
-- [ ] 5.5 Specify `CnFormDialog` auto-fill: when a schema declares an
-      `organisation` relation, the dialog MUST pre-fill the active
-      tenant's UUID and disable the field unless the user has
-      cross-tenant edit rights.
-- [ ] 5.6 Cite `nextcloud-vue/openspec/changes/multi-tenancy-context/`
-      as the upstream dependency. Cite
+- [ ] 5. Spec `App.vue::setup()` calling `useTenantContext()` once
+      `multi-tenancy-context` archives; every `createObjectStore()` MUST
+      receive `organisationUuidGetter`; `<CnTenantBadge>` lives top-bar
+      left of the user menu on every route; switching tenant MUST reset
+      all stores + pagination + filters (or scope filters per tenant —
+      decide in `design.md`); `CnFormDialog` MUST auto-fill + lock the
+      active tenant on schemas with an `organisation` relation unless
+      the user has cross-tenant edit rights; cite
+      `nextcloud-vue/.../multi-tenancy-context/` +
       `.claude/audit-2026-05-03/research/R2-nc-vue-multitenancy.md`.
 
-## Phase 6: Adopt the app manifest convention (Tier 2-3)
+## Phase 6 — Adopt the app manifest convention (Tier 2-3)
 
-- [ ] 6.1 Specify that opencatalogi MUST ship `src/manifest.json` per
-      ADR-024 and `hydra/openspec/changes/adopt-app-manifest/`.
-- [ ] 6.2 Tier the app as **Tier 2-3**: bespoke catalog landing pages,
-      the publication renderer, and the public CMS view declare
-      `type: "custom"`; all admin CRUD entries declare `type: "list"`
-      / `type: "detail"` and are rendered by the manifest interpreter.
-- [ ] 6.3 Catalogue every existing route in
-      `src/router/index.js` and tag it as `list` / `detail` /
-      `custom` in a table in `specs/.../spec.md`. The implementation
-      cannot ship if a route is missing from the table.
-- [ ] 6.4 Specify `dependencies: ["openregister"]` in the manifest so
-      the registry refuses to load the app when OR is missing or below
-      the minimum version.
-- [ ] 6.5 Specify the deletion of hand-rolled router/sidebar code
-      (`src/router/index.js`, custom `<NcAppNavigation>` blocks)
-      once the manifest interpreter takes over. Capture this as a
-      "MUST NOT exist" requirement so the cleanup isn't forgotten.
-- [ ] 6.6 Specify that `appinfo/routes.php` is the source of truth for
-      backend routes; the manifest references controller names, not
-      paths, so changing a backend route doesn't require a manifest
-      bump.
-- [ ] 6.7 Cite `hydra/openspec/changes/adopt-app-manifest/`,
-      ADR-024, and `.claude/audit-2026-05-03/research/R6-manifest-json.md`
-      (which names opencatalogi as the Tier 2-3 pilot).
+- [ ] 6. Spec `src/manifest.json` per ADR-024 + `adopt-app-manifest`;
+      tier opencatalogi as Tier 2-3 (custom catalog/publication/CMS views
+      = `type: "custom"`, all admin CRUD = `type: "list" | "detail"`);
+      catalogue every `src/router/index.js` route in a table tagged
+      list/detail/custom (implementation cannot ship with missing rows);
+      manifest declares `dependencies: ["openregister"]`; spec the
+      "MUST NOT exist" deletion of hand-rolled router + custom
+      `<NcAppNavigation>` blocks once the interpreter takes over;
+      `appinfo/routes.php` is the backend source of truth (manifest
+      references controller names, not paths); cite
+      `adopt-app-manifest` + ADR-024 + R6-manifest-json audit.
 
-## Phase 7: Spec rewrites for `search`, `admin-settings`, `dashboard`, `download-service`
+## Phase 7 — Spec rewrites: `search`, `admin-settings`, `dashboard`, `download-service`
 
-- [ ] 7.1 **`search`** (P2, MISSING-OR-DEP) — rewrite
-      `openspec/specs/search/spec.md` to cite OR's `zoeken-filteren`
-      capability as the primary surface. Federated/cross-catalog search
-      becomes a thin orchestrator that fans out to multiple
-      `zoeken-filteren` calls and merges results — opencatalogi MUST NOT
-      re-implement query parsing, faceting, or ranking.
-- [ ] 7.2 **`admin-settings`** (P2, NEEDS-REWRITE) — rewrite
-      `openspec/specs/admin-settings/spec.md` to cite OR's `IAppConfig`
-      conventions: key naming, validation, secret handling, default
-      values. Remove the duplicated patterns this spec re-derives.
-- [ ] 7.3 **`dashboard`** (P2) — confirm and add the citation to OR's
-      aggregations annotation. Remove hand-rolled aggregation prose
-      and reference the OR capability by name.
-- [ ] 7.4 **`download-service`** (P2, NEEDS-REWRITE) — rewrite to
-      consume OR's File Attachments + versioning capability for ZIP
-      generation. The download service becomes a streaming wrapper
-      that pipes OR file streams into a ZIP — no local file CRUD,
-      no bespoke versioning logic.
-- [ ] 7.5 In each rewrite, mark the original requirements as REMOVED
-      with a brief rationale ("re-implements OR's <capability>; consume
-      OR instead per ADR-022").
-- [ ] 7.6 Cite `.claude/audit-2026-05-03/02-spec-rewrite.md` as the
-      audit basis for each rewrite.
+- [ ] 7. Rewrite the four specs per `.claude/audit-2026-05-03/02-spec-rewrite.md`:
+      `search` cites OR `zoeken-filteren` (federated = thin
+      orchestrator, no local query parsing/faceting/ranking);
+      `admin-settings` cites OR `IAppConfig` conventions (key naming,
+      validation, secrets, defaults — remove duplicated patterns);
+      `dashboard` cites OR aggregations annotation; `download-service`
+      becomes a streaming wrapper over OR File Attachments + versioning
+      (no local file CRUD, no bespoke versioning). In each rewrite, mark
+      replaced requirements REMOVED with rationale ("re-implements OR's
+      <capability>; consume OR per ADR-022").
 
-## Phase 8: Hardcoded magic-number cleanup
+## Phase 8 — Hardcoded magic-number cleanup
 
-- [ ] 8.1 `lib/Service/BroadcastService.php:68,75` — promote
-      `MAX_RETRIES = 3` and `REQUEST_TIMEOUT = 30` to admin-config keys
-      (`broadcast_max_retries`, `broadcast_request_timeout`). Specify
-      defaults equal to the current values so behaviour is unchanged.
-- [ ] 8.2 `lib/Service/SitemapService.php:40` — promote
-      `MAX_PER_PAGE = 1000` to admin-config (`sitemap_max_per_page`).
-- [ ] 8.3 `lib/Service/SettingsService.php:64` — **delete**
-      `MIN_OPENREGISTER_VERSION = '0.1.7'`. Specify that
-      `appinfo/info.xml` `<dependencies>` is the only source of truth
-      for the minimum OR version; Nextcloud's app dependency check
-      enforces it at install time.
-- [ ] 8.4 `openspec/specs/auto-publishing/spec.md` — rewrite the
-      publication state-transition section to consume
-      `x-openregister-lifecycle` from the schema rather than encoding
-      the state machine in PHP.
-- [ ] 8.5 `openspec/specs/federation/spec.md` — rewrite per-app
-      retry/backoff to consume OR's outbound webhook policy.
-      opencatalogi MUST NOT re-derive retry maths.
-- [ ] 8.6 Specify that any new admin-config keys appear in the
-      `admin-settings` spec table from Phase 7.2 (single inventory).
-- [ ] 8.7 Cite `.claude/audit-2026-05-03/04-hardcoded.md` as the audit
-      basis.
-
-## Phase order rationale
-
-- Phase 1 lands first because Phase 2's `createObjectStore` invocations
-  call controllers that must already use `RegisterResolverService` —
-  otherwise the store sees inconsistent error shapes.
-- Phase 2 lands before Phase 3 because file-attachment migration is
-  cleaner once the store is the canonical object surface.
-- Phase 3 lands before Phase 7 because `download-service` (Phase 7.4)
-  builds on top of the file APIs adopted in Phase 3.
-- Phase 4 (i18n editing) is independent of 1-3 but lands before 5
-  because the language-picker UI must coexist with the tenant badge
-  in the top bar and we want one design pass on the bar layout.
-- Phase 5 lands before Phase 6 because the manifest interpreter must
-  understand `organisationUuidGetter` to generate Tier 2 list views
-  correctly.
-- Phase 6 lands before Phase 7 because spec rewrites can reference
-  manifest-tier semantics ("custom view" vs "list view").
-- Phase 8 lands last — it is independent and has the lowest blast
-  radius. Bundling it earlier risks scope creep on the higher-impact
-  phases.
+- [ ] 8. Promote `BroadcastService::MAX_RETRIES = 3` +
+      `REQUEST_TIMEOUT = 30` to `broadcast_max_retries` /
+      `broadcast_request_timeout` (defaults unchanged); promote
+      `SitemapService::MAX_PER_PAGE = 1000` to `sitemap_max_per_page`;
+      DELETE `SettingsService::MIN_OPENREGISTER_VERSION` —
+      `appinfo/info.xml` `<dependencies>` is the sole source of truth;
+      rewrite `auto-publishing` spec to consume `x-openregister-lifecycle`
+      (no PHP state machine); rewrite `federation` spec to consume OR's
+      outbound webhook retry policy (no re-derived backoff maths); all
+      new admin-config keys appear in the Phase 7 `admin-settings`
+      inventory table. Cite `.claude/audit-2026-05-03/04-hardcoded.md`.
 
 ## Cross-cutting acceptance criteria
 
-- [ ] X.1 Every requirement in `specs/opencatalogi-adopt-or-abstractions/spec.md`
-      is traceable back to either an audit file
-      (`.claude/audit-2026-05-03/*.md`) or an upstream openspec change
-      slug. No floating requirements.
-- [ ] X.2 No phase ships before its upstream dependency is archived.
-      Capture the dependency graph in `design.md`.
-- [ ] X.3 The `breaking-changes` section of each affected spec lists
-      the API surface that becomes a hard error (e.g., empty-string
-      fallback in `getValueString` returning a misconfigured register
-      now throws 503).
-- [ ] X.4 The line-count reduction targets in `proposal.md` (≈2 250
-      lines for Phase 2) are tracked as KPIs in the implementation
-      change, not in this spec change.
-- [ ] X.5 Each affected spec under `openspec/specs/` is updated in
-      lockstep with its phase landing — partial updates (e.g.,
-      `admin-settings` rewritten but `download-service` still bespoke)
-      are explicitly forbidden by the cross-cutting validation.
+- [ ] X.1 Every requirement in
+      `specs/opencatalogi-adopt-or-abstractions/spec.md` traces back to an
+      audit file or an upstream openspec change slug — no floating
+      requirements. Dependency graph captured in `design.md`; no phase
+      ships before its upstream change is archived.
+- [ ] X.2 The `breaking-changes` section of each affected spec lists the
+      API surface that becomes a hard error (e.g., empty-string
+      `getValueString` fallback for a misconfigured register now throws
+      503). Line-count reduction targets (≈2 250 lines for Phase 2) live
+      as KPIs in the implementation change, not in this spec change.
+- [ ] X.3 Each affected spec under `openspec/specs/` updates in lockstep
+      with its phase landing — partial updates (e.g., `admin-settings`
+      rewritten but `download-service` still bespoke) are explicitly
+      forbidden by cross-cutting validation.
+
+## Phase order rationale
+
+- Phase 1 first: Phase 2's `createObjectStore` calls hit controllers that
+  must already use `RegisterResolverService` — otherwise the store sees
+  inconsistent error shapes.
+- Phase 2 before Phase 3: file-attachment migration is cleaner once the
+  store is the canonical object surface.
+- Phase 3 before Phase 7: `download-service` (Phase 7) builds on the file
+  APIs adopted in Phase 3.
+- Phase 4 independent of 1-3 but before Phase 5: the language picker must
+  coexist with the tenant badge in the top bar; one design pass on the
+  bar layout.
+- Phase 5 before Phase 6: the manifest interpreter must understand
+  `organisationUuidGetter` to generate Tier 2 list views correctly.
+- Phase 6 before Phase 7: spec rewrites can reference manifest-tier
+  semantics ("custom view" vs "list view").
+- Phase 8 last: independent, lowest blast radius; bundling earlier risks
+  scope creep on higher-impact phases.

--- a/openspec/changes/opencatalogi-legacy-quality-cleanup/tasks.md
+++ b/openspec/changes/opencatalogi-legacy-quality-cleanup/tasks.md
@@ -2,75 +2,65 @@
 
 ## Phase 1 — Inventory + planning
 
-- [ ] Run `composer phpcs` and capture current baseline error count
-      (target: starting from 8 exclude-patterns in phpcs.xml)
-- [ ] Run `composer phpmd` for the first time as a unified gate
-      and capture violation count + categories
-- [ ] Run `composer phpstan` for the first time as a unified gate
-      and capture error count + categories
-- [ ] Decide per gate: fix-outright (if <50 violations) or capture
-      a fresh baseline (if larger)
-- [ ] Confirm CI runs `composer check:strict` on every PR before
-      starting burn-down work
+- [ ] 1. Capture baselines for all three gates: run `composer phpcs`
+      (start: 8 exclude-patterns in `phpcs.xml`), `composer phpmd`
+      (first-time unified-gate run — capture violation count +
+      categories), and `composer phpstan` (first-time unified-gate run —
+      capture error count + categories). Per-gate decision rule:
+      fix-outright if <50 violations, otherwise capture a fresh baseline.
+- [ ] 2. Confirm CI runs `composer check:strict` on every PR before any
+      burn-down work begins.
 
 ## Phase 2 — PHPCS burn-down (per excluded file)
 
-For each file: fix errors, remove the phpcs.xml `<exclude-pattern>`
-entry, verify gate stays green.
+Recipe: fix sniffs, remove the `phpcs.xml` `<exclude-pattern>`, verify
+gate stays green.
 
-- [ ] Excluded file 1 — fix sniffs + drop exclude
-- [ ] Excluded file 2 — fix sniffs + drop exclude
-- [ ] Excluded file 3 — fix sniffs + drop exclude
-- [ ] Excluded file 4 — fix sniffs + drop exclude
-- [ ] Excluded file 5 — fix sniffs + drop exclude
-- [ ] Excluded file 6 — fix sniffs + drop exclude
-- [ ] Excluded file 7 — fix sniffs + drop exclude
-- [ ] Excluded file 8 — fix sniffs + drop exclude
-- [ ] Once all excludes are gone, drop the legacy-debt block from
-      phpcs.xml entirely
+- [ ] 3. Excluded files 1–4 — fix sniffs + drop excludes.
+- [ ] 4. Excluded files 5–8 — fix sniffs + drop excludes.
+- [ ] 5. Once all excludes are gone, drop the legacy-debt block from
+      `phpcs.xml` entirely.
 
 ## Phase 3 — PHPMD burn-down
 
-Contingent on Phase 1's first-run output. If a baseline was captured,
-work the categories in roughly volume-descending order.
+Contingent on Phase 1 output. If a baseline was captured, work categories
+in roughly volume-descending order.
 
-- [ ] ElseExpression — re-shape `if/else` chains to early-return
-- [ ] CyclomaticComplexity — extract methods to flatten branches
-- [ ] NPathComplexity — split branches into named helpers
-- [ ] MissingImport — add `use` statements; remove inline FQCNs
-- [ ] ExcessiveMethodLength — extract helpers
-- [ ] StaticAccess — replace static calls with DI services
-- [ ] LongVariable / ShortVariable — rename to 4-20 chars
-- [ ] UndefinedVariable / UnusedFormalParameter — fix or document
-      with `@SuppressWarnings`
-- [ ] Once baseline reaches 0 lines: delete phpmd.baseline.xml and
-      drop `--baseline-file` from composer.json's phpmd script
+- [ ] 6. Flatten branching: `ElseExpression` → early-return;
+      `CyclomaticComplexity` + `NPathComplexity` → extract named
+      helpers; `ExcessiveMethodLength` → extract helpers.
+- [ ] 7. Style + DI fixes: `MissingImport` → add `use` statements (drop
+      inline FQCNs); `StaticAccess` → replace with DI services;
+      `LongVariable` / `ShortVariable` → rename to 4-20 chars;
+      `UndefinedVariable` / `UnusedFormalParameter` → fix or annotate
+      with `@SuppressWarnings`.
+- [ ] 8. Once the baseline reaches 0 lines, delete `phpmd.baseline.xml`
+      and drop `--baseline-file` from composer.json's phpmd script.
 
 ## Phase 4 — PHPStan burn-down
 
-Contingent on Phase 1's first-run output. If a baseline was captured,
-work per-cluster.
+Contingent on Phase 1 output. If a baseline was captured, work per
+cluster.
 
-- [ ] Inventory phpstan-baseline.neon by error type and file
-- [ ] Per-cluster common patterns to fix:
-  - [ ] Missing return-type / param-type declarations
-  - [ ] Mixed types (specify generic / union)
-  - [ ] Possibly-null dereferences (add null guards)
-- [ ] Once baseline reaches 0 lines: delete phpstan-baseline.neon
+- [ ] 9. Inventory `phpstan-baseline.neon` by error type + file; fix
+      the common-pattern clusters: missing return-type / param-type
+      declarations, mixed types (specify generic / union),
+      possibly-null dereferences (add null guards).
+- [ ] 10. Once the baseline reaches 0 lines, delete
+      `phpstan-baseline.neon`.
 
 ## Phase 5 — CI integration
 
-- [ ] Verify `composer check:strict` runs in CI on every PR
-- [ ] Once all baselines are empty:
-  - [ ] Delete `phpmd.baseline.xml` (if it was created)
-  - [ ] Delete `phpstan-baseline.neon` (if it was created)
-  - [ ] Drop the legacy-debt section from `phpcs.xml`
-- [ ] Add a smoke-test cron that runs `composer check:strict`
-      weekly on `development`
+- [ ] 11. Verify `composer check:strict` runs in CI on every PR; once
+      all baselines are empty, delete `phpmd.baseline.xml` +
+      `phpstan-baseline.neon` (if they were created) and drop the
+      legacy-debt section from `phpcs.xml`.
+- [ ] 12. Add a smoke-test cron that runs `composer check:strict`
+      weekly on `development`.
 
 ## Phase 6 — Documentation
 
-- [ ] Update README quality-gates section
-- [ ] Note in `app-config.json` that legacy quality cleanup is done
-- [ ] Close the burn-down tracking issue once the last baseline
-      line is removed
+- [ ] 13. Update the README quality-gates section and note in
+      `app-config.json` that legacy quality cleanup is done.
+- [ ] 14. Close the burn-down tracking issue once the last baseline
+      line is removed.


### PR DESCRIPTION
Wave 2 fleet rollout of the ADR-032 spec-sizing fix. Brings opencatalogi's oversized openspec changes under Hydra's 20-task cap (mix of multi-spec splits + single-spec task-trims). Part of an 8-app fleet sweep following shillinq's #91/#94 precedent. All semantic content preserved.