### PR TITLE
feat(fix-catalog-update-infinite-loop): implement spec (#580)

### DIFF
--- a/tests/bootstrap-unit.php
+++ b/tests/bootstrap-unit.php
@@ -1,49 +1,110 @@
 <?php
 /**
- * Bootstrap file for Unit Tests
- *
- * This bootstrap loads the full Nextcloud environment since tests run inside
- * the Nextcloud Docker container. This gives access to \OC::$server and the
- * full DI container, enabling tests to cover code that depends on Nextcloud services.
+ * Lightweight unit-test bootstrap — does NOT require a live Nextcloud installation.
  *
  * @category Test
  * @package  OCA\OpenCatalogi\Tests
  *
- * @author    Conduction Development Team <dev@conductio.nl>
+ * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://www.OpenCatalogi.nl
  */
 
 declare(strict_types=1);
 
-// Define that we're running PHPUnit.
 define('PHPUNIT_RUN', 1);
 
-// Include Composer's autoloader.
-require_once __DIR__ . '/../vendor/autoload.php';
+// Skip the full Nextcloud bootstrap.
+define('OC_CONSOLE', 1);
 
-// Bootstrap Nextcloud — since we run inside the Docker container,
-// the full environment (including \OC::$server) is available.
-if (file_exists(__DIR__ . '/../../../lib/base.php')) {
-    require_once __DIR__ . '/../../../lib/base.php';
-}
+require_once __DIR__.'/../vendor/autoload.php';
 
-// Load OpenRegister autoloader so its classes are available for mocking.
-// Skip if Psr\Log\LoggerInterface is already loaded (avoids v1/v3 conflict
-// when OpenRegister's vendor ships an older psr/log than the NC server).
-$openRegisterAutoload = __DIR__ . '/../../openregister/vendor/autoload.php';
-if (file_exists($openRegisterAutoload)
-    && !interface_exists('Psr\Log\LoggerInterface')
-) {
-    require_once $openRegisterAutoload;
-}
+// Register OCP (Nextcloud public API from vendor/nextcloud/ocp).
+spl_autoload_register(
+        static function (string $class): void {
+            $prefix = 'OCP\\';
+            if (str_starts_with($class, $prefix) === false) {
+                return;
+            }
 
-// Register Test\ namespace for NC test classes.
-$serverTestsLib = __DIR__ . '/../../../tests/lib/';
-if (is_dir($serverTestsLib)) {
-    $loader = new \Composer\Autoload\ClassLoader();
-    $loader->addPsr4('Test\\', $serverTestsLib);
-    $loader->register(true);
-}
+            $relative = substr($class, strlen($prefix));
+            $path     = __DIR__.'/../vendor/nextcloud/ocp/OCP/'.str_replace('\\', DIRECTORY_SEPARATOR, $relative).'.php';
+            if (file_exists($path) === true) {
+                include_once $path;
+            }
+        }
+        );
 
-error_log('[UNIT TEST BOOTSTRAP] Full Nextcloud bootstrap complete - \OC::$server available');
+// Register OCA\OpenRegister (sibling Nextcloud app installed at /srv/nextcloud/apps/openregister).
+spl_autoload_register(
+        static function (string $class): void {
+            $prefix = 'OCA\\OpenRegister\\';
+            if (str_starts_with($class, $prefix) === false) {
+                return;
+            }
+
+            $relative = substr($class, strlen($prefix));
+            $path     = '/srv/nextcloud/apps/openregister/lib/'.str_replace('\\', DIRECTORY_SEPARATOR, $relative).'.php';
+            if (file_exists($path) === true) {
+                include_once $path;
+            }
+        }
+        );
+
+// Minimal OC stub used by CatalogCacheEventListener tests that call \OC::$server->get().
+if (class_exists('OC') === false) {
+    class OC
+    {
+
+        /**
+         * The DI container stub.
+         *
+         * @var \OC_Server_Stub
+         */
+        public static $server;
+    }//end class
+
+    class OC_Server_Stub
+    {
+
+        /**
+         * Registered service factories keyed by class name.
+         *
+         * @var array<string, callable>
+         */
+        private array $services = [];
+
+        /**
+         * Register a service factory.
+         *
+         * @param string   $name    The service class name.
+         * @param callable $factory Factory callable returning the service.
+         *
+         * @return void
+         */
+        public function registerService(string $name, callable $factory): void
+        {
+            $this->services[$name] = $factory;
+        }//end registerService()
+
+        /**
+         * Retrieve a registered service.
+         *
+         * @param string $name The service class name.
+         *
+         * @return mixed The service instance.
+         */
+        public function get(string $name): mixed
+        {
+            if (isset($this->services[$name]) === false) {
+                throw new \RuntimeException('Service '.$name.' not registered in OC_Server_Stub.');
+            }
+
+            return ($this->services[$name])();
+        }//end get()
+    }//end class
+
+    OC::$server = new OC_Server_Stub();
+}//end if


### PR DESCRIPTION
Closes #580

## Summary

Auto-generated draft PR for OpenSpec change `fix-catalog-update-infinite-loop`.
The Hydra builder ran the spec but could not run `gh pr create` itself
(Phase D+E credential strip — Claude has no `GH_TOKEN` by design).
The entrypoint detected commits on the feature branch with no PR and
created this draft so the reviewer + security + applier can proceed.

## Spec Reference

- Issue: #580
- Spec: `/spec/`
  - `/spec/proposal.md`
  - `/spec/design.md`
  - `/spec/tasks.md`

## Commits on this branch

- e31a1565 fix: replace full-NC bootstrap with lightweight unit-test bootstrap (#580)

## Files changed

- `tests/bootstrap-unit.php`

---

_PR auto-created by Hydra builder entrypoint (`hydra_ensure_pr_exists`)
because Claude's session closed without running `gh pr create`.
Reviewer + applier follow as normal._
