### PR TITLE
fix(docs): descriptive homepage title (#80)

### DIFF
--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -209,7 +209,7 @@ const WIDGETS = [
 export default function Home() {
   return (
     <Layout
-      title="OpenCatalogi"
+      title="OpenCatalogi, open-source component catalog for Nextcloud"
       description="Federated data catalogue for apps, datasets, APIs. Public-facing search at your Nextcloud, federation to data.overheid.nl out of the box."
     >
       <main className="marketing-page">


### PR DESCRIPTION
Part of the SEO epic (ConductionNL/.github#75) and closes ConductionNL/.github#80.

Replaces the bare-brand Layout title with a descriptive form so SERPs surface the keyword payload before the site-title suffix Docusaurus appends. No copy or component changes beyond the title prop.