### PR TITLE
sync: development → documentation (meta descriptions #81)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 1
 title: Open Catalogi Documentation
-description: Comprehensive documentation for Open Catalogi - an open source solution for creating, managing, and sharing catalogs of government software, services, and data
+description: Get started with OpenCatalogi, the open-source component catalog for Nextcloud. Publish, federate, and search software registers across organisations.
 ---
 
 # Open Catalogi

--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -210,7 +210,7 @@ export default function Home() {
   return (
     <Layout
       title="OpenCatalogi, open-source component catalog for Nextcloud"
-      description="Federated data catalogue for apps, datasets, APIs. Public-facing search at your Nextcloud, federation to data.overheid.nl out of the box."
+      description="Public software catalog for Nextcloud. Federated component register with schema validation, REST and GraphQL APIs, and Common Ground alignment."
     >
       <main className="marketing-page">
         <DetailHero


### PR DESCRIPTION
Sync development → documentation so the meta-description deploy fires.