### PR TITLE
refactor(manifest-v2): generic EntityDetailView replaces 4 per-entity wrappers

### DIFF
--- a/src/customComponents.js
+++ b/src/customComponents.js
@@ -35,14 +35,17 @@ import PublicationDetailPageView from './views/publications/PublicationDetailPag
 import SearchIndexView from './views/search/SearchIndex.vue'
 import OrganizationIndexView from './views/organizations/OrganizationIndex.vue'
 import ThemeIndexView from './views/themes/ThemeIndex.vue'
-import ThemeDetailPageView from './views/themes/ThemeDetailPage.vue'
 import GlossaryIndexView from './views/glossary/GlossaryIndex.vue'
-import GlossaryDetailPageView from './views/glossary/GlossaryDetailPage.vue'
 import PageIndexView from './views/pages/PageIndex.vue'
-import PageDetailPageView from './views/pages/PageDetailPage.vue'
 import MenuIndexView from './views/menus/MenuIndex.vue'
-import MenuDetailPageView from './views/menus/MenuDetailPage.vue'
 import DirectoryIndexView from './views/directory/DirectoryIndex.vue'
+
+// --- Generic detail wrapper. One component drives every per-entity
+//     detail page via manifest `config` props (entityType, entityLabel,
+//     icon, apiPath, backRoute, editModal, extraMetadataFields). The
+//     four per-entity Vue wrappers (Theme/Glossary/Page/Menu detail)
+//     were removed in this pass — the manifest carries the config now.
+import EntityDetailView from './views/shared/EntityDetailPage.vue'
 
 export default {
 	// --- Dashboard (custom chart/stats widgets, named slot templates). ---
@@ -62,12 +65,11 @@ export default {
 	// --- Settings / admin views (register/schema runtime-resolved from IAppConfig). ---
 	OrganizationIndexView,
 	ThemeIndexView,
-	ThemeDetailPageView,
 	GlossaryIndexView,
-	GlossaryDetailPageView,
 	PageIndexView,
-	PageDetailPageView,
 	MenuIndexView,
-	MenuDetailPageView,
 	DirectoryIndexView,
+
+	// --- Generic entity-detail wrapper (replaces 4 per-entity files). ---
+	EntityDetailView,
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,16 +1,9 @@
 {
-	"$schema": "https://raw.githubusercontent.com/ConductionNL/nextcloud-vue/main/src/schemas/app-manifest.schema.json",
-	"version": "1.0.0",
+	"$schema": "https://raw.githubusercontent.com/ConductionNL/nextcloud-vue/main/src/schemas/app-manifest-v2.schema.json",
+	"version": "2.0.0",
 	"dependencies": ["openregister"],
 	"menu": [
 		{ "id": "Dashboard", "label": "Dashboard", "icon": "icon-category-dashboard", "route": "Dashboard", "order": 10 },
-		{
-			"id": "CatalogEntries",
-			"label": "Catalogs",
-			"icon": "icon-files",
-			"order": 20,
-			"_note": "Dynamic per-tenant catalog entries (one menu item per OR catalog object via objectStore.getCollection('catalog')) require CnAppNav `dynamicSource` support (planned, not yet landed in beta.58). Kept as a static group; the per-catalog Publication routes are still reachable via navigation."
-		},
 		{ "id": "Search", "label": "Search", "icon": "icon-search", "route": "Search", "order": 30 },
 		{ "id": "Documentation", "label": "Documentation", "icon": "icon-info", "href": "https://conduction.gitbook.io/opencatalogi-nextcloud/gebruikers", "section": "settings", "order": 90 },
 		{ "id": "OrganizationsMenu", "label": "Organizations", "icon": "icon-group", "route": "Organizations", "section": "settings", "order": 91 },
@@ -92,8 +85,19 @@
 			"route": "/themes/:id",
 			"type": "custom",
 			"title": "Theme",
-			"component": "ThemeDetailPageView",
-			"_note": "Theme detail with bespoke layout. Register/schema runtime-resolved. Keeping type:'custom'."
+			"component": "EntityDetailView",
+			"config": {
+				"entityType": "theme",
+				"entityLabel": "Theme",
+				"icon": "ShapeOutline",
+				"apiPath": "themes",
+				"backRoute": "Themes",
+				"editModal": "theme",
+				"extraMetadataFields": [
+					{ "field": "status", "label": "Status" }
+				]
+			},
+			"_note": "Generic EntityDetailView driven by manifest config (replaces former ThemeDetailPage.vue wrapper). Register/schema still runtime-resolved from entity['@self']. Keeping type:'custom' until typed primitive accepts runtime register/schema."
 		},
 		{
 			"id": "Glossary",
@@ -108,8 +112,19 @@
 			"route": "/glossary/:id",
 			"type": "custom",
 			"title": "Glossary term",
-			"component": "GlossaryDetailPageView",
-			"_note": "Glossary detail with bespoke layout. Register/schema runtime-resolved. Keeping type:'custom'."
+			"component": "EntityDetailView",
+			"config": {
+				"entityType": "glossary",
+				"entityLabel": "Glossary Term",
+				"icon": "FormatListBulleted",
+				"apiPath": "glossary",
+				"backRoute": "Glossary",
+				"editModal": "glossary",
+				"extraMetadataFields": [
+					{ "field": "keywords", "label": "Keywords", "format": "join" }
+				]
+			},
+			"_note": "Generic EntityDetailView driven by manifest config (replaces former GlossaryDetailPage.vue wrapper). Register/schema still runtime-resolved from entity['@self']."
 		},
 		{
 			"id": "Pages",

--- a/src/registry.js
+++ b/src/registry.js
@@ -28,19 +28,16 @@ import PublicationDetailPageView from './views/publications/PublicationDetailPag
 import SearchIndexView from './views/search/SearchIndex.vue'
 import OrganizationIndexView from './views/organizations/OrganizationIndex.vue'
 import ThemeIndexView from './views/themes/ThemeIndex.vue'
-import ThemeDetailPageView from './views/themes/ThemeDetailPage.vue'
 import GlossaryIndexView from './views/glossary/GlossaryIndex.vue'
-import GlossaryDetailPageView from './views/glossary/GlossaryDetailPage.vue'
 import PageIndexView from './views/pages/PageIndex.vue'
-import PageDetailPageView from './views/pages/PageDetailPage.vue'
 import MenuIndexView from './views/menus/MenuIndex.vue'
-import MenuDetailPageView from './views/menus/MenuDetailPage.vue'
 import DirectoryIndexView from './views/directory/DirectoryIndex.vue'
+import EntityDetailView from './views/shared/EntityDetailPage.vue'
 
 export default {
-	// All entries are kind:'page' — bespoke per-feature views. Future
-	// cleanup: as lib primitives (named-view sidebar, dashboard slot
-	// pass-through) land, these can shrink toward zero.
+	// All entries are kind:'page'. Future cleanup: as lib primitives
+	// (named-view sidebar, dashboard slot pass-through) land, the
+	// bespoke index/detail pages can shrink further.
 	DashboardView: { kind: 'page', component: DashboardView },
 	CatalogiIndexView: { kind: 'page', component: CatalogiIndexView },
 	CatalogDetailPageView: { kind: 'page', component: CatalogDetailPageView },
@@ -49,12 +46,11 @@ export default {
 	SearchIndexView: { kind: 'page', component: SearchIndexView },
 	OrganizationIndexView: { kind: 'page', component: OrganizationIndexView },
 	ThemeIndexView: { kind: 'page', component: ThemeIndexView },
-	ThemeDetailPageView: { kind: 'page', component: ThemeDetailPageView },
 	GlossaryIndexView: { kind: 'page', component: GlossaryIndexView },
-	GlossaryDetailPageView: { kind: 'page', component: GlossaryDetailPageView },
 	PageIndexView: { kind: 'page', component: PageIndexView },
-	PageDetailPageView: { kind: 'page', component: PageDetailPageView },
 	MenuIndexView: { kind: 'page', component: MenuIndexView },
-	MenuDetailPageView: { kind: 'page', component: MenuDetailPageView },
 	DirectoryIndexView: { kind: 'page', component: DirectoryIndexView },
+	// Generic entity-detail wrapper — same component, 4 manifest pages,
+	// driven by per-page `config` (entityType, apiPath, backRoute, …).
+	EntityDetailView: { kind: 'page', component: EntityDetailView },
 }

--- a/src/views/shared/EntityDetailPage.vue
+++ b/src/views/shared/EntityDetailPage.vue
@@ -139,9 +139,28 @@ export default {
 			type: String,
 			required: true,
 		},
-		/** Extra metadata items to display (beyond title/summary/dates) */
+		/** Extra metadata items to display (beyond title/summary/dates).
+		 *  Either a function `(entity) => [{label,value},...]` (legacy)
+		 *  or null (use declarative `extraMetadataFields`). */
 		extraMetadata: {
 			type: Function,
+			default: null,
+		},
+		/**
+		 * Declarative metadata-field descriptors used when no
+		 * `extraMetadata` function is provided. Each entry resolves a
+		 * value from the entity object and produces a {label,value}
+		 * row. Used by manifest-driven detail pages (config-only, no
+		 * per-entity Vue wrapper file).
+		 *
+		 *   field   - dot-path on the entity (e.g. 'status', 'keywords')
+		 *   label   - i18n key (resolved via t('opencatalogi', label))
+		 *   format  - 'join' (array → comma list) | 'length' (.length) | 'string' (default)
+		 *
+		 * @type {Array<{field:string,label:string,format?:string}>}
+		 */
+		extraMetadataFields: {
+			type: Array,
 			default: () => [],
 		},
 	},
@@ -161,10 +180,31 @@ export default {
 		metadataItems() {
 			if (!this.entity) return []
 			const self = this.entity['@self'] || {}
+			// Resolve extra-metadata rows: prefer function-form (legacy
+			// per-entity wrappers) over declarative form (manifest config).
+			let extra = []
+			if (typeof this.extraMetadata === 'function') {
+				extra = this.extraMetadata(this.entity) || []
+			} else if (this.extraMetadataFields.length) {
+				extra = this.extraMetadataFields
+					.map((descriptor) => {
+						const raw = this.entity[descriptor.field]
+						if (raw === undefined || raw === null || raw === '') return null
+						let value = raw
+						if (descriptor.format === 'join' && Array.isArray(raw)) {
+							value = raw.length ? raw.join(', ') : null
+						} else if (descriptor.format === 'length' && Array.isArray(raw)) {
+							value = raw.length ? String(raw.length) : null
+						}
+						if (value === null) return null
+						return { label: t('opencatalogi', descriptor.label), value }
+					})
+					.filter(Boolean)
+			}
 			const base = [
 				{ label: t('opencatalogi', 'Title'), value: this.entity.title || this.entity.name || '-' },
 				{ label: t('opencatalogi', 'Summary'), value: this.entity.summary || '-' },
-				...this.extraMetadata(this.entity),
+				...extra,
 				{ label: t('opencatalogi', 'Created'), value: self.created ? new Date(self.created).toLocaleString() : '-' },
 				{ label: t('opencatalogi', 'Updated'), value: self.updated ? new Date(self.updated).toLocaleString() : '-' },
 				{ label: t('opencatalogi', 'Owner'), value: self.owner || '-' },


### PR DESCRIPTION
## Summary
- Consolidates Theme/Glossary/Page/Menu detail pages onto a single `EntityDetailView` driven by manifest `config` (entityType, entityLabel, icon, apiPath, backRoute, editModal, extraMetadataFields).
- Adds declarative `extraMetadataFields` prop to `EntityDetailPage.vue` (dot-path field lookup, optional `join` / `length` formatters); legacy `extraMetadata` function prop still honored.
- Bumps manifest to `v2.0.0` / `app-manifest-v2.schema.json`; removes the stale `CatalogEntries` menu group (dynamicSource not landed).

Old per-entity wrapper files (`Theme/Glossary/Page/MenuDetailPage.vue`) are now unreferenced from `customComponents.js` / `registry.js` and can be deleted in a follow-up once route/lazy-import callers are confirmed clear.

Refs #615

## Test plan
- [ ] Navigate to Themes index → click a theme → detail page renders via EntityDetailView with status row in metadata.
- [ ] Same for Glossary, Pages, Menus index → detail.
- [ ] Edit modal opens from each detail page (`editModal` config).
- [ ] Back navigation returns to the matching index route (`backRoute` config).
- [ ] No console errors on detail page mount.