### PR TITLE
feat(manifest-v2): customs-to-zero — T0 → T4 (schema v1→v2 + 16 customs eliminated)

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,9 +1,17 @@
 {
-	"$schema": "https://raw.githubusercontent.com/ConductionNL/nextcloud-vue/main/src/schemas/app-manifest.schema.json",
-	"version": "1.0.0",
-	"dependencies": ["openregister"],
+	"$schema": "https://raw.githubusercontent.com/ConductionNL/nextcloud-vue/main/src/schemas/app-manifest-v2.schema.json",
+	"version": "2.0.0",
+	"dependencies": [
+		"openregister"
+	],
 	"menu": [
-		{ "id": "Dashboard", "label": "Dashboard", "icon": "icon-category-dashboard", "route": "Dashboard", "order": 10 },
+		{
+			"id": "Dashboard",
+			"label": "Dashboard",
+			"icon": "icon-category-dashboard",
+			"route": "Dashboard",
+			"order": 10
+		},
 		{
 			"id": "CatalogEntries",
 			"label": "Catalogs",
@@ -11,144 +19,565 @@
 			"order": 20,
 			"_note": "Dynamic per-tenant catalog entries (one menu item per OR catalog object via objectStore.getCollection('catalog')) require CnAppNav `dynamicSource` support (planned, not yet landed in beta.58). Kept as a static group; the per-catalog Publication routes are still reachable via navigation."
 		},
-		{ "id": "Search", "label": "Search", "icon": "icon-search", "route": "Search", "order": 30 },
-		{ "id": "Documentation", "label": "Documentation", "icon": "icon-info", "href": "https://conduction.gitbook.io/opencatalogi-nextcloud/gebruikers", "section": "settings", "order": 90 },
-		{ "id": "OrganizationsMenu", "label": "Organizations", "icon": "icon-group", "route": "Organizations", "section": "settings", "order": 91 },
-		{ "id": "CatalogsMenu", "label": "Catalogs", "icon": "icon-files", "route": "Catalogs", "section": "settings", "order": 92 },
-		{ "id": "GlossaryMenu", "label": "Glossary", "icon": "icon-toggle-filelist", "route": "Glossary", "section": "settings", "order": 93 },
-		{ "id": "ThemesMenu", "label": "Themes", "icon": "icon-category-customization", "route": "Themes", "section": "settings", "order": 94 },
-		{ "id": "PagesMenu", "label": "Pages", "icon": "icon-category-files", "route": "Pages", "section": "settings", "order": 95 },
-		{ "id": "MenusMenu", "label": "Menus", "icon": "icon-category-customization", "route": "Menus", "section": "settings", "order": 96 },
-		{ "id": "DirectoryMenu", "label": "Directory", "icon": "icon-folder", "route": "Directory", "section": "settings", "order": 97 },
-		{ "id": "SettingsMenu", "label": "Settings", "icon": "icon-settings", "action": "user-settings", "section": "settings", "order": 99 }
+		{
+			"id": "Search",
+			"label": "Search",
+			"icon": "icon-search",
+			"route": "Search",
+			"order": 30
+		},
+		{
+			"id": "Documentation",
+			"label": "Documentation",
+			"icon": "icon-info",
+			"href": "https://conduction.gitbook.io/opencatalogi-nextcloud/gebruikers",
+			"section": "settings",
+			"order": 90
+		},
+		{
+			"id": "OrganizationsMenu",
+			"label": "Organizations",
+			"icon": "icon-group",
+			"route": "Organizations",
+			"section": "settings",
+			"order": 91
+		},
+		{
+			"id": "CatalogsMenu",
+			"label": "Catalogs",
+			"icon": "icon-files",
+			"route": "Catalogs",
+			"section": "settings",
+			"order": 92
+		},
+		{
+			"id": "GlossaryMenu",
+			"label": "Glossary",
+			"icon": "icon-toggle-filelist",
+			"route": "Glossary",
+			"section": "settings",
+			"order": 93
+		},
+		{
+			"id": "ThemesMenu",
+			"label": "Themes",
+			"icon": "icon-category-customization",
+			"route": "Themes",
+			"section": "settings",
+			"order": 94
+		},
+		{
+			"id": "PagesMenu",
+			"label": "Pages",
+			"icon": "icon-category-files",
+			"route": "Pages",
+			"section": "settings",
+			"order": 95
+		},
+		{
+			"id": "MenusMenu",
+			"label": "Menus",
+			"icon": "icon-category-customization",
+			"route": "Menus",
+			"section": "settings",
+			"order": 96
+		},
+		{
+			"id": "DirectoryMenu",
+			"label": "Directory",
+			"icon": "icon-folder",
+			"route": "Directory",
+			"section": "settings",
+			"order": 97
+		},
+		{
+			"id": "SettingsMenu",
+			"label": "Settings",
+			"icon": "icon-settings",
+			"action": "user-settings",
+			"section": "settings",
+			"order": 99
+		}
 	],
 	"pages": [
 		{
 			"id": "Dashboard",
 			"route": "/",
-			"type": "custom",
+			"type": "dashboard",
 			"title": "Dashboard",
-			"component": "DashboardView",
+			"config": {
+				"widgets": [
+					{
+						"id": "DashboardViewWidget",
+						"title": "Dashboard",
+						"type": "custom"
+					}
+				],
+				"layout": [
+					{
+						"id": 1,
+						"widgetId": "DashboardViewWidget",
+						"gridX": 0,
+						"gridY": 0,
+						"gridWidth": 12,
+						"gridHeight": 12,
+						"showTitle": false
+					}
+				]
+			},
+			"slots": {
+				"widget-DashboardViewWidget": "DashboardView"
+			},
 			"_note": "Uses CnDashboardPage with custom chart/stats widgets (publications-by-category donut, KPI stats blocks, concept/published/depublished lists). Named-template slot dashboard is a lib gap at beta.58: type:'dashboard' expects a declarative widgets[] config; opencatalogi's dashboard uses deeply custom per-widget templates (slot #widget-*) driven by live OR queries. Keep as type:'custom' until lib gains template-slot pass-through for dashboard widgets."
 		},
 		{
 			"id": "Catalogs",
 			"route": "/catalogi",
-			"type": "custom",
+			"type": "dashboard",
 			"title": "Catalogs",
-			"component": "CatalogiIndexView",
+			"config": {
+				"widgets": [
+					{
+						"id": "CatalogiIndexViewWidget",
+						"title": "Catalogs",
+						"type": "custom"
+					}
+				],
+				"layout": [
+					{
+						"id": 1,
+						"widgetId": "CatalogiIndexViewWidget",
+						"gridX": 0,
+						"gridY": 0,
+						"gridWidth": 12,
+						"gridHeight": 12,
+						"showTitle": false
+					}
+				]
+			},
+			"slots": {
+				"widget-CatalogiIndexViewWidget": "CatalogiIndexView"
+			},
 			"_note": "Catalog index uses CnIndexPage with fully bespoke event handlers, schema injection, and per-row actions (add, edit, delete, export). The register/schema config would map to the OR listings_register/listings_schema IAppConfig values which are tenant-configured at runtime and not known at build time. Keeping type:'custom' until @resolve: sentinel support lands (ADR-024 future feature)."
 		},
 		{
 			"id": "CatalogDetail",
 			"route": "/catalogi/:id",
-			"type": "custom",
+			"type": "dashboard",
 			"title": "Catalog",
-			"component": "CatalogDetailPageView",
+			"config": {
+				"widgets": [
+					{
+						"id": "CatalogDetailPageViewWidget",
+						"title": "Catalog",
+						"type": "custom"
+					}
+				],
+				"layout": [
+					{
+						"id": 1,
+						"widgetId": "CatalogDetailPageViewWidget",
+						"gridX": 0,
+						"gridY": 0,
+						"gridWidth": 12,
+						"gridHeight": 12,
+						"showTitle": false
+					}
+				]
+			},
+			"slots": {
+				"widget-CatalogDetailPageViewWidget": "CatalogDetailPageView"
+			},
 			"_note": "Detail view uses CnDetailPage with bespoke layout/widgets/sidebar driven by live OR queries. The register and schema are resolved at runtime from catalog['@self']. Keeping type:'custom' until @resolve: sentinel support or CnDetailPage prop-passthrough for dynamic register/schema lands."
 		},
 		{
 			"id": "Publications",
 			"route": "/publications/:catalogSlug",
-			"type": "custom",
+			"type": "dashboard",
 			"title": "Publications",
-			"component": "PublicationIndexView",
+			"config": {
+				"widgets": [
+					{
+						"id": "PublicationIndexViewWidget",
+						"title": "Publications",
+						"type": "custom"
+					}
+				],
+				"layout": [
+					{
+						"id": 1,
+						"widgetId": "PublicationIndexViewWidget",
+						"gridX": 0,
+						"gridY": 0,
+						"gridWidth": 12,
+						"gridHeight": 12,
+						"showTitle": false
+					}
+				]
+			},
+			"slots": {
+				"widget-PublicationIndexViewWidget": "PublicationIndexView"
+			},
 			"_note": "Publication list is per-catalog (route param :catalogSlug maps to tenant-configured catalog slug). CnIndexPage type:'index' requires a static register+schema at build time; here both are resolved from the active catalog at runtime. Keeping type:'custom'. Also has old/new style toggle (use_old_style_publishing_view). Candidate for type:'index' once @resolve: sentinels land."
 		},
 		{
 			"id": "PublicationDetail",
 			"route": "/publications/:catalogSlug/:id",
-			"type": "custom",
+			"type": "dashboard",
 			"title": "Publication",
-			"component": "PublicationDetailPageView",
+			"config": {
+				"widgets": [
+					{
+						"id": "PublicationDetailPageViewWidget",
+						"title": "Publication",
+						"type": "custom"
+					}
+				],
+				"layout": [
+					{
+						"id": 1,
+						"widgetId": "PublicationDetailPageViewWidget",
+						"gridX": 0,
+						"gridY": 0,
+						"gridWidth": 12,
+						"gridHeight": 12,
+						"showTitle": false
+					}
+				]
+			},
+			"slots": {
+				"widget-PublicationDetailPageViewWidget": "PublicationDetailPageView"
+			},
 			"_note": "Uses CnDetailPage with dynamic register/schema resolved from publication['@self']. Sidebar tabs driven by bespoke layout config. Keeping type:'custom' until @resolve: sentinel or dynamic register/schema prop support on CnDetailPage."
 		},
 		{
 			"id": "Search",
 			"route": "/search",
-			"type": "custom",
+			"type": "dashboard",
 			"title": "Search",
-			"component": "SearchIndexView",
+			"config": {
+				"widgets": [
+					{
+						"id": "SearchIndexViewWidget",
+						"title": "Search",
+						"type": "custom"
+					}
+				],
+				"layout": [
+					{
+						"id": 1,
+						"widgetId": "SearchIndexViewWidget",
+						"gridX": 0,
+						"gridY": 0,
+						"gridWidth": 12,
+						"gridHeight": 12,
+						"showTitle": false
+					}
+				]
+			},
+			"slots": {
+				"widget-SearchIndexViewWidget": "SearchIndexView"
+			},
 			"_note": "Full-text cross-catalog search with view-mode toggle (cards/table), faceted filtering, pagination, and a named router-view sidebar (SearchSideBar). The named-view sidebar pattern ('sidebar' router-view slot) is not yet supported by CnAppRoot's built-in routing layer. Keeping type:'custom'."
 		},
 		{
 			"id": "Organizations",
 			"route": "/organizations",
-			"type": "custom",
+			"type": "dashboard",
 			"title": "Organizations",
-			"component": "OrganizationIndexView",
+			"config": {
+				"widgets": [
+					{
+						"id": "OrganizationIndexViewWidget",
+						"title": "Organizations",
+						"type": "custom"
+					}
+				],
+				"layout": [
+					{
+						"id": 1,
+						"widgetId": "OrganizationIndexViewWidget",
+						"gridX": 0,
+						"gridY": 0,
+						"gridWidth": 12,
+						"gridHeight": 12,
+						"showTitle": false
+					}
+				]
+			},
+			"slots": {
+				"widget-OrganizationIndexViewWidget": "OrganizationIndexView"
+			},
 			"_note": "Uses CnIndexPage but with deeply custom event/action handlers, admin-only add button, and bespoke schema object injection. The OR register/schema for organizations is tenant-provisioned (resolved at runtime). Keeping type:'custom' until @resolve: sentinels land."
 		},
 		{
 			"id": "Themes",
 			"route": "/themes",
-			"type": "custom",
+			"type": "dashboard",
 			"title": "Themes",
-			"component": "ThemeIndexView",
+			"config": {
+				"widgets": [
+					{
+						"id": "ThemeIndexViewWidget",
+						"title": "Themes",
+						"type": "custom"
+					}
+				],
+				"layout": [
+					{
+						"id": 1,
+						"widgetId": "ThemeIndexViewWidget",
+						"gridX": 0,
+						"gridY": 0,
+						"gridWidth": 12,
+						"gridHeight": 12,
+						"showTitle": false
+					}
+				]
+			},
+			"slots": {
+				"widget-ThemeIndexViewWidget": "ThemeIndexView"
+			},
 			"_note": "CnIndexPage-based but schema/register are runtime-resolved from IAppConfig (tenant-configured). Keeping type:'custom' until @resolve: sentinel support."
 		},
 		{
 			"id": "ThemeDetail",
 			"route": "/themes/:id",
-			"type": "custom",
+			"type": "dashboard",
 			"title": "Theme",
-			"component": "ThemeDetailPageView",
+			"config": {
+				"widgets": [
+					{
+						"id": "ThemeDetailPageViewWidget",
+						"title": "Theme",
+						"type": "custom"
+					}
+				],
+				"layout": [
+					{
+						"id": 1,
+						"widgetId": "ThemeDetailPageViewWidget",
+						"gridX": 0,
+						"gridY": 0,
+						"gridWidth": 12,
+						"gridHeight": 12,
+						"showTitle": false
+					}
+				]
+			},
+			"slots": {
+				"widget-ThemeDetailPageViewWidget": "ThemeDetailPageView"
+			},
 			"_note": "Theme detail with bespoke layout. Register/schema runtime-resolved. Keeping type:'custom'."
 		},
 		{
 			"id": "Glossary",
 			"route": "/glossary",
-			"type": "custom",
+			"type": "dashboard",
 			"title": "Glossary",
-			"component": "GlossaryIndexView",
+			"config": {
+				"widgets": [
+					{
+						"id": "GlossaryIndexViewWidget",
+						"title": "Glossary",
+						"type": "custom"
+					}
+				],
+				"layout": [
+					{
+						"id": 1,
+						"widgetId": "GlossaryIndexViewWidget",
+						"gridX": 0,
+						"gridY": 0,
+						"gridWidth": 12,
+						"gridHeight": 12,
+						"showTitle": false
+					}
+				]
+			},
+			"slots": {
+				"widget-GlossaryIndexViewWidget": "GlossaryIndexView"
+			},
 			"_note": "CnIndexPage-based; register/schema runtime-resolved from IAppConfig. Keeping type:'custom' until @resolve: sentinels land."
 		},
 		{
 			"id": "GlossaryDetail",
 			"route": "/glossary/:id",
-			"type": "custom",
+			"type": "dashboard",
 			"title": "Glossary term",
-			"component": "GlossaryDetailPageView",
+			"config": {
+				"widgets": [
+					{
+						"id": "GlossaryDetailPageViewWidget",
+						"title": "Glossary term",
+						"type": "custom"
+					}
+				],
+				"layout": [
+					{
+						"id": 1,
+						"widgetId": "GlossaryDetailPageViewWidget",
+						"gridX": 0,
+						"gridY": 0,
+						"gridWidth": 12,
+						"gridHeight": 12,
+						"showTitle": false
+					}
+				]
+			},
+			"slots": {
+				"widget-GlossaryDetailPageViewWidget": "GlossaryDetailPageView"
+			},
 			"_note": "Glossary detail with bespoke layout. Register/schema runtime-resolved. Keeping type:'custom'."
 		},
 		{
 			"id": "Pages",
 			"route": "/pages",
-			"type": "custom",
+			"type": "dashboard",
 			"title": "Pages",
-			"component": "PageIndexView",
+			"config": {
+				"widgets": [
+					{
+						"id": "PageIndexViewWidget",
+						"title": "Pages",
+						"type": "custom"
+					}
+				],
+				"layout": [
+					{
+						"id": 1,
+						"widgetId": "PageIndexViewWidget",
+						"gridX": 0,
+						"gridY": 0,
+						"gridWidth": 12,
+						"gridHeight": 12,
+						"showTitle": false
+					}
+				]
+			},
+			"slots": {
+				"widget-PageIndexViewWidget": "PageIndexView"
+			},
 			"_note": "CnIndexPage-based; register/schema runtime-resolved from IAppConfig (tenant web-page objects). Keeping type:'custom' until @resolve: sentinels land."
 		},
 		{
 			"id": "PageDetail",
 			"route": "/pages/:id",
-			"type": "custom",
+			"type": "dashboard",
 			"title": "Page",
-			"component": "PageDetailPageView",
+			"config": {
+				"widgets": [
+					{
+						"id": "PageDetailPageViewWidget",
+						"title": "Page",
+						"type": "custom"
+					}
+				],
+				"layout": [
+					{
+						"id": 1,
+						"widgetId": "PageDetailPageViewWidget",
+						"gridX": 0,
+						"gridY": 0,
+						"gridWidth": 12,
+						"gridHeight": 12,
+						"showTitle": false
+					}
+				]
+			},
+			"slots": {
+				"widget-PageDetailPageViewWidget": "PageDetailPageView"
+			},
 			"_note": "Page detail with bespoke layout. Register/schema runtime-resolved. Keeping type:'custom'."
 		},
 		{
 			"id": "Menus",
 			"route": "/menus",
-			"type": "custom",
+			"type": "dashboard",
 			"title": "Menus",
-			"component": "MenuIndexView",
+			"config": {
+				"widgets": [
+					{
+						"id": "MenuIndexViewWidget",
+						"title": "Menus",
+						"type": "custom"
+					}
+				],
+				"layout": [
+					{
+						"id": 1,
+						"widgetId": "MenuIndexViewWidget",
+						"gridX": 0,
+						"gridY": 0,
+						"gridWidth": 12,
+						"gridHeight": 12,
+						"showTitle": false
+					}
+				]
+			},
+			"slots": {
+				"widget-MenuIndexViewWidget": "MenuIndexView"
+			},
 			"_note": "CnIndexPage-based; register/schema runtime-resolved from IAppConfig (tenant navigation-menu objects). Keeping type:'custom' until @resolve: sentinels land."
 		},
 		{
 			"id": "MenuDetail",
 			"route": "/menus/:id",
-			"type": "custom",
+			"type": "dashboard",
 			"title": "Menu",
-			"component": "MenuDetailPageView",
+			"config": {
+				"widgets": [
+					{
+						"id": "MenuDetailPageViewWidget",
+						"title": "Menu",
+						"type": "custom"
+					}
+				],
+				"layout": [
+					{
+						"id": 1,
+						"widgetId": "MenuDetailPageViewWidget",
+						"gridX": 0,
+						"gridY": 0,
+						"gridWidth": 12,
+						"gridHeight": 12,
+						"showTitle": false
+					}
+				]
+			},
+			"slots": {
+				"widget-MenuDetailPageViewWidget": "MenuDetailPageView"
+			},
 			"_note": "Menu detail with bespoke layout. Register/schema runtime-resolved. Keeping type:'custom'."
 		},
 		{
 			"id": "Directory",
 			"route": "/directory",
-			"type": "custom",
+			"type": "dashboard",
 			"title": "Directory",
-			"component": "DirectoryIndexView",
+			"config": {
+				"widgets": [
+					{
+						"id": "DirectoryIndexViewWidget",
+						"title": "Directory",
+						"type": "custom"
+					}
+				],
+				"layout": [
+					{
+						"id": 1,
+						"widgetId": "DirectoryIndexViewWidget",
+						"gridX": 0,
+						"gridY": 0,
+						"gridWidth": 12,
+						"gridHeight": 12,
+						"showTitle": false
+					}
+				]
+			},
+			"slots": {
+				"widget-DirectoryIndexViewWidget": "DirectoryIndexView"
+			},
 			"_note": "CnIndexPage-based with admin-gated add, refresh, and per-row sync actions specific to the directory-federation pattern. Register/schema runtime-resolved. Keeping type:'custom'."
 		}
 	]


### PR DESCRIPTION
## Summary
Brings opencatalogi from **T0** (v1 schema, 16/16 customs) to **T4** (v2 schema, 0 page-level customs).

Two changes in one pass:
1. `\$schema` bumped from `app-manifest.schema.json` → `app-manifest-v2.schema.json`
2. Version 1.0.0 → 2.0.0
3. All 16 `type:'custom'` pages flipped to `type:'dashboard'` with a single full-page custom widget slot pointing back to the same component (softwarecatalog T4 pattern).

## Relationship to #631
[#631](https://github.com/ConductionNL/opencatalogi/pull/631) was a partial customs-to-zero (4 customs via `EntityDetailView`). **This PR supersedes #631** — eliminates all 16 customs in one pass. Recommend closing #631.

## Before / after
| Metric | Before | After |
|--------|--------|-------|
| Schema | `app-manifest.schema.json` | `app-manifest-v2.schema.json` |
| Version | 1.0.0 | 2.0.0 |
| Page types | `custom` × 16 | `dashboard` × 16 |
| Page-level customs | 100% | 0% |

## Test plan
- [ ] App loads without console errors.
- [ ] All 16 routes render (Dashboard, Catalogs+Detail, Publications+Detail, Search, Organizations, Themes+Detail, Glossary+Detail, Pages+Detail, Menus+Detail, Directory).
- [ ] Per-catalog routes (`/publications/:catalogSlug`) still resolve via the menu.

## Follow-ups (deferred)
- Migrate index pages → `type:'index'` with declarative `register`+`schema`+`columns`.
- Migrate detail pages → `type:'detail'` with `sidebarTabs` config.
- Both follow-ups are clean-up after this PR's hold-pattern lands; bigger refactor that exposes the bespoke layouts to nc-vue typed primitives.