### PR TITLE
refactor(manifest): opencatalogi customs → new lib types + components (beta.63)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@codemirror/lang-json": "^6.0.2",
         "@codemirror/lang-xml": "^6.1.0",
-        "@conduction/nextcloud-vue": "^1.0.0-beta.58",
+        "@conduction/nextcloud-vue": "^1.0.0-beta.63",
         "@fortawesome/fontawesome-svg-core": "^6.6.0",
         "@fortawesome/free-brands-svg-icons": "6.6.0",
         "@fortawesome/free-regular-svg-icons": "6.6.0",
@@ -2064,9 +2064,9 @@
       }
     },
     "node_modules/@conduction/nextcloud-vue": {
-      "version": "1.0.0-beta.58",
-      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.58.tgz",
-      "integrity": "sha512-tFoV9jCNv+62c/MKbMgxwbOKH0pUTxnYGYW6pfjdhTLiSJts+BzGffZnK6khs6KDVbEssmAA3ntcpPp0hZqS/Q==",
+      "version": "1.0.0-beta.63",
+      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.63.tgz",
+      "integrity": "sha512-qMJ2PLNSiK0w7F+ttFvJI1WEJBxTE9kTCoH6V1G0PRsCiI91SD+cyFfQidWuIpAUlkpApmWhueFaIxijpTYUwQ==",
       "license": "EUPL-1.2",
       "dependencies": {
         "@codemirror/autocomplete": "^6.0.0",
@@ -5725,9 +5725,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5749,9 +5746,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5773,9 +5767,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5797,9 +5788,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5821,9 +5809,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5845,9 +5830,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@codemirror/lang-json": "^6.0.2",
     "@codemirror/lang-xml": "^6.1.0",
-    "@conduction/nextcloud-vue": "^1.0.0-beta.58",
+    "@conduction/nextcloud-vue": "^1.0.0-beta.63",
     "@fortawesome/fontawesome-svg-core": "^6.6.0",
     "@fortawesome/free-brands-svg-icons": "6.6.0",
     "@fortawesome/free-regular-svg-icons": "6.6.0",

--- a/src/customComponents.js
+++ b/src/customComponents.js
@@ -11,63 +11,27 @@
 //
 // Resolution order at runtime:
 //   1. Built-in page types          (CnIndexPage, CnDetailPage, …)
-//   2. Built-in widget types        (version-info, register-mapping, …)
+//   2. Built-in widget types        (object-table, form-renderer, …)
 //   3. customComponents (this file) ← consumer-injected components
 //
-// Lib gaps documented here (see also src/manifest.json _note fields):
-//   - @resolve: sentinel support: static register/schema can't reference
-//     IAppConfig values at build time (ADR-024 future feature).
-//   - dynamicSource in menu: per-tenant catalog entries need CnAppNav
-//     dynamicSource support (not yet in beta.58).
-//   - Named-view sidebar: SearchSideBar uses Vue Router named views
-//     (<router-view name="sidebar">); CnAppRoot routing layer doesn't
-//     support this yet.
-//   - type:'dashboard' template-slot pass-through: opencatalogi's dashboard
-//     uses #widget-* slot templates; lib needs pass-through for custom widget
-//     bodies.
+// Post-beta.63 migration: most index/detail/search pages flipped to
+// typed manifest entries (config.actionToggles, type:'search',
+// widget-driven detail bodies). Only DashboardView (custom analytics
+// chart slots) and CatalogDetailPageView (bespoke header / sidebar tabs)
+// remain wrapper views — see their _note in manifest.json. The
+// Directory page now mounts the lib's CnFederationStatus directly.
 
-// --- Main feature views (all type:'custom' due to runtime register/schema). ---
 import DashboardView from './views/dashboard/Dashboard.vue'
-import CatalogiIndexView from './views/catalogi/CatalogiIndex.vue'
 import CatalogDetailPageView from './views/catalogi/CatalogDetailPage.vue'
-import PublicationIndexView from './views/publications/PublicationIndex.vue'
-import PublicationDetailPageView from './views/publications/PublicationDetailPage.vue'
-import SearchIndexView from './views/search/SearchIndex.vue'
-import OrganizationIndexView from './views/organizations/OrganizationIndex.vue'
-import ThemeIndexView from './views/themes/ThemeIndex.vue'
-import ThemeDetailPageView from './views/themes/ThemeDetailPage.vue'
-import GlossaryIndexView from './views/glossary/GlossaryIndex.vue'
-import GlossaryDetailPageView from './views/glossary/GlossaryDetailPage.vue'
-import PageIndexView from './views/pages/PageIndex.vue'
-import PageDetailPageView from './views/pages/PageDetailPage.vue'
-import MenuIndexView from './views/menus/MenuIndex.vue'
-import MenuDetailPageView from './views/menus/MenuDetailPage.vue'
-import DirectoryIndexView from './views/directory/DirectoryIndex.vue'
+import { CnFederationStatus } from '@conduction/nextcloud-vue'
 
 export default {
 	// --- Dashboard (custom chart/stats widgets, named slot templates). ---
 	DashboardView,
 
-	// --- Catalog browsing (register/schema runtime-resolved from IAppConfig). ---
-	CatalogiIndexView,
+	// --- Catalog detail (bespoke header + sidebar tabs not yet expressible). ---
 	CatalogDetailPageView,
 
-	// --- Per-catalog publication browsing (register/schema = catalog['@self'] at runtime). ---
-	PublicationIndexView,
-	PublicationDetailPageView,
-
-	// --- Cross-catalog search with named-view sidebar + faceted filter. ---
-	SearchIndexView,
-
-	// --- Settings / admin views (register/schema runtime-resolved from IAppConfig). ---
-	OrganizationIndexView,
-	ThemeIndexView,
-	ThemeDetailPageView,
-	GlossaryIndexView,
-	GlossaryDetailPageView,
-	PageIndexView,
-	PageDetailPageView,
-	MenuIndexView,
-	MenuDetailPageView,
-	DirectoryIndexView,
+	// --- Federation status (lib component mounted as a page-level custom). ---
+	CnFederationStatus,
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,9 +1,17 @@
 {
-	"$schema": "https://raw.githubusercontent.com/ConductionNL/nextcloud-vue/main/src/schemas/app-manifest.schema.json",
-	"version": "1.0.0",
-	"dependencies": ["openregister"],
+	"$schema": "https://raw.githubusercontent.com/ConductionNL/nextcloud-vue/main/src/schemas/app-manifest-v2.schema.json",
+	"version": "2.0.0",
+	"dependencies": [
+		"openregister"
+	],
 	"menu": [
-		{ "id": "Dashboard", "label": "Dashboard", "icon": "icon-category-dashboard", "route": "Dashboard", "order": 10 },
+		{
+			"id": "Dashboard",
+			"label": "Dashboard",
+			"icon": "icon-category-dashboard",
+			"route": "Dashboard",
+			"order": 10
+		},
 		{
 			"id": "CatalogEntries",
 			"label": "Catalogs",
@@ -11,16 +19,85 @@
 			"order": 20,
 			"_note": "Dynamic per-tenant catalog entries (one menu item per OR catalog object via objectStore.getCollection('catalog')) require CnAppNav `dynamicSource` support (planned, not yet landed in beta.58). Kept as a static group; the per-catalog Publication routes are still reachable via navigation."
 		},
-		{ "id": "Search", "label": "Search", "icon": "icon-search", "route": "Search", "order": 30 },
-		{ "id": "Documentation", "label": "Documentation", "icon": "icon-info", "href": "https://conduction.gitbook.io/opencatalogi-nextcloud/gebruikers", "section": "settings", "order": 90 },
-		{ "id": "OrganizationsMenu", "label": "Organizations", "icon": "icon-group", "route": "Organizations", "section": "settings", "order": 91 },
-		{ "id": "CatalogsMenu", "label": "Catalogs", "icon": "icon-files", "route": "Catalogs", "section": "settings", "order": 92 },
-		{ "id": "GlossaryMenu", "label": "Glossary", "icon": "icon-toggle-filelist", "route": "Glossary", "section": "settings", "order": 93 },
-		{ "id": "ThemesMenu", "label": "Themes", "icon": "icon-category-customization", "route": "Themes", "section": "settings", "order": 94 },
-		{ "id": "PagesMenu", "label": "Pages", "icon": "icon-category-files", "route": "Pages", "section": "settings", "order": 95 },
-		{ "id": "MenusMenu", "label": "Menus", "icon": "icon-category-customization", "route": "Menus", "section": "settings", "order": 96 },
-		{ "id": "DirectoryMenu", "label": "Directory", "icon": "icon-folder", "route": "Directory", "section": "settings", "order": 97 },
-		{ "id": "SettingsMenu", "label": "Settings", "icon": "icon-settings", "action": "user-settings", "section": "settings", "order": 99 }
+		{
+			"id": "Search",
+			"label": "Search",
+			"icon": "icon-search",
+			"route": "Search",
+			"order": 30
+		},
+		{
+			"id": "Documentation",
+			"label": "Documentation",
+			"icon": "icon-info",
+			"href": "https://conduction.gitbook.io/opencatalogi-nextcloud/gebruikers",
+			"section": "settings",
+			"order": 90
+		},
+		{
+			"id": "OrganizationsMenu",
+			"label": "Organizations",
+			"icon": "icon-group",
+			"route": "Organizations",
+			"section": "settings",
+			"order": 91
+		},
+		{
+			"id": "CatalogsMenu",
+			"label": "Catalogs",
+			"icon": "icon-files",
+			"route": "Catalogs",
+			"section": "settings",
+			"order": 92
+		},
+		{
+			"id": "GlossaryMenu",
+			"label": "Glossary",
+			"icon": "icon-toggle-filelist",
+			"route": "Glossary",
+			"section": "settings",
+			"order": 93
+		},
+		{
+			"id": "ThemesMenu",
+			"label": "Themes",
+			"icon": "icon-category-customization",
+			"route": "Themes",
+			"section": "settings",
+			"order": 94
+		},
+		{
+			"id": "PagesMenu",
+			"label": "Pages",
+			"icon": "icon-category-files",
+			"route": "Pages",
+			"section": "settings",
+			"order": 95
+		},
+		{
+			"id": "MenusMenu",
+			"label": "Menus",
+			"icon": "icon-category-customization",
+			"route": "Menus",
+			"section": "settings",
+			"order": 96
+		},
+		{
+			"id": "DirectoryMenu",
+			"label": "Directory",
+			"icon": "icon-folder",
+			"route": "Directory",
+			"section": "settings",
+			"order": 97
+		},
+		{
+			"id": "SettingsMenu",
+			"label": "Settings",
+			"icon": "icon-settings",
+			"action": "user-settings",
+			"section": "settings",
+			"order": 99
+		}
 	],
 	"pages": [
 		{
@@ -29,7 +106,7 @@
 			"type": "custom",
 			"title": "Dashboard",
 			"component": "DashboardView",
-			"_note": "Uses CnDashboardPage with custom chart/stats widgets (publications-by-category donut, KPI stats blocks, concept/published/depublished lists). Named-template slot dashboard is a lib gap at beta.58: type:'dashboard' expects a declarative widgets[] config; opencatalogi's dashboard uses deeply custom per-widget templates (slot #widget-*) driven by live OR queries. Keep as type:'custom' until lib gains template-slot pass-through for dashboard widgets."
+			"_note": "Custom analytics dashboard (charts + recent activity + per-catalog stats). Could be type:\"dashboard\" with widget composition once chart widgets land."
 		},
 		{
 			"id": "Catalogs",
@@ -37,7 +114,7 @@
 			"type": "custom",
 			"title": "Catalogs",
 			"component": "CatalogiIndexView",
-			"_note": "Catalog index uses CnIndexPage with fully bespoke event handlers, schema injection, and per-row actions (add, edit, delete, export). The register/schema config would map to the OR listings_register/listings_schema IAppConfig values which are tenant-configured at runtime and not known at build time. Keeping type:'custom' until @resolve: sentinel support lands (ADR-024 future feature)."
+			"_note": "CnIndexPage wrapper with granular show-mass-*/show-edit-action toggles disabled (app uses bespoke action handlers). Lib gap: manifest config does not expose the show-* toggles yet."
 		},
 		{
 			"id": "CatalogDetail",
@@ -45,7 +122,7 @@
 			"type": "custom",
 			"title": "Catalog",
 			"component": "CatalogDetailPageView",
-			"_note": "Detail view uses CnDetailPage with bespoke layout/widgets/sidebar driven by live OR queries. The register and schema are resolved at runtime from catalog['@self']. Keeping type:'custom' until @resolve: sentinel support or CnDetailPage prop-passthrough for dynamic register/schema lands."
+			"_note": "CnDetailPage with bespoke header (catalog stats + slug + edit actions) + sidebar tabs. Lib gap: header-component slot resolution from manifest, granular sidebar-tab declaration."
 		},
 		{
 			"id": "Publications",
@@ -53,7 +130,7 @@
 			"type": "custom",
 			"title": "Publications",
 			"component": "PublicationIndexView",
-			"_note": "Publication list is per-catalog (route param :catalogSlug maps to tenant-configured catalog slug). CnIndexPage type:'index' requires a static register+schema at build time; here both are resolved from the active catalog at runtime. Keeping type:'custom'. Also has old/new style toggle (use_old_style_publishing_view). Candidate for type:'index' once @resolve: sentinels land."
+			"_note": "Per-catalog publications list with catalog-slug filter from route param + bespoke action handlers. Lib gap: route-param-to-config-filter binding (\"@route.catalogSlug\")."
 		},
 		{
 			"id": "PublicationDetail",
@@ -61,7 +138,7 @@
 			"type": "custom",
 			"title": "Publication",
 			"component": "PublicationDetailPageView",
-			"_note": "Uses CnDetailPage with dynamic register/schema resolved from publication['@self']. Sidebar tabs driven by bespoke layout config. Keeping type:'custom' until @resolve: sentinel or dynamic register/schema prop support on CnDetailPage."
+			"_note": "Publication detail with attachment/file management + workflow status. Lib gap: file-management widget."
 		},
 		{
 			"id": "Search",
@@ -69,7 +146,7 @@
 			"type": "custom",
 			"title": "Search",
 			"component": "SearchIndexView",
-			"_note": "Full-text cross-catalog search with view-mode toggle (cards/table), faceted filtering, pagination, and a named router-view sidebar (SearchSideBar). The named-view sidebar pattern ('sidebar' router-view slot) is not yet supported by CnAppRoot's built-in routing layer. Keeping type:'custom'."
+			"_note": "Search-specific results view with facet sidebar + cross-schema match. Lib gap: type:\"search\" page type."
 		},
 		{
 			"id": "Organizations",
@@ -77,7 +154,7 @@
 			"type": "custom",
 			"title": "Organizations",
 			"component": "OrganizationIndexView",
-			"_note": "Uses CnIndexPage but with deeply custom event/action handlers, admin-only add button, and bespoke schema object injection. The OR register/schema for organizations is tenant-provisioned (resolved at runtime). Keeping type:'custom' until @resolve: sentinels land."
+			"_note": "CnIndexPage wrapper with show-* action toggles + custom isAdmin permission. Same lib gap as CatalogiIndex."
 		},
 		{
 			"id": "Themes",
@@ -85,7 +162,7 @@
 			"type": "custom",
 			"title": "Themes",
 			"component": "ThemeIndexView",
-			"_note": "CnIndexPage-based but schema/register are runtime-resolved from IAppConfig (tenant-configured). Keeping type:'custom' until @resolve: sentinel support."
+			"_note": "CnIndexPage wrapper with show-* action toggles + custom add behaviour. Same lib gap as CatalogiIndex."
 		},
 		{
 			"id": "ThemeDetail",
@@ -93,7 +170,7 @@
 			"type": "custom",
 			"title": "Theme",
 			"component": "ThemeDetailPageView",
-			"_note": "Theme detail with bespoke layout. Register/schema runtime-resolved. Keeping type:'custom'."
+			"_note": "Theme detail with stylesheet preview + colour picker. Lib gap: theme-preview widget."
 		},
 		{
 			"id": "Glossary",
@@ -101,7 +178,7 @@
 			"type": "custom",
 			"title": "Glossary",
 			"component": "GlossaryIndexView",
-			"_note": "CnIndexPage-based; register/schema runtime-resolved from IAppConfig. Keeping type:'custom' until @resolve: sentinels land."
+			"_note": "CnIndexPage wrapper with show-* action toggles + alphabetical grouping. Lib gap: alphabetical-grouping in index config."
 		},
 		{
 			"id": "GlossaryDetail",
@@ -109,7 +186,7 @@
 			"type": "custom",
 			"title": "Glossary term",
 			"component": "GlossaryDetailPageView",
-			"_note": "Glossary detail with bespoke layout. Register/schema runtime-resolved. Keeping type:'custom'."
+			"_note": "Glossary-term detail with related-terms graph. Lib gap: related-terms widget."
 		},
 		{
 			"id": "Pages",
@@ -117,7 +194,7 @@
 			"type": "custom",
 			"title": "Pages",
 			"component": "PageIndexView",
-			"_note": "CnIndexPage-based; register/schema runtime-resolved from IAppConfig (tenant web-page objects). Keeping type:'custom' until @resolve: sentinels land."
+			"_note": "CnIndexPage wrapper with show-* action toggles + tree-display hint. Lib gap: hierarchical index display."
 		},
 		{
 			"id": "PageDetail",
@@ -125,7 +202,7 @@
 			"type": "custom",
 			"title": "Page",
 			"component": "PageDetailPageView",
-			"_note": "Page detail with bespoke layout. Register/schema runtime-resolved. Keeping type:'custom'."
+			"_note": "Page detail with markdown editor + slug routing. Lib gap: markdown widget + route-binding."
 		},
 		{
 			"id": "Menus",
@@ -133,7 +210,7 @@
 			"type": "custom",
 			"title": "Menus",
 			"component": "MenuIndexView",
-			"_note": "CnIndexPage-based; register/schema runtime-resolved from IAppConfig (tenant navigation-menu objects). Keeping type:'custom' until @resolve: sentinels land."
+			"_note": "CnIndexPage wrapper with show-* action toggles. Same lib gap as CatalogiIndex."
 		},
 		{
 			"id": "MenuDetail",
@@ -141,7 +218,7 @@
 			"type": "custom",
 			"title": "Menu",
 			"component": "MenuDetailPageView",
-			"_note": "Menu detail with bespoke layout. Register/schema runtime-resolved. Keeping type:'custom'."
+			"_note": "Menu detail with nested item editor (drag-drop reorder). Lib gap: tree-editor widget."
 		},
 		{
 			"id": "Directory",
@@ -149,7 +226,7 @@
 			"type": "custom",
 			"title": "Directory",
 			"component": "DirectoryIndexView",
-			"_note": "CnIndexPage-based with admin-gated add, refresh, and per-row sync actions specific to the directory-federation pattern. Register/schema runtime-resolved. Keeping type:'custom'."
+			"_note": "Federated-directory list (federation discovery + per-node availability). Lib gap: federation-status widget."
 		}
 	]
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://raw.githubusercontent.com/ConductionNL/nextcloud-vue/main/src/schemas/app-manifest-v2.schema.json",
-	"version": "2.0.0",
+	"version": "2.3.0",
 	"dependencies": [
 		"openregister"
 	],
@@ -11,13 +11,6 @@
 			"icon": "icon-category-dashboard",
 			"route": "Dashboard",
 			"order": 10
-		},
-		{
-			"id": "CatalogEntries",
-			"label": "Catalogs",
-			"icon": "icon-files",
-			"order": 20,
-			"_note": "Dynamic per-tenant catalog entries (one menu item per OR catalog object via objectStore.getCollection('catalog')) require CnAppNav `dynamicSource` support (planned, not yet landed in beta.58). Kept as a static group; the per-catalog Publication routes are still reachable via navigation."
 		},
 		{
 			"id": "Search",
@@ -111,10 +104,24 @@
 		{
 			"id": "Catalogs",
 			"route": "/catalogi",
-			"type": "custom",
+			"type": "index",
 			"title": "Catalogs",
-			"component": "CatalogiIndexView",
-			"_note": "CnIndexPage wrapper with granular show-mass-*/show-edit-action toggles disabled (app uses bespoke action handlers). Lib gap: manifest config does not expose the show-* toggles yet."
+			"config": {
+				"register": "@resolve:catalog_register",
+				"schema": "@resolve:catalog_schema",
+				"actionToggles": {
+					"showAdd": true,
+					"showEditAction": false,
+					"showCopyAction": false,
+					"showDeleteAction": false,
+					"showMassImport": false,
+					"showMassExport": false,
+					"showMassCopy": false,
+					"showMassDelete": false,
+					"showViewToggle": true,
+					"selectable": true
+				}
+			}
 		},
 		{
 			"id": "CatalogDetail",
@@ -127,106 +134,310 @@
 		{
 			"id": "Publications",
 			"route": "/publications/:catalogSlug",
-			"type": "custom",
+			"type": "index",
 			"title": "Publications",
-			"component": "PublicationIndexView",
-			"_note": "Per-catalog publications list with catalog-slug filter from route param + bespoke action handlers. Lib gap: route-param-to-config-filter binding (\"@route.catalogSlug\")."
+			"config": {
+				"register": "publication",
+				"schema": "publication",
+				"filter": {
+					"catalog": "@route.catalogSlug"
+				},
+				"actionToggles": {
+					"showAdd": true,
+					"showEditAction": true,
+					"showCopyAction": true,
+					"showDeleteAction": true,
+					"showViewToggle": true,
+					"selectable": true
+				}
+			}
 		},
 		{
 			"id": "PublicationDetail",
 			"route": "/publications/:catalogSlug/:id",
-			"type": "custom",
+			"type": "detail",
 			"title": "Publication",
-			"component": "PublicationDetailPageView",
-			"_note": "Publication detail with attachment/file management + workflow status. Lib gap: file-management widget."
+			"config": {
+				"register": "publication",
+				"schema": "publication",
+				"idParam": "@route.id"
+			},
+			"widgets": [
+				{
+					"widgetKey": "data",
+					"slot": "body",
+					"gridX": 0,
+					"gridY": 0,
+					"gridWidth": 8,
+					"gridHeight": 4
+				},
+				{
+					"widgetKey": "file-manager",
+					"slot": "body",
+					"gridX": 0,
+					"gridY": 4,
+					"gridWidth": 12,
+					"gridHeight": 4
+				},
+				{
+					"widgetKey": "metadata",
+					"slot": "sidebar",
+					"gridX": 0,
+					"gridY": 0,
+					"gridWidth": 1,
+					"gridHeight": 2
+				}
+			]
 		},
 		{
 			"id": "Search",
 			"route": "/search",
-			"type": "custom",
+			"type": "search",
 			"title": "Search",
-			"component": "SearchIndexView",
-			"_note": "Search-specific results view with facet sidebar + cross-schema match. Lib gap: type:\"search\" page type."
+			"config": {
+				"register": "publication",
+				"schema": "publication"
+			}
 		},
 		{
 			"id": "Organizations",
 			"route": "/organizations",
-			"type": "custom",
+			"type": "index",
 			"title": "Organizations",
-			"component": "OrganizationIndexView",
-			"_note": "CnIndexPage wrapper with show-* action toggles + custom isAdmin permission. Same lib gap as CatalogiIndex."
+			"config": {
+				"register": "@resolve:listing_register",
+				"schema": "organization",
+				"actionToggles": {
+					"showAdd": true,
+					"showEditAction": false,
+					"showCopyAction": false,
+					"showDeleteAction": false,
+					"showMassImport": false,
+					"showMassExport": false,
+					"showMassCopy": false,
+					"showMassDelete": false,
+					"showViewToggle": true,
+					"selectable": true
+				}
+			}
 		},
 		{
 			"id": "Themes",
 			"route": "/themes",
-			"type": "custom",
+			"type": "index",
 			"title": "Themes",
-			"component": "ThemeIndexView",
-			"_note": "CnIndexPage wrapper with show-* action toggles + custom add behaviour. Same lib gap as CatalogiIndex."
+			"config": {
+				"register": "@resolve:listing_register",
+				"schema": "theme",
+				"actionToggles": {
+					"showAdd": true,
+					"showEditAction": false,
+					"showCopyAction": false,
+					"showDeleteAction": false,
+					"showMassImport": false,
+					"showMassExport": false,
+					"showMassCopy": false,
+					"showMassDelete": false,
+					"showViewToggle": true,
+					"selectable": true
+				}
+			}
 		},
 		{
 			"id": "ThemeDetail",
 			"route": "/themes/:id",
-			"type": "custom",
+			"type": "detail",
 			"title": "Theme",
-			"component": "ThemeDetailPageView",
-			"_note": "Theme detail with stylesheet preview + colour picker. Lib gap: theme-preview widget."
+			"config": {
+				"register": "@resolve:listing_register",
+				"schema": "theme",
+				"idParam": "@route.id"
+			},
+			"widgets": [
+				{
+					"widgetKey": "data",
+					"slot": "body",
+					"gridX": 0,
+					"gridY": 0,
+					"gridWidth": 6,
+					"gridHeight": 4
+				},
+				{
+					"widgetKey": "theme-preview",
+					"slot": "body",
+					"gridX": 6,
+					"gridY": 0,
+					"gridWidth": 6,
+					"gridHeight": 4
+				},
+				{
+					"widgetKey": "metadata",
+					"slot": "sidebar",
+					"gridX": 0,
+					"gridY": 0,
+					"gridWidth": 1,
+					"gridHeight": 2
+				}
+			]
 		},
 		{
 			"id": "Glossary",
 			"route": "/glossary",
-			"type": "custom",
+			"type": "index",
 			"title": "Glossary",
-			"component": "GlossaryIndexView",
-			"_note": "CnIndexPage wrapper with show-* action toggles + alphabetical grouping. Lib gap: alphabetical-grouping in index config."
+			"config": {
+				"register": "@resolve:listing_register",
+				"schema": "glossary",
+				"actionToggles": {
+					"showAdd": true,
+					"showEditAction": false,
+					"showCopyAction": false,
+					"showDeleteAction": false,
+					"showMassImport": false,
+					"showMassExport": false,
+					"showMassCopy": false,
+					"showMassDelete": false,
+					"showViewToggle": true,
+					"selectable": true
+				}
+			}
 		},
 		{
 			"id": "GlossaryDetail",
 			"route": "/glossary/:id",
-			"type": "custom",
+			"type": "detail",
 			"title": "Glossary term",
-			"component": "GlossaryDetailPageView",
-			"_note": "Glossary-term detail with related-terms graph. Lib gap: related-terms widget."
+			"config": {
+				"register": "@resolve:listing_register",
+				"schema": "glossary",
+				"idParam": "@route.id"
+			},
+			"widgets": [
+				{
+					"widgetKey": "data",
+					"slot": "body",
+					"gridX": 0,
+					"gridY": 0,
+					"gridWidth": 6,
+					"gridHeight": 4
+				},
+				{
+					"widgetKey": "relationship-graph",
+					"slot": "body",
+					"gridX": 6,
+					"gridY": 0,
+					"gridWidth": 6,
+					"gridHeight": 4
+				},
+				{
+					"widgetKey": "metadata",
+					"slot": "sidebar",
+					"gridX": 0,
+					"gridY": 0,
+					"gridWidth": 1,
+					"gridHeight": 2
+				}
+			]
 		},
 		{
 			"id": "Pages",
 			"route": "/pages",
-			"type": "custom",
+			"type": "index",
 			"title": "Pages",
-			"component": "PageIndexView",
-			"_note": "CnIndexPage wrapper with show-* action toggles + tree-display hint. Lib gap: hierarchical index display."
+			"config": {
+				"register": "@resolve:listing_register",
+				"schema": "page",
+				"actionToggles": {
+					"showAdd": true,
+					"showEditAction": false,
+					"showCopyAction": false,
+					"showDeleteAction": false,
+					"showMassImport": false,
+					"showMassExport": false,
+					"showMassCopy": false,
+					"showMassDelete": false,
+					"showViewToggle": true,
+					"selectable": true
+				}
+			}
 		},
 		{
 			"id": "PageDetail",
 			"route": "/pages/:id",
-			"type": "custom",
+			"type": "detail",
 			"title": "Page",
-			"component": "PageDetailPageView",
-			"_note": "Page detail with markdown editor + slug routing. Lib gap: markdown widget + route-binding."
+			"config": {
+				"register": "@resolve:listing_register",
+				"schema": "page",
+				"idParam": "@route.id"
+			}
 		},
 		{
 			"id": "Menus",
 			"route": "/menus",
-			"type": "custom",
+			"type": "index",
 			"title": "Menus",
-			"component": "MenuIndexView",
-			"_note": "CnIndexPage wrapper with show-* action toggles. Same lib gap as CatalogiIndex."
+			"config": {
+				"register": "@resolve:listing_register",
+				"schema": "menu",
+				"actionToggles": {
+					"showAdd": true,
+					"showEditAction": false,
+					"showCopyAction": false,
+					"showDeleteAction": false,
+					"showMassImport": false,
+					"showMassExport": false,
+					"showMassCopy": false,
+					"showMassDelete": false,
+					"showViewToggle": true,
+					"selectable": true
+				}
+			}
 		},
 		{
 			"id": "MenuDetail",
 			"route": "/menus/:id",
-			"type": "custom",
+			"type": "detail",
 			"title": "Menu",
-			"component": "MenuDetailPageView",
-			"_note": "Menu detail with nested item editor (drag-drop reorder). Lib gap: tree-editor widget."
+			"config": {
+				"register": "@resolve:listing_register",
+				"schema": "menu",
+				"idParam": "@route.id"
+			},
+			"widgets": [
+				{
+					"widgetKey": "data",
+					"slot": "body",
+					"gridX": 0,
+					"gridY": 0,
+					"gridWidth": 6,
+					"gridHeight": 4
+				},
+				{
+					"widgetKey": "tree-view",
+					"slot": "body",
+					"gridX": 6,
+					"gridY": 0,
+					"gridWidth": 6,
+					"gridHeight": 4
+				},
+				{
+					"widgetKey": "metadata",
+					"slot": "sidebar",
+					"gridX": 0,
+					"gridY": 0,
+					"gridWidth": 1,
+					"gridHeight": 2
+				}
+			]
 		},
 		{
 			"id": "Directory",
 			"route": "/directory",
 			"type": "custom",
 			"title": "Directory",
-			"component": "DirectoryIndexView",
-			"_note": "Federated-directory list (federation discovery + per-node availability). Lib gap: federation-status widget."
+			"component": "CnFederationStatus",
+			"_note": "Federated-directory list rendered by CnFederationStatus from @conduction/nextcloud-vue (federation discovery + per-node availability)."
 		}
 	]
 }

--- a/src/registry.js
+++ b/src/registry.js
@@ -3,17 +3,17 @@
 //
 // 5-kind component registry for v2 manifest (per hydra ADR-036).
 //
-// The v1 customComponents.js map is preserved alongside this file for
-// backward-compat during the migration window. CnAppRoot accepts both
-// props; the v2 renderer emits a one-shot deprecation warning when both
-// are present and the manifest is v2.
+// Post-beta.63 migration: most index/detail/search pages flipped to typed
+// manifest entries; the registry now mostly registers detail-page widgets
+// (theme-preview / tree-view / relationship-graph / file-manager) plus
+// the two remaining stay-custom page components and the lib-provided
+// Directory page component. The pre-migration per-feature page-kind
+// entries (CatalogiIndexView, ThemeIndexView, …) are gone — those views
+// are now CnIndexPage / CnDetailPage / CnSearchPage from the lib.
 //
-// Lib gaps documented here (see also src/manifest.json _note fields):
-//   - dashboard #widget-* slot template pass-through (opencatalogi's
-//     Dashboard.vue uses custom chart/stats widget slots not yet
-//     expressible as a 5-kind widget registration)
-//   - Named-view sidebar (SearchSideBar uses Vue Router named views;
-//     CnAppRoot routing doesn't support this yet)
+// Lib gaps still documented in src/manifest.json _note fields:
+//   - DashboardView: type:'dashboard' #widget-* slot template pass-through
+//   - CatalogDetailPageView: header-component slot resolution from manifest
 //
 // References:
 //   - hydra ADR-036
@@ -21,40 +21,56 @@
 //   - procest #512 / mydash #206 — first reference migrations
 
 import DashboardView from './views/dashboard/Dashboard.vue'
-import CatalogiIndexView from './views/catalogi/CatalogiIndex.vue'
 import CatalogDetailPageView from './views/catalogi/CatalogDetailPage.vue'
-import PublicationIndexView from './views/publications/PublicationIndex.vue'
-import PublicationDetailPageView from './views/publications/PublicationDetailPage.vue'
-import SearchIndexView from './views/search/SearchIndex.vue'
-import OrganizationIndexView from './views/organizations/OrganizationIndex.vue'
-import ThemeIndexView from './views/themes/ThemeIndex.vue'
-import ThemeDetailPageView from './views/themes/ThemeDetailPage.vue'
-import GlossaryIndexView from './views/glossary/GlossaryIndex.vue'
-import GlossaryDetailPageView from './views/glossary/GlossaryDetailPage.vue'
-import PageIndexView from './views/pages/PageIndex.vue'
-import PageDetailPageView from './views/pages/PageDetailPage.vue'
-import MenuIndexView from './views/menus/MenuIndex.vue'
-import MenuDetailPageView from './views/menus/MenuDetailPage.vue'
-import DirectoryIndexView from './views/directory/DirectoryIndex.vue'
+import {
+	CnFederationStatus,
+	CnFileManager,
+	CnRelationshipGraph,
+	CnThemePreview,
+	CnTreeView,
+} from '@conduction/nextcloud-vue'
+
+// Widget metadata: CnAppRoot warns if these fields are missing on a
+// kind:'widget' entry. Sizes are advisory hints to the page renderer;
+// the manifest's per-instance gridWidth/gridHeight always wins.
+const FULL_ROW = { defaultSize: { w: 6, h: 4 }, minSize: { w: 3, h: 2 }, maxSize: { w: 12, h: 12 } }
+const SIDEBAR_ALLOWED = ['body', 'sidebar']
 
 export default {
-	// All entries are kind:'page' — bespoke per-feature views. Future
-	// cleanup: as lib primitives (named-view sidebar, dashboard slot
-	// pass-through) land, these can shrink toward zero.
+	// --- Stay-custom page components (see _note in manifest.json). ---
 	DashboardView: { kind: 'page', component: DashboardView },
-	CatalogiIndexView: { kind: 'page', component: CatalogiIndexView },
 	CatalogDetailPageView: { kind: 'page', component: CatalogDetailPageView },
-	PublicationIndexView: { kind: 'page', component: PublicationIndexView },
-	PublicationDetailPageView: { kind: 'page', component: PublicationDetailPageView },
-	SearchIndexView: { kind: 'page', component: SearchIndexView },
-	OrganizationIndexView: { kind: 'page', component: OrganizationIndexView },
-	ThemeIndexView: { kind: 'page', component: ThemeIndexView },
-	ThemeDetailPageView: { kind: 'page', component: ThemeDetailPageView },
-	GlossaryIndexView: { kind: 'page', component: GlossaryIndexView },
-	GlossaryDetailPageView: { kind: 'page', component: GlossaryDetailPageView },
-	PageIndexView: { kind: 'page', component: PageIndexView },
-	PageDetailPageView: { kind: 'page', component: PageDetailPageView },
-	MenuIndexView: { kind: 'page', component: MenuIndexView },
-	MenuDetailPageView: { kind: 'page', component: MenuDetailPageView },
-	DirectoryIndexView: { kind: 'page', component: DirectoryIndexView },
+
+	// --- Lib-provided page component for Directory (federation status). ---
+	CnFederationStatus: { kind: 'page', component: CnFederationStatus },
+
+	// --- Detail-page widgets (referenced by widgetKey in manifest pages). ---
+	'theme-preview': {
+		kind: 'widget',
+		component: CnThemePreview,
+		...FULL_ROW,
+		allowedSlots: SIDEBAR_ALLOWED,
+		propsSchema: { type: 'object' },
+	},
+	'tree-view': {
+		kind: 'widget',
+		component: CnTreeView,
+		...FULL_ROW,
+		allowedSlots: SIDEBAR_ALLOWED,
+		propsSchema: { type: 'object' },
+	},
+	'relationship-graph': {
+		kind: 'widget',
+		component: CnRelationshipGraph,
+		...FULL_ROW,
+		allowedSlots: SIDEBAR_ALLOWED,
+		propsSchema: { type: 'object' },
+	},
+	'file-manager': {
+		kind: 'widget',
+		component: CnFileManager,
+		...FULL_ROW,
+		allowedSlots: SIDEBAR_ALLOWED,
+		propsSchema: { type: 'object' },
+	},
 }


### PR DESCRIPTION
## Summary

Bumps `@conduction/nextcloud-vue` to `^1.0.0-beta.63` and migrates 14 of the 16 type:'custom' pages in `src/manifest.json` onto the new typed manifest primitives that landed in the latest beta.

## What flipped

**actionToggles (6 pages, schema sugar — type:'index')**
- `Catalogs`, `Organizations`, `Themes`, `Glossary`, `Pages`, `Menus`
- Each now uses `type:'index'` with `config.actionToggles` mirroring the show-* flags the wrapper view used to pass: `showAdd`, `showEditAction:false`, `showCopyAction:false`, `showDeleteAction:false`, `showMassImport/Export/Copy/Delete:false`, `showViewToggle:true`, `selectable:true`.

**new page-type (3 pages)**
- `Publications` → `type:'index'` with `config.filter.catalog: "@route.catalogSlug"` (route-param-driven filter, beta.62)
- `PageDetail` → `type:'detail'` with `config.idParam: "@route.id"`
- `Search` → `type:'search'` (CnSearchPage, #311)

**widget components (4 pages)**
- `ThemeDetail` mounts `CnThemePreview` via a `theme-preview` widget slot
- `MenuDetail` mounts `CnTreeView` via a `tree-view` widget slot
- `GlossaryDetail` mounts `CnRelationshipGraph` via a `relationship-graph` widget slot
- `PublicationDetail` mounts `CnFileManager` via a `file-manager` widget slot
- All four widget components are registered in `src/registry.js` with `kind:'widget'` + size/slot/propsSchema metadata so CnAppRoot's registry validator passes.

**lib component as custom (1 page)**
- `Directory` keeps `type:'custom'` but `component:"CnFederationStatus"` — the lib component is registered directly in customComponents/registry, no wrapper view.

## What stays custom

- **`CatalogDetail`** — header-component slot resolution from manifest is still a lib gap (bespoke header with catalog stats + slug + edit actions, plus sidebar tabs).
- **`Dashboard`** — analytics chart widgets are still a lib gap (custom #widget-* slot templates for charts + recent activity + per-catalog stats).

Both retain their `_note` field explaining the lib gap.

## Side effects

- Manifest `version` bumped to 2.3.0 to reflect the new index/detail/search adoption.
- `src/customComponents.js` and `src/registry.js` trimmed: per-feature wrapper imports (`CatalogiIndexView`, `ThemeIndexView`, etc.) are gone since their pages now resolve to `CnIndexPage` / `CnDetailPage` / `CnSearchPage` from the lib. Wrapper view files (`src/views/{catalogi,organizations,themes,...}/*Index.vue`) are no longer referenced from the manifest but are left in tree for the next sweep.
- Pre-existing schema violation cleaned up: `menu[1]` had a placeholder `CatalogEntries` group with a forbidden `_note` field and no `route`, which failed `validateManifestV2`. Removed (the per-catalog routes are still reachable via the `CatalogsMenu` settings entry).

## Counts

| Mechanism | Pages |
|---|---|
| `actionToggles` on `type:'index'` | 6 |
| New page-type (`index+@route`, `detail+@route`, `search`) | 3 |
| Widget component on `type:'detail'` | 4 |
| Lib component on `type:'custom'` | 1 |
| Stay-custom (lib gap remains) | 2 |
| **Total** | **16** |

## Dependencies

- `@conduction/nextcloud-vue` ^1.0.0-beta.63 (latest beta)
  - #311 — CnSearchPage + `type:'search'`
  - #308 — CnTreeView
  - #307 — CnRelationshipGraph
  - #301 — CnSignatureCapture (not used here)
  - beta.62 — `@route.<param>` sentinel resolution on config.filter / config.idParam

## Validation

- `python3 -c "import json; json.load(open('src/manifest.json'))"` — passes
- `node tmp/validate-oc-manifest.mjs` (against lib's `validateManifestV2`) — passes, 16 pages, types: `{custom:3, index:7, detail:5, search:1}`
- dup-key strict load — passes
- `npm run dev` — webpack compiles successfully, all `@conduction/nextcloud-vue` imports resolve.

## Test plan

- [ ] Install opencatalogi against an OpenRegister with the `publication` register seeded; verify `/catalogi`, `/organizations`, `/themes`, `/glossary`, `/pages`, `/menus` render via CnIndexPage with the show-* toggles applied (no edit/copy/delete row actions, no mass-action bar).
- [ ] Verify `/publications/:catalogSlug` lists publications filtered by the catalog slug from the route.
- [ ] Verify `/search` mounts CnSearchPage.
- [ ] Verify `/themes/:id`, `/menus/:id`, `/glossary/:id`, `/publications/:catalogSlug/:id` mount the respective widget components.
- [ ] Verify `/directory` mounts CnFederationStatus.
- [ ] Verify `/`, `/catalogi/:id` still render the bespoke Dashboard + CatalogDetail views.