### PR TITLE
chore(deps): bump @conduction/nextcloud-vue to ^1.0.0-beta.66

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@codemirror/lang-json": "^6.0.2",
         "@codemirror/lang-xml": "^6.1.0",
-        "@conduction/nextcloud-vue": "^1.0.0-beta.63",
+        "@conduction/nextcloud-vue": "^1.0.0-beta.66",
         "@fortawesome/fontawesome-svg-core": "^6.6.0",
         "@fortawesome/free-brands-svg-icons": "6.6.0",
         "@fortawesome/free-regular-svg-icons": "6.6.0",
@@ -2064,9 +2064,9 @@
       }
     },
     "node_modules/@conduction/nextcloud-vue": {
-      "version": "1.0.0-beta.63",
-      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.63.tgz",
-      "integrity": "sha512-qMJ2PLNSiK0w7F+ttFvJI1WEJBxTE9kTCoH6V1G0PRsCiI91SD+cyFfQidWuIpAUlkpApmWhueFaIxijpTYUwQ==",
+      "version": "1.0.0-beta.66",
+      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.66.tgz",
+      "integrity": "sha512-Igd9KdaA90JA0i96CG4zyQxM7NmAyYfkdrT6rBWjuNZBkNwwW2TnxbP1NG3Qev6bc99yqWYbRcBVgnnP8SJnNw==",
       "license": "EUPL-1.2",
       "dependencies": {
         "@codemirror/autocomplete": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@codemirror/lang-json": "^6.0.2",
     "@codemirror/lang-xml": "^6.1.0",
-    "@conduction/nextcloud-vue": "^1.0.0-beta.63",
+    "@conduction/nextcloud-vue": "^1.0.0-beta.66",
     "@fortawesome/fontawesome-svg-core": "^6.6.0",
     "@fortawesome/free-brands-svg-icons": "6.6.0",
     "@fortawesome/free-regular-svg-icons": "6.6.0",


### PR DESCRIPTION
Picks up the schema 2.7.0 + CnPageRenderer top-level forwarding + CnDetailPage `_lockState` rename + `config.schema → objectType` bridging shipped in nextcloud-vue#317/#319/#320 tonight. Mechanical bump — no app-side code changes. Build: pass (npm run dev — production build OOMed).