### PR TITLE
fix: restore federation publications endpoint and Vue UI mount

### DIFF
--- a/lib/Service/PublicationService.php
+++ b/lib/Service/PublicationService.php
@@ -461,8 +461,7 @@ class PublicationService
             $objectService->searchObjectsPaginated(
                 query: $searchQuery,
                 _rbac: true,
-                _multitenancy: false,
-                published: false
+                _multitenancy: false
             )
         );
 

--- a/templates/index.php
+++ b/templates/index.php
@@ -3,6 +3,13 @@
 use OCP\Util;
 
 $appId = OCA\OpenCatalogi\AppInfo\Application::APP_ID;
+// The webpack build (see webpack.config.js → optimization.splitChunks) emits
+// the entry point as three files: the shared vendor chunk, the shared
+// @conduction/nextcloud-vue chunk, and the entry chunk itself. All three must
+// be loaded, in dependency order, for the bundle to bootstrap — the entry
+// chunk references modules that live in the shared chunks.
+Util::addScript($appId, $appId . '-shared-vendor');
+Util::addScript($appId, $appId . '-shared-nc-vue');
 Util::addScript($appId, $appId . '-main');
 Util::addStyle($appId, 'main');
 ?>


### PR DESCRIPTION
## Summary

Two unrelated-but-both-blocking bugs surfaced while validating /api/federation/publications against a federated source. Both reproduce from a clean install of opencatalogi against any Listing pointing at an external publications endpoint.

### 1. PublicationService::searchPublications — invalid named argument

lib/Service/PublicationService.php:461-466 calls ObjectService::searchObjectsPaginated(..., published: false). OpenRegister's signature is ($query, $_rbac, $_multitenancy, $deleted, $ids, $uses, $views) — no $published parameter exists, so PHP fatals with "Unknown named parameter $published" and /api/federation/publications returns HTTP 500.

Fix: drop the invalid argument. Default behavior is preserved.

### 2. templates/index.php — missing webpack shared-chunk preload

The webpack build emits the entry behind __webpack_require__.O() waiting on opencatalogi-shared-nc-vue and opencatalogi-shared-vendor. The template registered only opencatalogi-main, so the entry module never executed and Vue silently never mounted — the app rendered as an empty <div id="opencatalogi">.

Fix: preload the two shared chunks in dependency order before -main. Identical fix already in pipelinq/templates/index.php with the same explanatory comment.

## Test plan

- [x] /api/federation/publications returns 200 + 711 publications when a Listing points at https://opencatalogi.nl/api/apps/opencatalogi/api/publications
- [x] OpenCatalogi UI mounts at /index.php/apps/opencatalogi/ (sidebar + content render)
- [x] Search view at /index.php/apps/opencatalogi/search?view=cards renders the 711 federated publications as cards