### PR TITLE
fix(store): honor IAppConfig per-type register in _registerTypesFromSettings

### DIFF
--- a/src/store/modules/object.js
+++ b/src/store/modules/object.js
@@ -1712,11 +1712,30 @@ export const useObjectStore = defineStore('object', {
 			// Include 'publication' alongside the settings-defined types
 			const objectTypes = [...(this.settings.objectTypes || []), 'publication']
 			const registers = this.settings.availableRegisters || []
+			const configuration = this.settings.configuration || {}
 
 			for (const type of objectTypes) {
 				if (this.objectTypeRegistry[type]) continue
 
-				// Find the schema matching this type slug in any register
+				// 1. Prefer the explicit per-type {type}_register / {type}_schema from
+				//    IAppConfig. This is the authoritative mapping the backend uses, and
+				//    it disambiguates correctly when multiple registers happen to contain
+				//    a schema with the same slug (e.g. a stale duplicate register).
+				const configuredRegisterId = configuration[`${type}_register`]
+				const configuredSchemaId = configuration[`${type}_schema`]
+				if (configuredRegisterId && configuredSchemaId) {
+					this.objectTypeRegistry = {
+						...this.objectTypeRegistry,
+						[type]: {
+							schema: String(configuredSchemaId),
+							register: String(configuredRegisterId),
+						},
+					}
+					continue
+				}
+
+				// 2. Fall back to slug-matching across availableRegisters for types that
+				//    have no explicit config entry yet (e.g. dynamically-registered types).
 				for (const register of registers) {
 					const matchingSchema = (register.schemas || []).find(
 						(s) => s.slug === type || s.title?.toLowerCase() === type,


### PR DESCRIPTION
## Summary

When an OpenRegister instance contains a duplicate of one of the opencatalogi schema slugs (catalog/listing/organization/theme/page/menu/glossary) in a different register than the one IAppConfig points at, the directory/listings pages in the UI render empty even though the data exists.

## Reproduction

1. Have OpenCatalogi installed against register N (e.g. listing_register=14).
2. Have a second register M (e.g. 15) that also contains a schema with slug=listing.
3. Seed a Listing in register N via POST /apps/openregister/api/objects/14/55.
4. /apps/opencatalogi/api/listings shows it (backend honors IAppConfig).
5. /apps/opencatalogi/directory in the UI shows "No directory listings found".

The UI was hitting /apps/openregister/api/objects/15/55 (register 15 wins the slug match) which is empty.

## Cause

_registerTypesFromSettings in src/store/modules/object.js iterated availableRegisters and picked the first register whose schemas[].slug matched the object type. The per-type IAppConfig mapping ({type}_register / {type}_schema, exposed on /api/settings) was ignored, even though the PHP side uses it as the source of truth for every API call.

## Fix

Honor the explicit {type}_register + {type}_schema configuration first; fall back to slug-matching only for types that have no explicit config entry (e.g. types registered dynamically at runtime by catalog browsing).

## Test plan

- [x] Reproduced empty Directory page locally with two registers containing schema slug=listing
- [x] Backend /api/listings returns the seeded record (proving register mismatch is the issue)
- [ ] After fix lands and bundle is rebuilt, verify /apps/opencatalogi/directory shows seeded listings
- [ ] Single-register installs unaffected (slug-match still works for dynamic types via the fallback branch)