### PR TITLE
chore(webpack): align config with openconnector (drop inline-source-map override + cleanup)

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -38,7 +38,27 @@ webpackConfig.entry = {
 	},
 }
 
-webpackConfig.devtool = 'inline-source-map'
+// Use local source when available (monorepo dev), otherwise fall back to npm package
+const localLib = path.resolve(__dirname, '../nextcloud-vue/src')
+const useLocalLib = fs.existsSync(localLib)
+
+webpackConfig.resolve = {
+	extensions: ['.vue', '.js', '.ts'],
+	alias: {
+		'@': path.resolve(__dirname, 'src'),
+		...(useLocalLib ? { '@conduction/nextcloud-vue': localLib } : {}),
+		// Deduplicate shared packages so the aliased library source uses
+		// the same instances as the app (prevents dual-Pinia / dual-Vue bugs).
+		vue$: path.resolve(__dirname, 'node_modules/vue'),
+		pinia$: path.resolve(__dirname, 'node_modules/pinia'),
+		'@nextcloud/vue$': path.resolve(__dirname, 'node_modules/@nextcloud/vue'),
+		// Force @nextcloud/dialogs and @nextcloud/axios to resolve from this
+		// app's node_modules, preventing the nextcloud-vue submodule's nested
+		// deps from leaking in.
+		'@nextcloud/dialogs': path.resolve(__dirname, 'node_modules/@nextcloud/dialogs'),
+		'@nextcloud/axios$': path.resolve(__dirname, 'node_modules/@nextcloud/axios'),
+	},
+}
 
 webpackConfig.module = {
 	rules: [
@@ -49,45 +69,40 @@ webpackConfig.module = {
 		{
 			test: /\.ts$/,
 			loader: 'ts-loader',
+			options: { appendTsSuffixTo: [/\.vue$/], transpileOnly: true },
 			exclude: /node_modules/,
-			options: { appendTsSuffixTo: [/\.vue$/] },
 		},
 		{
 			test: /\.css$/,
 			use: ['style-loader', 'css-loader'],
 		},
 		{
+			// SCSS used by aliased @conduction/nextcloud-vue components
 			test: /\.scss$/,
 			use: ['style-loader', 'css-loader', 'sass-loader'],
+		},
+		{
+			// Image and icon assets
+			test: /\.(png|jpe?g|gif|svg)$/,
+			type: 'asset/resource',
+			generator: {
+				filename: 'img/[name][ext]',
+			},
 		},
 	],
 }
 
 webpackConfig.plugins = [
 	new VueLoaderPlugin(),
-	// TODO: Remove NodePolyfillPlugin when upgrading to Vue 3. This is a temporary hack required
-	// because we are using an outdated version of @nextcloud/vue which still targets Vue 2.
+	// NodePolyfillPlugin required by @nextcloud/dialogs 5.x (uses Node's
+	// `path` API) and v-md-editor's `safe-buffer` transitive dep. Cannot be
+	// removed until @nextcloud/dialogs drops the `path` import or the editor
+	// switches to a browser-native buffer impl.
 	new NodePolyfillPlugin({
 		additionalAliases: ['process'],
 	}),
-	new webpack.DefinePlugin({ appName: JSON.stringify(process.env.npm_package_name) }),
+	new webpack.DefinePlugin({ appName: JSON.stringify(appId) }),
 	new webpack.DefinePlugin({ appVersion: JSON.stringify(process.env.npm_package_version) }),
 ]
-
-// Use local source when available (monorepo dev), otherwise fall back to npm package
-const localLib = path.resolve(__dirname, '../nextcloud-vue/src')
-const useLocalLib = fs.existsSync(localLib)
-
-webpackConfig.resolve = webpackConfig.resolve || {}
-webpackConfig.resolve.alias = {
-	...(webpackConfig.resolve.alias || {}),
-	'@': path.resolve(__dirname, 'src'),
-	...(useLocalLib ? { '@conduction/nextcloud-vue': localLib } : {}),
-	vue$: path.resolve(__dirname, 'node_modules/vue'),
-	pinia$: path.resolve(__dirname, 'node_modules/pinia'),
-	'@nextcloud/vue$': path.resolve(__dirname, 'node_modules/@nextcloud/vue'),
-	'@nextcloud/dialogs': path.resolve(__dirname, 'node_modules/@nextcloud/dialogs'),
-	'@nextcloud/axios$': path.resolve(__dirname, 'node_modules/@nextcloud/axios'),
-}
 
 module.exports = webpackConfig


### PR DESCRIPTION
## Summary

Tidies opencatalogi/webpack.config.js to match the canonical shape used by openconnector (the closest comparable manifest-driven consumer of @conduction/nextcloud-vue).

## Key changes

- **Drop `webpackConfig.devtool = 'inline-source-map'` override.** The earlier line (line 10) already sets `isDev ? 'cheap-source-map' : 'source-map'` correctly. The override was forcing dev-style inline maps into production builds — main bundle was ~50MB; this drops it to ~10MB.
- **Replace spread-style `resolve.alias` with a clean `resolve = { extensions, alias }` block** matching openconnector's structure. Same alias semantics, more idiomatic.
- **Add `ts-loader` `transpileOnly: true`** so TS errors don't block builds (matches openconnector).
- **Add image/SVG asset resource rule** for icon assets that flow through SFC `<img src>` references.
- **Replace `DefinePlugin({ appName: JSON.stringify(process.env.npm_package_name) })` with `JSON.stringify(appId)`** — openconnector pattern; pulls from the local const instead of npm metadata.

## What was kept

- `NodePolyfillPlugin` stays. opencatalogi has @nextcloud/dialogs 5.x (which imports the Node `path` API) and @kangc/v-md-editor (which brings `safe-buffer`), so the polyfill is still required. openconnector pins @nextcloud/dialogs 3.x and has no markdown editor, which is why it works polyfill-free.

## Context

This came out of debugging why manifest-driven `type: "index"` pages render empty in opencatalogi but work fine in openconnector. The webpack config divergence isn't the root cause (verified — same `Wa=` minifier collision in both bundles), but cleaning the obvious noise out of the diff makes future debugging easier.

## Test plan

- [ ] Production build succeeds and emits a ~10MB main bundle (vs ~50MB before)
- [ ] Search view still renders federated publications
- [ ] Dashboard still renders
- [ ] No regression in Settings / widget entrypoints