### PR TITLE
fix(health): remove dead ElasticSearchService reference

### DIFF
--- a/lib/Controller/HealthController.php
+++ b/lib/Controller/HealthController.php
@@ -24,7 +24,6 @@ use OCP\AppFramework\Http\JSONResponse;
 use OCP\IDBConnection;
 use OCP\IRequest;
 use OCP\App\IAppManager;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -37,12 +36,11 @@ class HealthController extends Controller
     /**
      * Constructor.
      *
-     * @param string             $appName    The application name.
-     * @param IRequest           $request    The HTTP request.
-     * @param IDBConnection      $db         Database connection.
-     * @param IAppManager        $appManager App manager.
-     * @param LoggerInterface    $logger     Logger.
-     * @param ContainerInterface $container  DI container.
+     * @param string          $appName    The application name.
+     * @param IRequest        $request    The HTTP request.
+     * @param IDBConnection   $db         Database connection.
+     * @param IAppManager     $appManager App manager.
+     * @param LoggerInterface $logger     Logger.
      */
     public function __construct(
         $appName,
@@ -50,7 +48,6 @@ class HealthController extends Controller
         private IDBConnection $db,
         private IAppManager $appManager,
         private LoggerInterface $logger,
-        private ContainerInterface $container,
     ) {
         parent::__construct(appName: $appName, request: $request);
 
@@ -79,9 +76,6 @@ class HealthController extends Controller
         if ($checks['filesystem'] !== 'ok' && $status !== 'error') {
             $status = 'degraded';
         }
-
-        // Check search backend.
-        $checks['search_backend'] = $this->checkSearchBackend();
 
         // Only database failure is critical (503). Degraded is still 200.
         $httpStatus = Http::STATUS_OK;
@@ -149,32 +143,6 @@ class HealthController extends Controller
         }
 
     }//end checkFilesystem()
-
-    /**
-     * Check search backend availability.
-     *
-     * @return string Backend type and status.
-     */
-    private function checkSearchBackend(): string
-    {
-        try {
-            // Check if ElasticSearch is configured.
-            $esService = $this->container->get(\OCA\OpenCatalogi\Service\ElasticSearchService::class);
-            if ($esService !== null && method_exists($esService, 'isAvailable') === true) {
-                if ($esService->isAvailable() === true) {
-                    return 'elasticsearch: ok';
-                }
-
-                return 'elasticsearch: unreachable';
-            }
-
-            return 'database';
-        } catch (\Exception $e) {
-            // ElasticSearch not configured — using database backend.
-            return 'database';
-        }
-
-    }//end checkSearchBackend()
 
     /**
      * Get the app version.


### PR DESCRIPTION
## Summary

Removes a dead container lookup in `HealthController::checkSearchBackend()` for `\OCA\OpenCatalogi\Service\ElasticSearchService` — a class that no longer exists in `lib/Service/`. The `try`/`catch` swallowed the failure and the health endpoint always returned `'database'` for `search_backend`, regardless of any real backend state.

## Why remove instead of replace?

There is currently no search backend service in `lib/Service/` (`find lib -iname '*Search*' -o -iname '*Index*'` returns nothing). Replacing the dead lookup with a stub would just be a different lie; removing the check is the honest fix. When a real search backend ships, the check can be re-added against the real service.

Also drops the `ContainerInterface` constructor dependency that only existed to host this lookup.

## Changes

- `lib/Controller/HealthController.php`
  - Remove `checkSearchBackend()` method (dead `ElasticSearchService` container lookup).
  - Remove `search_backend` entry from the `index()` response payload.
  - Remove the `ContainerInterface` constructor injection (no longer needed).
  - Remove the `Psr\Container\ContainerInterface` use statement.

## Verification

- `find lib -name 'ElasticSearchService*'` → empty (class genuinely gone)
- `grep -rn 'ElasticSearchService' lib/` after this PR → empty
- PHPCS: 0 errors, 2 pre-existing `@spec` retrofit warnings (apply to all 44 `lib/` files, fleet-wide)
- PHPMD: clean

Refs #664