### PR TITLE
chore(specs): normalize requirement headings to Form A (ADR-037)

### DIFF
--- a/openspec/specs/admin-settings/spec.md
+++ b/openspec/specs/admin-settings/spec.md
@@ -10,22 +10,75 @@ The admin settings module provides the configuration interface for OpenCatalogi.
 
 ## Requirements
 
-| ID | Requirement | Priority | Status |
-|----|------------|----------|--------|
-| SET-001 | Retrieve current settings including object type configurations and available registers | Must | Implemented |
-| SET-002 | Update settings (schema/register mappings) via POST | Must | Implemented |
-| SET-003 | Load/import configuration from `publication_register.json` via OpenRegister's ConfigurationService | Must | Implemented |
-| SET-004 | Auto-configure registers and schemas by matching slugs | Should | Implemented |
-| SET-005 | Check and install/update OpenRegister dependency (minimum version 0.1.7) | Should | Implemented |
-| SET-006 | Track configuration version and compare with app version for upgrade detection | Must | Implemented |
-| SET-007 | Manual import trigger with optional force parameter | Must | Implemented |
-| SET-008 | Publish options: auto_publish_attachments, auto_publish_objects, use_old_style_publishing_view | Should | Implemented |
-| SET-009 | Get and update publishing options separately | Should | Implemented |
-| SET-010 | Version info endpoint showing app version, configured version, and match status | Must | Implemented |
-| SET-011 | Repair step to initialize settings on app install/upgrade | Must | Implemented |
-| SET-012 | Nextcloud admin settings page with template rendering | Must | Implemented |
-| SET-013 | Enrich register listings with full schema objects (not just IDs) | Should | Implemented |
-| SET-014 | Database migration history tracked across 4 migration files | Must | Implemented |
+### Requirement: Retrieve current settings including object type configurations and available registers
+The system MUST retrieve current settings including object type configurations and available registers.
+
+**ID:** SET-001 — Priority: Must — Status: Implemented
+
+### Requirement: Update settings (schema/register mappings) via POST
+The system MUST allow updating settings (schema/register mappings) via POST.
+
+**ID:** SET-002 — Priority: Must — Status: Implemented
+
+### Requirement: Load/import configuration from `publication_register.json` via OpenRegister's ConfigurationService
+The system MUST load/import configuration from `publication_register.json` via OpenRegister's ConfigurationService.
+
+**ID:** SET-003 — Priority: Must — Status: Implemented
+
+### Requirement: Auto-configure registers and schemas by matching slugs
+The system SHOULD auto-configure registers and schemas by matching slugs.
+
+**ID:** SET-004 — Priority: Should — Status: Implemented
+
+### Requirement: Check and install/update OpenRegister dependency (minimum version 0.1.7)
+The system SHOULD check and install/update the OpenRegister dependency (minimum version 0.1.7).
+
+**ID:** SET-005 — Priority: Should — Status: Implemented
+
+### Requirement: Track configuration version and compare with app version for upgrade detection
+The system MUST track the configuration version and compare it with the app version for upgrade detection.
+
+**ID:** SET-006 — Priority: Must — Status: Implemented
+
+### Requirement: Manual import trigger with optional force parameter
+The system MUST expose a manual import trigger with an optional force parameter.
+
+**ID:** SET-007 — Priority: Must — Status: Implemented
+
+### Requirement: Publish options: auto_publish_attachments, auto_publish_objects, use_old_style_publishing_view
+The system SHOULD expose publish options: auto_publish_attachments, auto_publish_objects, use_old_style_publishing_view.
+
+**ID:** SET-008 — Priority: Should — Status: Implemented
+
+### Requirement: Get and update publishing options separately
+The system SHOULD allow getting and updating publishing options separately.
+
+**ID:** SET-009 — Priority: Should — Status: Implemented
+
+### Requirement: Version info endpoint showing app version, configured version, and match status
+The system MUST expose a version info endpoint showing app version, configured version, and match status.
+
+**ID:** SET-010 — Priority: Must — Status: Implemented
+
+### Requirement: Repair step to initialize settings on app install/upgrade
+The system MUST provide a repair step to initialize settings on app install/upgrade.
+
+**ID:** SET-011 — Priority: Must — Status: Implemented
+
+### Requirement: Nextcloud admin settings page with template rendering
+The system MUST provide a Nextcloud admin settings page with template rendering.
+
+**ID:** SET-012 — Priority: Must — Status: Implemented
+
+### Requirement: Enrich register listings with full schema objects (not just IDs)
+The system SHOULD enrich register listings with full schema objects (not just IDs).
+
+**ID:** SET-013 — Priority: Should — Status: Implemented
+
+### Requirement: Database migration history tracked across 4 migration files
+The system MUST track database migration history across 4 migration files.
+
+**ID:** SET-014 — Priority: Must — Status: Implemented
 
 ## Data Model
 

--- a/openspec/specs/admin-settings/spec.md
+++ b/openspec/specs/admin-settings/spec.md
@@ -10,75 +10,75 @@ The admin settings module provides the configuration interface for OpenCatalogi.
 
 ## Requirements
 
-### Requirement: Retrieve current settings including object type configurations and available registers
+### Requirement: Retrieve current settings including object type configurations and available registers (SET-001)
 The system MUST retrieve current settings including object type configurations and available registers.
 
-**ID:** SET-001 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Update settings (schema/register mappings) via POST
+### Requirement: Update settings (schema/register mappings) via POST (SET-002)
 The system MUST allow updating settings (schema/register mappings) via POST.
 
-**ID:** SET-002 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Load/import configuration from `publication_register.json` via OpenRegister's ConfigurationService
+### Requirement: Load/import configuration from `publication_register.json` via OpenRegister's ConfigurationService (SET-003)
 The system MUST load/import configuration from `publication_register.json` via OpenRegister's ConfigurationService.
 
-**ID:** SET-003 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Auto-configure registers and schemas by matching slugs
+### Requirement: Auto-configure registers and schemas by matching slugs (SET-004)
 The system SHOULD auto-configure registers and schemas by matching slugs.
 
-**ID:** SET-004 — Priority: Should — Status: Implemented
+**Priority:** Should **Status:** Implemented
 
-### Requirement: Check and install/update OpenRegister dependency (minimum version 0.1.7)
+### Requirement: Check and install/update OpenRegister dependency (minimum version 0.1.7) (SET-005)
 The system SHOULD check and install/update the OpenRegister dependency (minimum version 0.1.7).
 
-**ID:** SET-005 — Priority: Should — Status: Implemented
+**Priority:** Should **Status:** Implemented
 
-### Requirement: Track configuration version and compare with app version for upgrade detection
+### Requirement: Track configuration version and compare with app version for upgrade detection (SET-006)
 The system MUST track the configuration version and compare it with the app version for upgrade detection.
 
-**ID:** SET-006 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Manual import trigger with optional force parameter
+### Requirement: Manual import trigger with optional force parameter (SET-007)
 The system MUST expose a manual import trigger with an optional force parameter.
 
-**ID:** SET-007 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Publish options: auto_publish_attachments, auto_publish_objects, use_old_style_publishing_view
+### Requirement: Publish options: auto_publish_attachments, auto_publish_objects, use_old_style_publishing_view (SET-008)
 The system SHOULD expose publish options: auto_publish_attachments, auto_publish_objects, use_old_style_publishing_view.
 
-**ID:** SET-008 — Priority: Should — Status: Implemented
+**Priority:** Should **Status:** Implemented
 
-### Requirement: Get and update publishing options separately
+### Requirement: Get and update publishing options separately (SET-009)
 The system SHOULD allow getting and updating publishing options separately.
 
-**ID:** SET-009 — Priority: Should — Status: Implemented
+**Priority:** Should **Status:** Implemented
 
-### Requirement: Version info endpoint showing app version, configured version, and match status
+### Requirement: Version info endpoint showing app version, configured version, and match status (SET-010)
 The system MUST expose a version info endpoint showing app version, configured version, and match status.
 
-**ID:** SET-010 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Repair step to initialize settings on app install/upgrade
+### Requirement: Repair step to initialize settings on app install/upgrade (SET-011)
 The system MUST provide a repair step to initialize settings on app install/upgrade.
 
-**ID:** SET-011 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Nextcloud admin settings page with template rendering
+### Requirement: Nextcloud admin settings page with template rendering (SET-012)
 The system MUST provide a Nextcloud admin settings page with template rendering.
 
-**ID:** SET-012 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Enrich register listings with full schema objects (not just IDs)
+### Requirement: Enrich register listings with full schema objects (not just IDs) (SET-013)
 The system SHOULD enrich register listings with full schema objects (not just IDs).
 
-**ID:** SET-013 — Priority: Should — Status: Implemented
+**Priority:** Should **Status:** Implemented
 
-### Requirement: Database migration history tracked across 4 migration files
+### Requirement: Database migration history tracked across 4 migration files (SET-014)
 The system MUST track database migration history across 4 migration files.
 
-**ID:** SET-014 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
 ## Data Model
 

--- a/openspec/specs/auto-publishing/spec.md
+++ b/openspec/specs/auto-publishing/spec.md
@@ -10,23 +10,80 @@ The auto-publishing system automatically publishes OpenRegister objects and thei
 
 ## Requirements
 
-| ID | Requirement | Priority | Status |
-|----|------------|----------|--------|
-| APB-001 | Listen to OpenRegister `ObjectCreatedEvent` and trigger auto-publishing logic | Must | Implemented |
-| APB-002 | Listen to OpenRegister `ObjectUpdatedEvent` and trigger auto-publishing logic | Must | Implemented |
-| APB-003 | Auto-publish newly created objects when `auto_publish_objects` is enabled | Must | Implemented |
-| APB-004 | Auto-publish file attachments (create share links) when `auto_publish_attachments` is enabled | Must | Implemented |
-| APB-005 | Only auto-publish objects whose register/schema match a configured catalog | Must | Implemented |
-| APB-006 | Determine publication status from `@self.published` and `@self.depublished` timestamps | Must | Implemented |
-| APB-007 | Skip event processing entirely when both auto-publish options are disabled (early return) | Should | Implemented |
-| APB-008 | On update events, only process attachment publishing for already-published objects | Should | Implemented |
-| APB-009 | On update events, detect publication status transitions (unpublished to published) | Should | Implemented |
-| APB-010 | Use FileMapper for direct database file access to avoid infinite loop with ObjectService | Must | Implemented |
-| APB-011 | Skip already-published files (those with existing share tokens) | Should | Implemented |
-| APB-012 | Return structured results with processed/published/error counts | Should | Implemented |
-| APB-013 | Log all processing results (successes and errors) for monitoring | Should | Implemented |
-| APB-014 | Gracefully handle exceptions without breaking the originating OpenRegister operation | Must | Implemented |
-| APB-015 | Event listeners registered in Application.php bootstrap via IRegistrationContext | Must | Implemented |
+### Requirement: Listen to OpenRegister `ObjectCreatedEvent` and trigger auto-publishing logic
+The system MUST listen to OpenRegister `ObjectCreatedEvent` and trigger auto-publishing logic.
+
+**ID:** APB-001 — Priority: Must — Status: Implemented
+
+### Requirement: Listen to OpenRegister `ObjectUpdatedEvent` and trigger auto-publishing logic
+The system MUST listen to OpenRegister `ObjectUpdatedEvent` and trigger auto-publishing logic.
+
+**ID:** APB-002 — Priority: Must — Status: Implemented
+
+### Requirement: Auto-publish newly created objects when `auto_publish_objects` is enabled
+The system MUST auto-publish newly created objects when `auto_publish_objects` is enabled.
+
+**ID:** APB-003 — Priority: Must — Status: Implemented
+
+### Requirement: Auto-publish file attachments (create share links) when `auto_publish_attachments` is enabled
+The system MUST auto-publish file attachments (create share links) when `auto_publish_attachments` is enabled.
+
+**ID:** APB-004 — Priority: Must — Status: Implemented
+
+### Requirement: Only auto-publish objects whose register/schema match a configured catalog
+The system MUST only auto-publish objects whose register/schema match a configured catalog.
+
+**ID:** APB-005 — Priority: Must — Status: Implemented
+
+### Requirement: Determine publication status from `@self.published` and `@self.depublished` timestamps
+The system MUST determine publication status from `@self.published` and `@self.depublished` timestamps.
+
+**ID:** APB-006 — Priority: Must — Status: Implemented
+
+### Requirement: Skip event processing entirely when both auto-publish options are disabled (early return)
+The system SHOULD skip event processing entirely when both auto-publish options are disabled (early return).
+
+**ID:** APB-007 — Priority: Should — Status: Implemented
+
+### Requirement: On update events, only process attachment publishing for already-published objects
+The system SHOULD only process attachment publishing for already-published objects on update events.
+
+**ID:** APB-008 — Priority: Should — Status: Implemented
+
+### Requirement: On update events, detect publication status transitions (unpublished to published)
+The system SHOULD detect publication status transitions (unpublished to published) on update events.
+
+**ID:** APB-009 — Priority: Should — Status: Implemented
+
+### Requirement: Use FileMapper for direct database file access to avoid infinite loop with ObjectService
+The system MUST use FileMapper for direct database file access to avoid infinite loop with ObjectService.
+
+**ID:** APB-010 — Priority: Must — Status: Implemented
+
+### Requirement: Skip already-published files (those with existing share tokens)
+The system SHOULD skip already-published files (those with existing share tokens).
+
+**ID:** APB-011 — Priority: Should — Status: Implemented
+
+### Requirement: Return structured results with processed/published/error counts
+The system SHOULD return structured results with processed/published/error counts.
+
+**ID:** APB-012 — Priority: Should — Status: Implemented
+
+### Requirement: Log all processing results (successes and errors) for monitoring
+The system SHOULD log all processing results (successes and errors) for monitoring.
+
+**ID:** APB-013 — Priority: Should — Status: Implemented
+
+### Requirement: Gracefully handle exceptions without breaking the originating OpenRegister operation
+The system MUST gracefully handle exceptions without breaking the originating OpenRegister operation.
+
+**ID:** APB-014 — Priority: Must — Status: Implemented
+
+### Requirement: Event listeners registered in Application.php bootstrap via IRegistrationContext
+Event listeners MUST be registered in Application.php bootstrap via IRegistrationContext.
+
+**ID:** APB-015 — Priority: Must — Status: Implemented
 
 ## Architecture
 

--- a/openspec/specs/auto-publishing/spec.md
+++ b/openspec/specs/auto-publishing/spec.md
@@ -10,80 +10,80 @@ The auto-publishing system automatically publishes OpenRegister objects and thei
 
 ## Requirements
 
-### Requirement: Listen to OpenRegister `ObjectCreatedEvent` and trigger auto-publishing logic
+### Requirement: Listen to OpenRegister `ObjectCreatedEvent` and trigger auto-publishing logic (APB-001)
 The system MUST listen to OpenRegister `ObjectCreatedEvent` and trigger auto-publishing logic.
 
-**ID:** APB-001 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Listen to OpenRegister `ObjectUpdatedEvent` and trigger auto-publishing logic
+### Requirement: Listen to OpenRegister `ObjectUpdatedEvent` and trigger auto-publishing logic (APB-002)
 The system MUST listen to OpenRegister `ObjectUpdatedEvent` and trigger auto-publishing logic.
 
-**ID:** APB-002 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Auto-publish newly created objects when `auto_publish_objects` is enabled
+### Requirement: Auto-publish newly created objects when `auto_publish_objects` is enabled (APB-003)
 The system MUST auto-publish newly created objects when `auto_publish_objects` is enabled.
 
-**ID:** APB-003 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Auto-publish file attachments (create share links) when `auto_publish_attachments` is enabled
+### Requirement: Auto-publish file attachments (create share links) when `auto_publish_attachments` is enabled (APB-004)
 The system MUST auto-publish file attachments (create share links) when `auto_publish_attachments` is enabled.
 
-**ID:** APB-004 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Only auto-publish objects whose register/schema match a configured catalog
+### Requirement: Only auto-publish objects whose register/schema match a configured catalog (APB-005)
 The system MUST only auto-publish objects whose register/schema match a configured catalog.
 
-**ID:** APB-005 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Determine publication status from `@self.published` and `@self.depublished` timestamps
+### Requirement: Determine publication status from `@self.published` and `@self.depublished` timestamps (APB-006)
 The system MUST determine publication status from `@self.published` and `@self.depublished` timestamps.
 
-**ID:** APB-006 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Skip event processing entirely when both auto-publish options are disabled (early return)
+### Requirement: Skip event processing entirely when both auto-publish options are disabled (early return) (APB-007)
 The system SHOULD skip event processing entirely when both auto-publish options are disabled (early return).
 
-**ID:** APB-007 — Priority: Should — Status: Implemented
+**Priority:** Should **Status:** Implemented
 
-### Requirement: On update events, only process attachment publishing for already-published objects
+### Requirement: On update events, only process attachment publishing for already-published objects (APB-008)
 The system SHOULD only process attachment publishing for already-published objects on update events.
 
-**ID:** APB-008 — Priority: Should — Status: Implemented
+**Priority:** Should **Status:** Implemented
 
-### Requirement: On update events, detect publication status transitions (unpublished to published)
+### Requirement: On update events, detect publication status transitions (unpublished to published) (APB-009)
 The system SHOULD detect publication status transitions (unpublished to published) on update events.
 
-**ID:** APB-009 — Priority: Should — Status: Implemented
+**Priority:** Should **Status:** Implemented
 
-### Requirement: Use FileMapper for direct database file access to avoid infinite loop with ObjectService
+### Requirement: Use FileMapper for direct database file access to avoid infinite loop with ObjectService (APB-010)
 The system MUST use FileMapper for direct database file access to avoid infinite loop with ObjectService.
 
-**ID:** APB-010 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Skip already-published files (those with existing share tokens)
+### Requirement: Skip already-published files (those with existing share tokens) (APB-011)
 The system SHOULD skip already-published files (those with existing share tokens).
 
-**ID:** APB-011 — Priority: Should — Status: Implemented
+**Priority:** Should **Status:** Implemented
 
-### Requirement: Return structured results with processed/published/error counts
+### Requirement: Return structured results with processed/published/error counts (APB-012)
 The system SHOULD return structured results with processed/published/error counts.
 
-**ID:** APB-012 — Priority: Should — Status: Implemented
+**Priority:** Should **Status:** Implemented
 
-### Requirement: Log all processing results (successes and errors) for monitoring
+### Requirement: Log all processing results (successes and errors) for monitoring (APB-013)
 The system SHOULD log all processing results (successes and errors) for monitoring.
 
-**ID:** APB-013 — Priority: Should — Status: Implemented
+**Priority:** Should **Status:** Implemented
 
-### Requirement: Gracefully handle exceptions without breaking the originating OpenRegister operation
+### Requirement: Gracefully handle exceptions without breaking the originating OpenRegister operation (APB-014)
 The system MUST gracefully handle exceptions without breaking the originating OpenRegister operation.
 
-**ID:** APB-014 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Event listeners registered in Application.php bootstrap via IRegistrationContext
+### Requirement: Event listeners registered in Application.php bootstrap via IRegistrationContext (APB-015)
 Event listeners MUST be registered in Application.php bootstrap via IRegistrationContext.
 
-**ID:** APB-015 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
 ## Architecture
 

--- a/openspec/specs/catalogs/spec.md
+++ b/openspec/specs/catalogs/spec.md
@@ -10,65 +10,65 @@ Catalogs are the top-level organizational unit in OpenCatalogi. A catalog groups
 
 ## Requirements
 
-### Requirement: List all catalogs via public API with CORS headers
+### Requirement: List all catalogs via public API with CORS headers (CAT-001)
 The system MUST list all catalogs via public API with CORS headers.
 
-**ID:** CAT-001 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Retrieve a single catalog by ID, returning all publications scoped to that catalog
+### Requirement: Retrieve a single catalog by ID, returning all publications scoped to that catalog (CAT-002)
 The system MUST retrieve a single catalog by ID, returning all publications scoped to that catalog.
 
-**ID:** CAT-002 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Catalogs are stored as OpenRegister objects using the `catalog` schema in the `publication` register
+### Requirement: Catalogs are stored as OpenRegister objects using the `catalog` schema in the `publication` register (CAT-003)
 Catalogs MUST be stored as OpenRegister objects using the `catalog` schema in the `publication` register.
 
-**ID:** CAT-003 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Catalog configuration (schema ID, register ID) is stored in IAppConfig as `catalog_schema` and `catalog_register`
+### Requirement: Catalog configuration (schema ID, register ID) is stored in IAppConfig as `catalog_schema` and `catalog_register` (CAT-004)
 Catalog configuration (schema ID, register ID) MUST be stored in IAppConfig as `catalog_schema` and `catalog_register`.
 
-**ID:** CAT-004 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Catalog lookups by slug are cached in a distributed cache (1 hour TTL) for performance
+### Requirement: Catalog lookups by slug are cached in a distributed cache (1 hour TTL) for performance (CAT-005)
 Catalog lookups by slug SHOULD be cached in a distributed cache (1 hour TTL) for performance.
 
-**ID:** CAT-005 — Priority: Should — Status: Implemented
+**Priority:** Should **Status:** Implemented
 
-### Requirement: Cache invalidation is supported by slug or by catalog ID
+### Requirement: Cache invalidation is supported by slug or by catalog ID (CAT-006)
 Cache invalidation SHOULD be supported by slug or by catalog ID.
 
-**ID:** CAT-006 — Priority: Should — Status: Implemented
+**Priority:** Should **Status:** Implemented
 
-### Requirement: Cache warmup is available to pre-load catalogs into cache
+### Requirement: Cache warmup is available to pre-load catalogs into cache (CAT-007)
 Cache warmup SHOULD be available to pre-load catalogs into cache.
 
-**ID:** CAT-007 — Priority: Nice — Status: Implemented
+**Priority:** Nice **Status:** Implemented
 
-### Requirement: CORS preflight OPTIONS responses must be supported on all catalog endpoints
+### Requirement: CORS preflight OPTIONS responses must be supported on all catalog endpoints (CAT-008)
 CORS preflight OPTIONS responses MUST be supported on all catalog endpoints.
 
-**ID:** CAT-008 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Public catalog endpoints must use `@PublicPage`, `@NoCSRFRequired`, `@NoAdminRequired` annotations
+### Requirement: Public catalog endpoints must use `@PublicPage`, `@NoCSRFRequired`, `@NoAdminRequired` annotations (CAT-009)
 Public catalog endpoints MUST use `@PublicPage`, `@NoCSRFRequired`, `@NoAdminRequired` annotations.
 
-**ID:** CAT-009 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Multi-schema and multi-register catalogs must be supported (a single catalog can span multiple schemas/registers)
+### Requirement: Multi-schema and multi-register catalogs must be supported (a single catalog can span multiple schemas/registers) (CAT-010)
 Multi-schema and multi-register catalogs SHOULD be supported (a single catalog can span multiple schemas/registers).
 
-**ID:** CAT-010 — Priority: Should — Status: Implemented
+**Priority:** Should **Status:** Implemented
 
-### Requirement: Automatic cache invalidation/warmup via CatalogCacheEventListener on post-save events; slug-to-ID normalisation via CatalogSchemaEventListener on pre-save events
+### Requirement: Automatic cache invalidation/warmup via CatalogCacheEventListener on post-save events; slug-to-ID normalisation via CatalogSchemaEventListener on pre-save events (CAT-011)
 Automatic cache invalidation/warmup MUST occur via CatalogCacheEventListener on object create/update/delete (post-save). Slug-to-ID normalisation of `registers`/`schemas` happens via CatalogSchemaEventListener on the **pre-save** events (`ObjectCreatingEvent`, `ObjectUpdatingEvent`) using `setModifiedData(...)`, never via a second `saveObject` call.
 
-**ID:** CAT-011 — Priority: Should — Status: Implemented
+**Priority:** Should **Status:** Implemented
 
-### Requirement: No catalog event listener may trigger a re-save of the originating object from a post-save event handler
+### Requirement: No catalog event listener may trigger a re-save of the originating object from a post-save event handler (CAT-012)
 No catalog event listener MUST trigger a re-save of the originating object from a post-save event handler. Listeners that need to mutate the entity MUST subscribe to the pre-save events and use `setModifiedData(...)`.
 
-**ID:** CAT-012 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
 ## Data Model
 

--- a/openspec/specs/catalogs/spec.md
+++ b/openspec/specs/catalogs/spec.md
@@ -10,20 +10,65 @@ Catalogs are the top-level organizational unit in OpenCatalogi. A catalog groups
 
 ## Requirements
 
-| ID | Requirement | Priority | Status |
-|----|------------|----------|--------|
-| CAT-001 | List all catalogs via public API with CORS headers | Must | Implemented |
-| CAT-002 | Retrieve a single catalog by ID, returning all publications scoped to that catalog | Must | Implemented |
-| CAT-003 | Catalogs are stored as OpenRegister objects using the `catalog` schema in the `publication` register | Must | Implemented |
-| CAT-004 | Catalog configuration (schema ID, register ID) is stored in IAppConfig as `catalog_schema` and `catalog_register` | Must | Implemented |
-| CAT-005 | Catalog lookups by slug are cached in a distributed cache (1 hour TTL) for performance | Should | Implemented |
-| CAT-006 | Cache invalidation is supported by slug or by catalog ID | Should | Implemented |
-| CAT-007 | Cache warmup is available to pre-load catalogs into cache | Nice | Implemented |
-| CAT-008 | CORS preflight OPTIONS responses must be supported on all catalog endpoints | Must | Implemented |
-| CAT-009 | Public catalog endpoints must use `@PublicPage`, `@NoCSRFRequired`, `@NoAdminRequired` annotations | Must | Implemented |
-| CAT-010 | Multi-schema and multi-register catalogs must be supported (a single catalog can span multiple schemas/registers) | Should | Implemented |
-| CAT-011 | Automatic cache invalidation/warmup via CatalogCacheEventListener on object create/update/delete (post-save). Slug-to-ID normalisation of `registers`/`schemas` happens via CatalogSchemaEventListener on the **pre-save** events (`ObjectCreatingEvent`, `ObjectUpdatingEvent`) using `setModifiedData(...)`, never via a second `saveObject` call. | Should | Implemented |
-| CAT-012 | No catalog event listener may trigger a re-save of the originating object from a post-save event handler. Listeners that need to mutate the entity MUST subscribe to the pre-save events and use `setModifiedData(...)`. | Must | Implemented |
+### Requirement: List all catalogs via public API with CORS headers
+The system MUST list all catalogs via public API with CORS headers.
+
+**ID:** CAT-001 — Priority: Must — Status: Implemented
+
+### Requirement: Retrieve a single catalog by ID, returning all publications scoped to that catalog
+The system MUST retrieve a single catalog by ID, returning all publications scoped to that catalog.
+
+**ID:** CAT-002 — Priority: Must — Status: Implemented
+
+### Requirement: Catalogs are stored as OpenRegister objects using the `catalog` schema in the `publication` register
+Catalogs MUST be stored as OpenRegister objects using the `catalog` schema in the `publication` register.
+
+**ID:** CAT-003 — Priority: Must — Status: Implemented
+
+### Requirement: Catalog configuration (schema ID, register ID) is stored in IAppConfig as `catalog_schema` and `catalog_register`
+Catalog configuration (schema ID, register ID) MUST be stored in IAppConfig as `catalog_schema` and `catalog_register`.
+
+**ID:** CAT-004 — Priority: Must — Status: Implemented
+
+### Requirement: Catalog lookups by slug are cached in a distributed cache (1 hour TTL) for performance
+Catalog lookups by slug SHOULD be cached in a distributed cache (1 hour TTL) for performance.
+
+**ID:** CAT-005 — Priority: Should — Status: Implemented
+
+### Requirement: Cache invalidation is supported by slug or by catalog ID
+Cache invalidation SHOULD be supported by slug or by catalog ID.
+
+**ID:** CAT-006 — Priority: Should — Status: Implemented
+
+### Requirement: Cache warmup is available to pre-load catalogs into cache
+Cache warmup SHOULD be available to pre-load catalogs into cache.
+
+**ID:** CAT-007 — Priority: Nice — Status: Implemented
+
+### Requirement: CORS preflight OPTIONS responses must be supported on all catalog endpoints
+CORS preflight OPTIONS responses MUST be supported on all catalog endpoints.
+
+**ID:** CAT-008 — Priority: Must — Status: Implemented
+
+### Requirement: Public catalog endpoints must use `@PublicPage`, `@NoCSRFRequired`, `@NoAdminRequired` annotations
+Public catalog endpoints MUST use `@PublicPage`, `@NoCSRFRequired`, `@NoAdminRequired` annotations.
+
+**ID:** CAT-009 — Priority: Must — Status: Implemented
+
+### Requirement: Multi-schema and multi-register catalogs must be supported (a single catalog can span multiple schemas/registers)
+Multi-schema and multi-register catalogs SHOULD be supported (a single catalog can span multiple schemas/registers).
+
+**ID:** CAT-010 — Priority: Should — Status: Implemented
+
+### Requirement: Automatic cache invalidation/warmup via CatalogCacheEventListener on post-save events; slug-to-ID normalisation via CatalogSchemaEventListener on pre-save events
+Automatic cache invalidation/warmup MUST occur via CatalogCacheEventListener on object create/update/delete (post-save). Slug-to-ID normalisation of `registers`/`schemas` happens via CatalogSchemaEventListener on the **pre-save** events (`ObjectCreatingEvent`, `ObjectUpdatingEvent`) using `setModifiedData(...)`, never via a second `saveObject` call.
+
+**ID:** CAT-011 — Priority: Should — Status: Implemented
+
+### Requirement: No catalog event listener may trigger a re-save of the originating object from a post-save event handler
+No catalog event listener MUST trigger a re-save of the originating object from a post-save event handler. Listeners that need to mutate the entity MUST subscribe to the pre-save events and use `setModifiedData(...)`.
+
+**ID:** CAT-012 — Priority: Must — Status: Implemented
 
 ## Data Model
 

--- a/openspec/specs/cms-tool/spec.md
+++ b/openspec/specs/cms-tool/spec.md
@@ -10,23 +10,80 @@ The CMS Tool provides AI agents running within OpenRegister with the ability to 
 
 ## Requirements
 
-| ID | Requirement | Priority | Status |
-|----|------------|----------|--------|
-| CMS-T-001 | Implement OpenRegister `ToolInterface` with getName(), getDescription(), setAgent(), getFunctions(), executeFunction() | Must | Implemented |
-| CMS-T-002 | Provide `cms_create_page` function to create pages with title, summary, description, slug | Must | Implemented |
-| CMS-T-003 | Provide `cms_list_pages` function to list pages with optional limit | Must | Implemented |
-| CMS-T-004 | Provide `cms_create_menu` function to create menus with title, position, items, groups, hideBeforeLogin | Must | Implemented |
-| CMS-T-005 | Provide `cms_list_menus` function to list all menus | Must | Implemented |
-| CMS-T-006 | Provide `cms_add_menu_item` function to add items to existing menus | Must | Implemented |
-| CMS-T-007 | Auto-generate URL-friendly slugs from page titles when not provided | Should | Implemented |
-| CMS-T-008 | Respect agent's organization boundaries (set organisation on created objects) | Must | Implemented |
-| CMS-T-009 | Use ObjectService for data operations with RBAC support | Must | Implemented |
-| CMS-T-010 | Support `__call` magic method for snake_case to camelCase method resolution (LLPhant compatibility) | Should | Implemented |
-| CMS-T-011 | Type-cast arguments from LLM (handle string 'null', integer/boolean coercion) | Should | Implemented |
-| CMS-T-012 | Return JSON-encoded results for LLM consumption via `__call` | Should | Implemented |
-| CMS-T-013 | Validate required parameters and return structured error responses | Must | Implemented |
-| CMS-T-014 | Register tool via ToolRegistrationListener on OpenRegister's ToolRegistrationEvent | Must | Implemented |
-| CMS-T-015 | Menu creation requires at least one item with order, name, and link fields | Must | Implemented |
+### Requirement: Implement OpenRegister `ToolInterface` with getName(), getDescription(), setAgent(), getFunctions(), executeFunction()
+The CMS tool MUST implement OpenRegister `ToolInterface` with getName(), getDescription(), setAgent(), getFunctions(), executeFunction().
+
+**ID:** CMS-T-001 — Priority: Must — Status: Implemented
+
+### Requirement: Provide `cms_create_page` function to create pages with title, summary, description, slug
+The CMS tool MUST provide a `cms_create_page` function to create pages with title, summary, description, slug.
+
+**ID:** CMS-T-002 — Priority: Must — Status: Implemented
+
+### Requirement: Provide `cms_list_pages` function to list pages with optional limit
+The CMS tool MUST provide a `cms_list_pages` function to list pages with an optional limit.
+
+**ID:** CMS-T-003 — Priority: Must — Status: Implemented
+
+### Requirement: Provide `cms_create_menu` function to create menus with title, position, items, groups, hideBeforeLogin
+The CMS tool MUST provide a `cms_create_menu` function to create menus with title, position, items, groups, hideBeforeLogin.
+
+**ID:** CMS-T-004 — Priority: Must — Status: Implemented
+
+### Requirement: Provide `cms_list_menus` function to list all menus
+The CMS tool MUST provide a `cms_list_menus` function to list all menus.
+
+**ID:** CMS-T-005 — Priority: Must — Status: Implemented
+
+### Requirement: Provide `cms_add_menu_item` function to add items to existing menus
+The CMS tool MUST provide a `cms_add_menu_item` function to add items to existing menus.
+
+**ID:** CMS-T-006 — Priority: Must — Status: Implemented
+
+### Requirement: Auto-generate URL-friendly slugs from page titles when not provided
+The CMS tool SHOULD auto-generate URL-friendly slugs from page titles when not provided.
+
+**ID:** CMS-T-007 — Priority: Should — Status: Implemented
+
+### Requirement: Respect agent's organization boundaries (set organisation on created objects)
+The CMS tool MUST respect the agent's organization boundaries (set organisation on created objects).
+
+**ID:** CMS-T-008 — Priority: Must — Status: Implemented
+
+### Requirement: Use ObjectService for data operations with RBAC support
+The CMS tool MUST use ObjectService for data operations with RBAC support.
+
+**ID:** CMS-T-009 — Priority: Must — Status: Implemented
+
+### Requirement: Support `__call` magic method for snake_case to camelCase method resolution (LLPhant compatibility)
+The CMS tool SHOULD support the `__call` magic method for snake_case to camelCase method resolution (LLPhant compatibility).
+
+**ID:** CMS-T-010 — Priority: Should — Status: Implemented
+
+### Requirement: Type-cast arguments from LLM (handle string 'null', integer/boolean coercion)
+The CMS tool SHOULD type-cast arguments from the LLM (handle string 'null', integer/boolean coercion).
+
+**ID:** CMS-T-011 — Priority: Should — Status: Implemented
+
+### Requirement: Return JSON-encoded results for LLM consumption via `__call`
+The CMS tool SHOULD return JSON-encoded results for LLM consumption via `__call`.
+
+**ID:** CMS-T-012 — Priority: Should — Status: Implemented
+
+### Requirement: Validate required parameters and return structured error responses
+The CMS tool MUST validate required parameters and return structured error responses.
+
+**ID:** CMS-T-013 — Priority: Must — Status: Implemented
+
+### Requirement: Register tool via ToolRegistrationListener on OpenRegister's ToolRegistrationEvent
+The CMS tool MUST register itself via ToolRegistrationListener on OpenRegister's ToolRegistrationEvent.
+
+**ID:** CMS-T-014 — Priority: Must — Status: Implemented
+
+### Requirement: Menu creation requires at least one item with order, name, and link fields
+Menu creation MUST require at least one item with order, name, and link fields.
+
+**ID:** CMS-T-015 — Priority: Must — Status: Implemented
 
 ## Architecture
 

--- a/openspec/specs/cms-tool/spec.md
+++ b/openspec/specs/cms-tool/spec.md
@@ -10,80 +10,80 @@ The CMS Tool provides AI agents running within OpenRegister with the ability to 
 
 ## Requirements
 
-### Requirement: Implement OpenRegister `ToolInterface` with getName(), getDescription(), setAgent(), getFunctions(), executeFunction()
+### Requirement: Implement OpenRegister `ToolInterface` with getName(), getDescription(), setAgent(), getFunctions(), executeFunction() (CMS-T-001)
 The CMS tool MUST implement OpenRegister `ToolInterface` with getName(), getDescription(), setAgent(), getFunctions(), executeFunction().
 
-**ID:** CMS-T-001 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Provide `cms_create_page` function to create pages with title, summary, description, slug
+### Requirement: Provide `cms_create_page` function to create pages with title, summary, description, slug (CMS-T-002)
 The CMS tool MUST provide a `cms_create_page` function to create pages with title, summary, description, slug.
 
-**ID:** CMS-T-002 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Provide `cms_list_pages` function to list pages with optional limit
+### Requirement: Provide `cms_list_pages` function to list pages with optional limit (CMS-T-003)
 The CMS tool MUST provide a `cms_list_pages` function to list pages with an optional limit.
 
-**ID:** CMS-T-003 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Provide `cms_create_menu` function to create menus with title, position, items, groups, hideBeforeLogin
+### Requirement: Provide `cms_create_menu` function to create menus with title, position, items, groups, hideBeforeLogin (CMS-T-004)
 The CMS tool MUST provide a `cms_create_menu` function to create menus with title, position, items, groups, hideBeforeLogin.
 
-**ID:** CMS-T-004 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Provide `cms_list_menus` function to list all menus
+### Requirement: Provide `cms_list_menus` function to list all menus (CMS-T-005)
 The CMS tool MUST provide a `cms_list_menus` function to list all menus.
 
-**ID:** CMS-T-005 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Provide `cms_add_menu_item` function to add items to existing menus
+### Requirement: Provide `cms_add_menu_item` function to add items to existing menus (CMS-T-006)
 The CMS tool MUST provide a `cms_add_menu_item` function to add items to existing menus.
 
-**ID:** CMS-T-006 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Auto-generate URL-friendly slugs from page titles when not provided
+### Requirement: Auto-generate URL-friendly slugs from page titles when not provided (CMS-T-007)
 The CMS tool SHOULD auto-generate URL-friendly slugs from page titles when not provided.
 
-**ID:** CMS-T-007 — Priority: Should — Status: Implemented
+**Priority:** Should **Status:** Implemented
 
-### Requirement: Respect agent's organization boundaries (set organisation on created objects)
+### Requirement: Respect agent's organization boundaries (set organisation on created objects) (CMS-T-008)
 The CMS tool MUST respect the agent's organization boundaries (set organisation on created objects).
 
-**ID:** CMS-T-008 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Use ObjectService for data operations with RBAC support
+### Requirement: Use ObjectService for data operations with RBAC support (CMS-T-009)
 The CMS tool MUST use ObjectService for data operations with RBAC support.
 
-**ID:** CMS-T-009 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Support `__call` magic method for snake_case to camelCase method resolution (LLPhant compatibility)
+### Requirement: Support `__call` magic method for snake_case to camelCase method resolution (LLPhant compatibility) (CMS-T-010)
 The CMS tool SHOULD support the `__call` magic method for snake_case to camelCase method resolution (LLPhant compatibility).
 
-**ID:** CMS-T-010 — Priority: Should — Status: Implemented
+**Priority:** Should **Status:** Implemented
 
-### Requirement: Type-cast arguments from LLM (handle string 'null', integer/boolean coercion)
+### Requirement: Type-cast arguments from LLM (handle string 'null', integer/boolean coercion) (CMS-T-011)
 The CMS tool SHOULD type-cast arguments from the LLM (handle string 'null', integer/boolean coercion).
 
-**ID:** CMS-T-011 — Priority: Should — Status: Implemented
+**Priority:** Should **Status:** Implemented
 
-### Requirement: Return JSON-encoded results for LLM consumption via `__call`
+### Requirement: Return JSON-encoded results for LLM consumption via `__call` (CMS-T-012)
 The CMS tool SHOULD return JSON-encoded results for LLM consumption via `__call`.
 
-**ID:** CMS-T-012 — Priority: Should — Status: Implemented
+**Priority:** Should **Status:** Implemented
 
-### Requirement: Validate required parameters and return structured error responses
+### Requirement: Validate required parameters and return structured error responses (CMS-T-013)
 The CMS tool MUST validate required parameters and return structured error responses.
 
-**ID:** CMS-T-013 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Register tool via ToolRegistrationListener on OpenRegister's ToolRegistrationEvent
+### Requirement: Register tool via ToolRegistrationListener on OpenRegister's ToolRegistrationEvent (CMS-T-014)
 The CMS tool MUST register itself via ToolRegistrationListener on OpenRegister's ToolRegistrationEvent.
 
-**ID:** CMS-T-014 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Menu creation requires at least one item with order, name, and link fields
+### Requirement: Menu creation requires at least one item with order, name, and link fields (CMS-T-015)
 Menu creation MUST require at least one item with order, name, and link fields.
 
-**ID:** CMS-T-015 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
 ## Architecture
 

--- a/openspec/specs/content-management/spec.md
+++ b/openspec/specs/content-management/spec.md
@@ -12,131 +12,131 @@ OpenCatalogi includes a lightweight CMS layer for managing static content on cat
 
 <!-- Pages -->
 
-### Requirement: List all pages with pagination via public API
+### Requirement: List all pages with pagination via public API (CMS-001)
 The system MUST list all pages with pagination via public API.
 
-**ID:** CMS-001 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Retrieve a single page by slug
+### Requirement: Retrieve a single page by slug (CMS-002)
 The system MUST retrieve a single page by slug.
 
-**ID:** CMS-002 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Pages support block-based content structure (contents array with type, data, groups)
+### Requirement: Pages support block-based content structure (contents array with type, data, groups) (CMS-003)
 Pages MUST support block-based content structure (contents array with type, data, groups).
 
-**ID:** CMS-003 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Pages support group-based access control (groups, hideAfterLogin, hideBeforeLogin)
+### Requirement: Pages support group-based access control (groups, hideAfterLogin, hideBeforeLogin) (CMS-004)
 Pages SHOULD support group-based access control (groups, hideAfterLogin, hideBeforeLogin).
 
-**ID:** CMS-004 — Priority: Should — Status: Implemented
+**Priority:** Should **Status:** Implemented
 
-### Requirement: Page configuration stored in IAppConfig as `page_schema` and `page_register`
+### Requirement: Page configuration stored in IAppConfig as `page_schema` and `page_register` (CMS-005)
 Page configuration MUST be stored in IAppConfig as `page_schema` and `page_register`.
 
-**ID:** CMS-005 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: CORS headers included on all page endpoints
+### Requirement: CORS headers included on all page endpoints (CMS-006)
 CORS headers MUST be included on all page endpoints.
 
-**ID:** CMS-006 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
 <!-- Menus -->
 
-### Requirement: List all menus with pagination via public API
+### Requirement: List all menus with pagination via public API (CMS-010)
 The system MUST list all menus with pagination via public API.
 
-**ID:** CMS-010 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Retrieve a single menu by ID
+### Requirement: Retrieve a single menu by ID (CMS-011)
 The system MUST retrieve a single menu by ID.
 
-**ID:** CMS-011 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Menus support hierarchical items with sub-items
+### Requirement: Menus support hierarchical items with sub-items (CMS-012)
 Menus MUST support hierarchical items with sub-items.
 
-**ID:** CMS-012 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Menu items support group-based visibility (groups, hideAfterLogin, hideBeforeLogin)
+### Requirement: Menu items support group-based visibility (groups, hideAfterLogin, hideBeforeLogin) (CMS-013)
 Menu items SHOULD support group-based visibility (groups, hideAfterLogin, hideBeforeLogin).
 
-**ID:** CMS-013 — Priority: Should — Status: Implemented
+**Priority:** Should **Status:** Implemented
 
-### Requirement: Menu configuration stored in IAppConfig as `menu_schema` and `menu_register`
+### Requirement: Menu configuration stored in IAppConfig as `menu_schema` and `menu_register` (CMS-014)
 Menu configuration MUST be stored in IAppConfig as `menu_schema` and `menu_register`.
 
-**ID:** CMS-014 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Default fallback: menu schema ID 7, register ID 1 when not configured
+### Requirement: Default fallback: menu schema ID 7, register ID 1 when not configured (CMS-015)
 The system SHOULD default to menu schema ID 7 and register ID 1 when not configured.
 
-**ID:** CMS-015 — Priority: Should — Status: Implemented
+**Priority:** Should **Status:** Implemented
 
-### Requirement: CORS headers included on all menu endpoints
+### Requirement: CORS headers included on all menu endpoints (CMS-016)
 CORS headers MUST be included on all menu endpoints.
 
-**ID:** CMS-016 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
 <!-- Themes -->
 
-### Requirement: List all themes with pagination and facets via public API
+### Requirement: List all themes with pagination and facets via public API (CMS-020)
 The system MUST list all themes with pagination and facets via public API.
 
-**ID:** CMS-020 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Retrieve a single theme by ID
+### Requirement: Retrieve a single theme by ID (CMS-021)
 The system MUST retrieve a single theme by ID.
 
-**ID:** CMS-021 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Theme configuration stored in IAppConfig as `theme_schema` and `theme_register`
+### Requirement: Theme configuration stored in IAppConfig as `theme_schema` and `theme_register` (CMS-022)
 Theme configuration MUST be stored in IAppConfig as `theme_schema` and `theme_register`.
 
-**ID:** CMS-022 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Themes include display fields (image, icon, link, url, sort, isExternal)
+### Requirement: Themes include display fields (image, icon, link, url, sort, isExternal) (CMS-023)
 Themes MUST include display fields (image, icon, link, url, sort, isExternal).
 
-**ID:** CMS-023 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: CORS headers included on all theme endpoints
+### Requirement: CORS headers included on all theme endpoints (CMS-024)
 CORS headers MUST be included on all theme endpoints.
 
-**ID:** CMS-024 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
 <!-- Glossary -->
 
-### Requirement: List all glossary terms with pagination and facets via public API
+### Requirement: List all glossary terms with pagination and facets via public API (CMS-030)
 The system MUST list all glossary terms with pagination and facets via public API.
 
-**ID:** CMS-030 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Retrieve a single glossary term by ID
+### Requirement: Retrieve a single glossary term by ID (CMS-031)
 The system MUST retrieve a single glossary term by ID.
 
-**ID:** CMS-031 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Glossary configuration stored in IAppConfig as `glossary_schema` and `glossary_register`
+### Requirement: Glossary configuration stored in IAppConfig as `glossary_schema` and `glossary_register` (CMS-032)
 Glossary configuration MUST be stored in IAppConfig as `glossary_schema` and `glossary_register`.
 
-**ID:** CMS-032 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Glossary queries force `_source: database` (no Solr dependency)
+### Requirement: Glossary queries force `_source: database` (no Solr dependency) (CMS-033)
 Glossary queries MUST force `_source: database` (no Solr dependency).
 
-**ID:** CMS-033 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Glossary terms do not use publishing workflow (published=false in queries)
+### Requirement: Glossary terms do not use publishing workflow (published=false in queries) (CMS-034)
 Glossary terms MUST NOT use the publishing workflow (published=false in queries).
 
-**ID:** CMS-034 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: CORS headers included on all glossary endpoints
+### Requirement: CORS headers included on all glossary endpoints (CMS-035)
 CORS headers MUST be included on all glossary endpoints.
 
-**ID:** CMS-035 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
 ## Data Model
 

--- a/openspec/specs/content-management/spec.md
+++ b/openspec/specs/content-management/spec.md
@@ -10,49 +10,133 @@ OpenCatalogi includes a lightweight CMS layer for managing static content on cat
 
 ## Requirements
 
-### Pages
+<!-- Pages -->
 
-| ID | Requirement | Priority | Status |
-|----|------------|----------|--------|
-| CMS-001 | List all pages with pagination via public API | Must | Implemented |
-| CMS-002 | Retrieve a single page by slug | Must | Implemented |
-| CMS-003 | Pages support block-based content structure (contents array with type, data, groups) | Must | Implemented |
-| CMS-004 | Pages support group-based access control (groups, hideAfterLogin, hideBeforeLogin) | Should | Implemented |
-| CMS-005 | Page configuration stored in IAppConfig as `page_schema` and `page_register` | Must | Implemented |
-| CMS-006 | CORS headers included on all page endpoints | Must | Implemented |
+### Requirement: List all pages with pagination via public API
+The system MUST list all pages with pagination via public API.
 
-### Menus
+**ID:** CMS-001 — Priority: Must — Status: Implemented
 
-| ID | Requirement | Priority | Status |
-|----|------------|----------|--------|
-| CMS-010 | List all menus with pagination via public API | Must | Implemented |
-| CMS-011 | Retrieve a single menu by ID | Must | Implemented |
-| CMS-012 | Menus support hierarchical items with sub-items | Must | Implemented |
-| CMS-013 | Menu items support group-based visibility (groups, hideAfterLogin, hideBeforeLogin) | Should | Implemented |
-| CMS-014 | Menu configuration stored in IAppConfig as `menu_schema` and `menu_register` | Must | Implemented |
-| CMS-015 | Default fallback: menu schema ID 7, register ID 1 when not configured | Should | Implemented |
-| CMS-016 | CORS headers included on all menu endpoints | Must | Implemented |
+### Requirement: Retrieve a single page by slug
+The system MUST retrieve a single page by slug.
 
-### Themes
+**ID:** CMS-002 — Priority: Must — Status: Implemented
 
-| ID | Requirement | Priority | Status |
-|----|------------|----------|--------|
-| CMS-020 | List all themes with pagination and facets via public API | Must | Implemented |
-| CMS-021 | Retrieve a single theme by ID | Must | Implemented |
-| CMS-022 | Theme configuration stored in IAppConfig as `theme_schema` and `theme_register` | Must | Implemented |
-| CMS-023 | Themes include display fields (image, icon, link, url, sort, isExternal) | Must | Implemented |
-| CMS-024 | CORS headers included on all theme endpoints | Must | Implemented |
+### Requirement: Pages support block-based content structure (contents array with type, data, groups)
+Pages MUST support block-based content structure (contents array with type, data, groups).
 
-### Glossary
+**ID:** CMS-003 — Priority: Must — Status: Implemented
 
-| ID | Requirement | Priority | Status |
-|----|------------|----------|--------|
-| CMS-030 | List all glossary terms with pagination and facets via public API | Must | Implemented |
-| CMS-031 | Retrieve a single glossary term by ID | Must | Implemented |
-| CMS-032 | Glossary configuration stored in IAppConfig as `glossary_schema` and `glossary_register` | Must | Implemented |
-| CMS-033 | Glossary queries force `_source: database` (no Solr dependency) | Must | Implemented |
-| CMS-034 | Glossary terms do not use publishing workflow (published=false in queries) | Must | Implemented |
-| CMS-035 | CORS headers included on all glossary endpoints | Must | Implemented |
+### Requirement: Pages support group-based access control (groups, hideAfterLogin, hideBeforeLogin)
+Pages SHOULD support group-based access control (groups, hideAfterLogin, hideBeforeLogin).
+
+**ID:** CMS-004 — Priority: Should — Status: Implemented
+
+### Requirement: Page configuration stored in IAppConfig as `page_schema` and `page_register`
+Page configuration MUST be stored in IAppConfig as `page_schema` and `page_register`.
+
+**ID:** CMS-005 — Priority: Must — Status: Implemented
+
+### Requirement: CORS headers included on all page endpoints
+CORS headers MUST be included on all page endpoints.
+
+**ID:** CMS-006 — Priority: Must — Status: Implemented
+
+<!-- Menus -->
+
+### Requirement: List all menus with pagination via public API
+The system MUST list all menus with pagination via public API.
+
+**ID:** CMS-010 — Priority: Must — Status: Implemented
+
+### Requirement: Retrieve a single menu by ID
+The system MUST retrieve a single menu by ID.
+
+**ID:** CMS-011 — Priority: Must — Status: Implemented
+
+### Requirement: Menus support hierarchical items with sub-items
+Menus MUST support hierarchical items with sub-items.
+
+**ID:** CMS-012 — Priority: Must — Status: Implemented
+
+### Requirement: Menu items support group-based visibility (groups, hideAfterLogin, hideBeforeLogin)
+Menu items SHOULD support group-based visibility (groups, hideAfterLogin, hideBeforeLogin).
+
+**ID:** CMS-013 — Priority: Should — Status: Implemented
+
+### Requirement: Menu configuration stored in IAppConfig as `menu_schema` and `menu_register`
+Menu configuration MUST be stored in IAppConfig as `menu_schema` and `menu_register`.
+
+**ID:** CMS-014 — Priority: Must — Status: Implemented
+
+### Requirement: Default fallback: menu schema ID 7, register ID 1 when not configured
+The system SHOULD default to menu schema ID 7 and register ID 1 when not configured.
+
+**ID:** CMS-015 — Priority: Should — Status: Implemented
+
+### Requirement: CORS headers included on all menu endpoints
+CORS headers MUST be included on all menu endpoints.
+
+**ID:** CMS-016 — Priority: Must — Status: Implemented
+
+<!-- Themes -->
+
+### Requirement: List all themes with pagination and facets via public API
+The system MUST list all themes with pagination and facets via public API.
+
+**ID:** CMS-020 — Priority: Must — Status: Implemented
+
+### Requirement: Retrieve a single theme by ID
+The system MUST retrieve a single theme by ID.
+
+**ID:** CMS-021 — Priority: Must — Status: Implemented
+
+### Requirement: Theme configuration stored in IAppConfig as `theme_schema` and `theme_register`
+Theme configuration MUST be stored in IAppConfig as `theme_schema` and `theme_register`.
+
+**ID:** CMS-022 — Priority: Must — Status: Implemented
+
+### Requirement: Themes include display fields (image, icon, link, url, sort, isExternal)
+Themes MUST include display fields (image, icon, link, url, sort, isExternal).
+
+**ID:** CMS-023 — Priority: Must — Status: Implemented
+
+### Requirement: CORS headers included on all theme endpoints
+CORS headers MUST be included on all theme endpoints.
+
+**ID:** CMS-024 — Priority: Must — Status: Implemented
+
+<!-- Glossary -->
+
+### Requirement: List all glossary terms with pagination and facets via public API
+The system MUST list all glossary terms with pagination and facets via public API.
+
+**ID:** CMS-030 — Priority: Must — Status: Implemented
+
+### Requirement: Retrieve a single glossary term by ID
+The system MUST retrieve a single glossary term by ID.
+
+**ID:** CMS-031 — Priority: Must — Status: Implemented
+
+### Requirement: Glossary configuration stored in IAppConfig as `glossary_schema` and `glossary_register`
+Glossary configuration MUST be stored in IAppConfig as `glossary_schema` and `glossary_register`.
+
+**ID:** CMS-032 — Priority: Must — Status: Implemented
+
+### Requirement: Glossary queries force `_source: database` (no Solr dependency)
+Glossary queries MUST force `_source: database` (no Solr dependency).
+
+**ID:** CMS-033 — Priority: Must — Status: Implemented
+
+### Requirement: Glossary terms do not use publishing workflow (published=false in queries)
+Glossary terms MUST NOT use the publishing workflow (published=false in queries).
+
+**ID:** CMS-034 — Priority: Must — Status: Implemented
+
+### Requirement: CORS headers included on all glossary endpoints
+CORS headers MUST be included on all glossary endpoints.
+
+**ID:** CMS-035 — Priority: Must — Status: Implemented
 
 ## Data Model
 

--- a/openspec/specs/dashboard/spec.md
+++ b/openspec/specs/dashboard/spec.md
@@ -10,45 +10,136 @@ The dashboard provides the main entry point for the OpenCatalogi Nextcloud app, 
 
 ## Requirements
 
-### Dashboard and UI
+<!-- Dashboard and UI -->
 
-| ID | Requirement | Priority | Status |
-|----|------------|----------|--------|
-| DSH-001 | Serve the Vue SPA template for the main app page | Must | Implemented |
-| DSH-002 | Support deep-link routing for all SPA pages (catalogi, publications, search, themes, glossary, pages, menus, directory, organizations) | Must | Implemented |
-| DSH-003 | Content Security Policy allows connect to all domains (for federation HTTP requests) | Must | Implemented |
-| DSH-004 | Dashboard data endpoint returns basic status info | Should | Dead Code (route exists but controller method removed) |
-| DSH-005 | Application.php bootstrap registers dashboard widgets (CatalogWidget, UnpublishedPublicationsWidget, UnpublishedAttachmentsWidget) | Must | Implemented |
-| DSH-006 | Application.php bootstrap registers event listeners for OpenRegister events | Must | Implemented |
-| DSH-007 | Application.php bootstrap registers tool registration listener for AI agents | Must | Implemented |
-| DSH-008 | Application.php bootstrap loads vendor autoload for Composer dependencies | Must | Implemented |
+### Requirement: Serve the Vue SPA template for the main app page
+The system MUST serve the Vue SPA template for the main app page.
 
-### Listings (CRUD)
+**ID:** DSH-001 — Priority: Must — Status: Implemented
 
-| ID | Requirement | Priority | Status |
-|----|------------|----------|--------|
-| LST-001 | List all listings with pagination | Must | Implemented |
-| LST-002 | Get a single listing by ID (public endpoint) | Must | Implemented |
-| LST-003 | Create a new listing | Must | Implemented |
-| LST-004 | Update an existing listing | Must | Implemented |
-| LST-005 | Delete a listing | Must | Implemented |
-| LST-006 | Listing configuration stored in IAppConfig as `listing_schema` and `listing_register` | Must | Implemented |
+### Requirement: Support deep-link routing for all SPA pages (catalogi, publications, search, themes, glossary, pages, menus, directory, organizations)
+The system MUST support deep-link routing for all SPA pages (catalogi, publications, search, themes, glossary, pages, menus, directory, organizations).
 
-### Directory and Synchronization
+**ID:** DSH-002 — Priority: Must — Status: Implemented
 
-| ID | Requirement | Priority | Status |
-|----|------------|----------|--------|
-| DIR-001 | Get combined directory data from all listings | Must | Implemented |
-| DIR-002 | Synchronize with an external directory URL (POST with directory parameter) | Must | Implemented |
-| DIR-003 | Synchronize a specific listing's directory | Must | Implemented |
-| DIR-004 | Synchronize all directories via cron (every hour) | Must | Implemented |
-| DIR-005 | Add a new listing from a URL (public endpoint) | Must | Implemented |
-| DIR-006 | Anti-loop protection during broadcast sync cycles | Should | Implemented |
-| DIR-007 | Broadcast this directory to external instances (cron every 4 hours) | Should | Bug (Not Registered) |
-| DIR-008 | CORS support on directory endpoints | Must | Implemented |
-| DIR-009 | Publication endpoint auto-detection from directory URLs | Should | Implemented |
-| DIR-010 | Listing staleness checking during directory sync | Should | Implemented |
-| DIR-011 | Catalog-to-listing conversion during sync | Should | Implemented |
+### Requirement: Content Security Policy allows connect to all domains (for federation HTTP requests)
+The Content Security Policy MUST allow connect to all domains (for federation HTTP requests).
+
+**ID:** DSH-003 — Priority: Must — Status: Implemented
+
+### Requirement: Dashboard data endpoint returns basic status info
+The dashboard data endpoint SHOULD return basic status info.
+
+**ID:** DSH-004 — Priority: Should — Status: Dead Code (route exists but controller method removed)
+
+### Requirement: Application.php bootstrap registers dashboard widgets (CatalogWidget, UnpublishedPublicationsWidget, UnpublishedAttachmentsWidget)
+Application.php bootstrap MUST register dashboard widgets (CatalogWidget, UnpublishedPublicationsWidget, UnpublishedAttachmentsWidget).
+
+**ID:** DSH-005 — Priority: Must — Status: Implemented
+
+### Requirement: Application.php bootstrap registers event listeners for OpenRegister events
+Application.php bootstrap MUST register event listeners for OpenRegister events.
+
+**ID:** DSH-006 — Priority: Must — Status: Implemented
+
+### Requirement: Application.php bootstrap registers tool registration listener for AI agents
+Application.php bootstrap MUST register the tool registration listener for AI agents.
+
+**ID:** DSH-007 — Priority: Must — Status: Implemented
+
+### Requirement: Application.php bootstrap loads vendor autoload for Composer dependencies
+Application.php bootstrap MUST load vendor autoload for Composer dependencies.
+
+**ID:** DSH-008 — Priority: Must — Status: Implemented
+
+<!-- Listings (CRUD) -->
+
+### Requirement: List all listings with pagination
+The system MUST list all listings with pagination.
+
+**ID:** LST-001 — Priority: Must — Status: Implemented
+
+### Requirement: Get a single listing by ID (public endpoint)
+The system MUST get a single listing by ID (public endpoint).
+
+**ID:** LST-002 — Priority: Must — Status: Implemented
+
+### Requirement: Create a new listing
+The system MUST allow creating a new listing.
+
+**ID:** LST-003 — Priority: Must — Status: Implemented
+
+### Requirement: Update an existing listing
+The system MUST allow updating an existing listing.
+
+**ID:** LST-004 — Priority: Must — Status: Implemented
+
+### Requirement: Delete a listing
+The system MUST allow deleting a listing.
+
+**ID:** LST-005 — Priority: Must — Status: Implemented
+
+### Requirement: Listing configuration stored in IAppConfig as `listing_schema` and `listing_register`
+Listing configuration MUST be stored in IAppConfig as `listing_schema` and `listing_register`.
+
+**ID:** LST-006 — Priority: Must — Status: Implemented
+
+<!-- Directory and Synchronization -->
+
+### Requirement: Get combined directory data from all listings
+The system MUST get combined directory data from all listings.
+
+**ID:** DIR-001 — Priority: Must — Status: Implemented
+
+### Requirement: Synchronize with an external directory URL (POST with directory parameter)
+The system MUST synchronize with an external directory URL (POST with directory parameter).
+
+**ID:** DIR-002 — Priority: Must — Status: Implemented
+
+### Requirement: Synchronize a specific listing's directory
+The system MUST synchronize a specific listing's directory.
+
+**ID:** DIR-003 — Priority: Must — Status: Implemented
+
+### Requirement: Synchronize all directories via cron (every hour)
+The system MUST synchronize all directories via cron (every hour).
+
+**ID:** DIR-004 — Priority: Must — Status: Implemented
+
+### Requirement: Add a new listing from a URL (public endpoint)
+The system MUST allow adding a new listing from a URL (public endpoint).
+
+**ID:** DIR-005 — Priority: Must — Status: Implemented
+
+### Requirement: Anti-loop protection during broadcast sync cycles
+The system SHOULD provide anti-loop protection during broadcast sync cycles.
+
+**ID:** DIR-006 — Priority: Should — Status: Implemented
+
+### Requirement: Broadcast this directory to external instances (cron every 4 hours)
+The system SHOULD broadcast this directory to external instances (cron every 4 hours).
+
+**ID:** DIR-007 — Priority: Should — Status: Bug (Not Registered)
+
+### Requirement: CORS support on directory endpoints
+The system MUST support CORS on directory endpoints.
+
+**ID:** DIR-008 — Priority: Must — Status: Implemented
+
+### Requirement: Publication endpoint auto-detection from directory URLs
+The system SHOULD support publication endpoint auto-detection from directory URLs.
+
+**ID:** DIR-009 — Priority: Should — Status: Implemented
+
+### Requirement: Listing staleness checking during directory sync
+The system SHOULD perform listing staleness checking during directory sync.
+
+**ID:** DIR-010 — Priority: Should — Status: Implemented
+
+### Requirement: Catalog-to-listing conversion during sync
+The system SHOULD perform catalog-to-listing conversion during sync.
+
+**ID:** DIR-011 — Priority: Should — Status: Implemented
 
 ## DashboardController Dead Code (Gap 17)
 

--- a/openspec/specs/dashboard/spec.md
+++ b/openspec/specs/dashboard/spec.md
@@ -12,134 +12,134 @@ The dashboard provides the main entry point for the OpenCatalogi Nextcloud app, 
 
 <!-- Dashboard and UI -->
 
-### Requirement: Serve the Vue SPA template for the main app page
+### Requirement: Serve the Vue SPA template for the main app page (DSH-001)
 The system MUST serve the Vue SPA template for the main app page.
 
-**ID:** DSH-001 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Support deep-link routing for all SPA pages (catalogi, publications, search, themes, glossary, pages, menus, directory, organizations)
+### Requirement: Support deep-link routing for all SPA pages (catalogi, publications, search, themes, glossary, pages, menus, directory, organizations) (DSH-002)
 The system MUST support deep-link routing for all SPA pages (catalogi, publications, search, themes, glossary, pages, menus, directory, organizations).
 
-**ID:** DSH-002 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Content Security Policy allows connect to all domains (for federation HTTP requests)
+### Requirement: Content Security Policy allows connect to all domains (for federation HTTP requests) (DSH-003)
 The Content Security Policy MUST allow connect to all domains (for federation HTTP requests).
 
-**ID:** DSH-003 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Dashboard data endpoint returns basic status info
+### Requirement: Dashboard data endpoint returns basic status info (DSH-004)
 The dashboard data endpoint SHOULD return basic status info.
 
-**ID:** DSH-004 — Priority: Should — Status: Dead Code (route exists but controller method removed)
+**Priority:** Should **Status:** Dead Code (route exists but controller method removed)
 
-### Requirement: Application.php bootstrap registers dashboard widgets (CatalogWidget, UnpublishedPublicationsWidget, UnpublishedAttachmentsWidget)
+### Requirement: Application.php bootstrap registers dashboard widgets (CatalogWidget, UnpublishedPublicationsWidget, UnpublishedAttachmentsWidget) (DSH-005)
 Application.php bootstrap MUST register dashboard widgets (CatalogWidget, UnpublishedPublicationsWidget, UnpublishedAttachmentsWidget).
 
-**ID:** DSH-005 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Application.php bootstrap registers event listeners for OpenRegister events
+### Requirement: Application.php bootstrap registers event listeners for OpenRegister events (DSH-006)
 Application.php bootstrap MUST register event listeners for OpenRegister events.
 
-**ID:** DSH-006 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Application.php bootstrap registers tool registration listener for AI agents
+### Requirement: Application.php bootstrap registers tool registration listener for AI agents (DSH-007)
 Application.php bootstrap MUST register the tool registration listener for AI agents.
 
-**ID:** DSH-007 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Application.php bootstrap loads vendor autoload for Composer dependencies
+### Requirement: Application.php bootstrap loads vendor autoload for Composer dependencies (DSH-008)
 Application.php bootstrap MUST load vendor autoload for Composer dependencies.
 
-**ID:** DSH-008 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
 <!-- Listings (CRUD) -->
 
-### Requirement: List all listings with pagination
+### Requirement: List all listings with pagination (LST-001)
 The system MUST list all listings with pagination.
 
-**ID:** LST-001 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Get a single listing by ID (public endpoint)
+### Requirement: Get a single listing by ID (public endpoint) (LST-002)
 The system MUST get a single listing by ID (public endpoint).
 
-**ID:** LST-002 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Create a new listing
+### Requirement: Create a new listing (LST-003)
 The system MUST allow creating a new listing.
 
-**ID:** LST-003 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Update an existing listing
+### Requirement: Update an existing listing (LST-004)
 The system MUST allow updating an existing listing.
 
-**ID:** LST-004 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Delete a listing
+### Requirement: Delete a listing (LST-005)
 The system MUST allow deleting a listing.
 
-**ID:** LST-005 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Listing configuration stored in IAppConfig as `listing_schema` and `listing_register`
+### Requirement: Listing configuration stored in IAppConfig as `listing_schema` and `listing_register` (LST-006)
 Listing configuration MUST be stored in IAppConfig as `listing_schema` and `listing_register`.
 
-**ID:** LST-006 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
 <!-- Directory and Synchronization -->
 
-### Requirement: Get combined directory data from all listings
+### Requirement: Get combined directory data from all listings (DIR-001)
 The system MUST get combined directory data from all listings.
 
-**ID:** DIR-001 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Synchronize with an external directory URL (POST with directory parameter)
+### Requirement: Synchronize with an external directory URL (POST with directory parameter) (DIR-002)
 The system MUST synchronize with an external directory URL (POST with directory parameter).
 
-**ID:** DIR-002 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Synchronize a specific listing's directory
+### Requirement: Synchronize a specific listing's directory (DIR-003)
 The system MUST synchronize a specific listing's directory.
 
-**ID:** DIR-003 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Synchronize all directories via cron (every hour)
+### Requirement: Synchronize all directories via cron (every hour) (DIR-004)
 The system MUST synchronize all directories via cron (every hour).
 
-**ID:** DIR-004 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Add a new listing from a URL (public endpoint)
+### Requirement: Add a new listing from a URL (public endpoint) (DIR-005)
 The system MUST allow adding a new listing from a URL (public endpoint).
 
-**ID:** DIR-005 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Anti-loop protection during broadcast sync cycles
+### Requirement: Anti-loop protection during broadcast sync cycles (DIR-006)
 The system SHOULD provide anti-loop protection during broadcast sync cycles.
 
-**ID:** DIR-006 — Priority: Should — Status: Implemented
+**Priority:** Should **Status:** Implemented
 
-### Requirement: Broadcast this directory to external instances (cron every 4 hours)
+### Requirement: Broadcast this directory to external instances (cron every 4 hours) (DIR-007)
 The system SHOULD broadcast this directory to external instances (cron every 4 hours).
 
-**ID:** DIR-007 — Priority: Should — Status: Bug (Not Registered)
+**Priority:** Should **Status:** Bug (Not Registered)
 
-### Requirement: CORS support on directory endpoints
+### Requirement: CORS support on directory endpoints (DIR-008)
 The system MUST support CORS on directory endpoints.
 
-**ID:** DIR-008 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Publication endpoint auto-detection from directory URLs
+### Requirement: Publication endpoint auto-detection from directory URLs (DIR-009)
 The system SHOULD support publication endpoint auto-detection from directory URLs.
 
-**ID:** DIR-009 — Priority: Should — Status: Implemented
+**Priority:** Should **Status:** Implemented
 
-### Requirement: Listing staleness checking during directory sync
+### Requirement: Listing staleness checking during directory sync (DIR-010)
 The system SHOULD perform listing staleness checking during directory sync.
 
-**ID:** DIR-010 — Priority: Should — Status: Implemented
+**Priority:** Should **Status:** Implemented
 
-### Requirement: Catalog-to-listing conversion during sync
+### Requirement: Catalog-to-listing conversion during sync (DIR-011)
 The system SHOULD perform catalog-to-listing conversion during sync.
 
-**ID:** DIR-011 — Priority: Should — Status: Implemented
+**Priority:** Should **Status:** Implemented
 
 ## DashboardController Dead Code (Gap 17)
 

--- a/openspec/specs/download-service/spec.md
+++ b/openspec/specs/download-service/spec.md
@@ -10,55 +10,55 @@ The Download Service provides functionality for generating downloadable export f
 
 ## Requirements
 
-### Requirement: Generate a PDF file containing all metadata of a publication
+### Requirement: Generate a PDF file containing all metadata of a publication (DWN-001)
 The system MUST generate a PDF file containing all metadata of a publication.
 
-**ID:** DWN-001 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Save generated PDF to Nextcloud file storage in structured folder hierarchy
+### Requirement: Save generated PDF to Nextcloud file storage in structured folder hierarchy (DWN-002)
 The system SHOULD save generated PDFs to Nextcloud file storage in a structured folder hierarchy.
 
-**ID:** DWN-002 — Priority: Should — Status: Implemented
+**Priority:** Should **Status:** Implemented
 
-### Requirement: Create and return share links for saved files
+### Requirement: Create and return share links for saved files (DWN-003)
 The system SHOULD create and return share links for saved files.
 
-**ID:** DWN-003 — Priority: Should — Status: Implemented
+**Priority:** Should **Status:** Implemented
 
-### Requirement: Support direct download response for generated PDFs
+### Requirement: Support direct download response for generated PDFs (DWN-004)
 The system SHOULD support direct download response for generated PDFs.
 
-**ID:** DWN-004 — Priority: Should — Status: Implemented
+**Priority:** Should **Status:** Implemented
 
-### Requirement: Generate ZIP archive containing metadata PDF and all publication attachments
+### Requirement: Generate ZIP archive containing metadata PDF and all publication attachments (DWN-005)
 The system MUST generate a ZIP archive containing the metadata PDF and all publication attachments.
 
-**ID:** DWN-005 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Organize ZIP contents with attachments in a "Bijlagen" subfolder
+### Requirement: Organize ZIP contents with attachments in a "Bijlagen" subfolder (DWN-006)
 The system MUST organize ZIP contents with attachments in a "Bijlagen" subfolder.
 
-**ID:** DWN-006 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Support configurable options: download-only, save-to-Nextcloud, or both
+### Requirement: Support configurable options: download-only, save-to-Nextcloud, or both (DWN-007)
 The system SHOULD support configurable options: download-only, save-to-Nextcloud, or both.
 
-**ID:** DWN-007 — Priority: Should — Status: Implemented
+**Priority:** Should **Status:** Implemented
 
-### Requirement: Validate that at least one output option (download or saveToNextCloud) is enabled
+### Requirement: Validate that at least one output option (download or saveToNextCloud) is enabled (DWN-008)
 The system MUST validate that at least one output option (download or saveToNextCloud) is enabled.
 
-**ID:** DWN-008 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Clean up temporary files after ZIP/PDF generation
+### Requirement: Clean up temporary files after ZIP/PDF generation (DWN-009)
 The system SHOULD clean up temporary files after ZIP/PDF generation.
 
-**ID:** DWN-009 — Priority: Should — Status: Implemented
+**Priority:** Should **Status:** Implemented
 
-### Requirement: Handle missing publications with appropriate error responses
+### Requirement: Handle missing publications with appropriate error responses (DWN-010)
 The system MUST handle missing publications with appropriate error responses.
 
-**ID:** DWN-010 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
 ## Architecture
 

--- a/openspec/specs/download-service/spec.md
+++ b/openspec/specs/download-service/spec.md
@@ -10,18 +10,55 @@ The Download Service provides functionality for generating downloadable export f
 
 ## Requirements
 
-| ID | Requirement | Priority | Status |
-|----|------------|----------|--------|
-| DWN-001 | Generate a PDF file containing all metadata of a publication | Must | Implemented |
-| DWN-002 | Save generated PDF to Nextcloud file storage in structured folder hierarchy | Should | Implemented |
-| DWN-003 | Create and return share links for saved files | Should | Implemented |
-| DWN-004 | Support direct download response for generated PDFs | Should | Implemented |
-| DWN-005 | Generate ZIP archive containing metadata PDF and all publication attachments | Must | Implemented |
-| DWN-006 | Organize ZIP contents with attachments in a "Bijlagen" subfolder | Must | Implemented |
-| DWN-007 | Support configurable options: download-only, save-to-Nextcloud, or both | Should | Implemented |
-| DWN-008 | Validate that at least one output option (download or saveToNextCloud) is enabled | Must | Implemented |
-| DWN-009 | Clean up temporary files after ZIP/PDF generation | Should | Implemented |
-| DWN-010 | Handle missing publications with appropriate error responses | Must | Implemented |
+### Requirement: Generate a PDF file containing all metadata of a publication
+The system MUST generate a PDF file containing all metadata of a publication.
+
+**ID:** DWN-001 — Priority: Must — Status: Implemented
+
+### Requirement: Save generated PDF to Nextcloud file storage in structured folder hierarchy
+The system SHOULD save generated PDFs to Nextcloud file storage in a structured folder hierarchy.
+
+**ID:** DWN-002 — Priority: Should — Status: Implemented
+
+### Requirement: Create and return share links for saved files
+The system SHOULD create and return share links for saved files.
+
+**ID:** DWN-003 — Priority: Should — Status: Implemented
+
+### Requirement: Support direct download response for generated PDFs
+The system SHOULD support direct download response for generated PDFs.
+
+**ID:** DWN-004 — Priority: Should — Status: Implemented
+
+### Requirement: Generate ZIP archive containing metadata PDF and all publication attachments
+The system MUST generate a ZIP archive containing the metadata PDF and all publication attachments.
+
+**ID:** DWN-005 — Priority: Must — Status: Implemented
+
+### Requirement: Organize ZIP contents with attachments in a "Bijlagen" subfolder
+The system MUST organize ZIP contents with attachments in a "Bijlagen" subfolder.
+
+**ID:** DWN-006 — Priority: Must — Status: Implemented
+
+### Requirement: Support configurable options: download-only, save-to-Nextcloud, or both
+The system SHOULD support configurable options: download-only, save-to-Nextcloud, or both.
+
+**ID:** DWN-007 — Priority: Should — Status: Implemented
+
+### Requirement: Validate that at least one output option (download or saveToNextCloud) is enabled
+The system MUST validate that at least one output option (download or saveToNextCloud) is enabled.
+
+**ID:** DWN-008 — Priority: Must — Status: Implemented
+
+### Requirement: Clean up temporary files after ZIP/PDF generation
+The system SHOULD clean up temporary files after ZIP/PDF generation.
+
+**ID:** DWN-009 — Priority: Should — Status: Implemented
+
+### Requirement: Handle missing publications with appropriate error responses
+The system MUST handle missing publications with appropriate error responses.
+
+**ID:** DWN-010 — Priority: Must — Status: Implemented
 
 ## Architecture
 

--- a/openspec/specs/federation/spec.md
+++ b/openspec/specs/federation/spec.md
@@ -10,20 +10,65 @@ Federation enables OpenCatalogi to aggregate publications from both local catalo
 
 ## Requirements
 
-| ID | Requirement | Priority | Status |
-|----|------------|----------|--------|
-| FED-001 | List all publications from local and federated sources with merged pagination | Must | Implemented |
-| FED-002 | Retrieve a single publication by ID from local or federated sources | Must | Implemented |
-| FED-003 | Retrieve outgoing relations (uses) with federation support | Must | Implemented |
-| FED-004 | Retrieve incoming relations (used-by) with federation support | Must | Implemented |
-| FED-005 | Retrieve publication attachments from local or federated sources | Must | Implemented |
-| FED-006 | Download publication files from local or federated sources | Must | Implemented |
-| FED-007 | All federation endpoints must be public (no auth required) | Must | Implemented |
-| FED-008 | Federation aggregation uses async HTTP requests to remote directories | Should | Implemented |
-| FED-009 | Directory listings provide the directory URLs for remote instances | Must | Implemented |
-| FED-010 | Listings with `integrationLevel: "search"` are included in federated search | Should | Implemented |
-| FED-011 | Sort merged results by relevance score (`_score`) | Should | Implemented |
-| FED-012 | All federation publication endpoints have corresponding routes in routes.php | Must | Implemented |
+### Requirement: List all publications from local and federated sources with merged pagination
+The system MUST list all publications from local and federated sources with merged pagination.
+
+**ID:** FED-001 — Priority: Must — Status: Implemented
+
+### Requirement: Retrieve a single publication by ID from local or federated sources
+The system MUST retrieve a single publication by ID from local or federated sources.
+
+**ID:** FED-002 — Priority: Must — Status: Implemented
+
+### Requirement: Retrieve outgoing relations (uses) with federation support
+The system MUST retrieve outgoing relations (uses) with federation support.
+
+**ID:** FED-003 — Priority: Must — Status: Implemented
+
+### Requirement: Retrieve incoming relations (used-by) with federation support
+The system MUST retrieve incoming relations (used-by) with federation support.
+
+**ID:** FED-004 — Priority: Must — Status: Implemented
+
+### Requirement: Retrieve publication attachments from local or federated sources
+The system MUST retrieve publication attachments from local or federated sources.
+
+**ID:** FED-005 — Priority: Must — Status: Implemented
+
+### Requirement: Download publication files from local or federated sources
+The system MUST allow downloading publication files from local or federated sources.
+
+**ID:** FED-006 — Priority: Must — Status: Implemented
+
+### Requirement: All federation endpoints must be public (no auth required)
+All federation endpoints MUST be public (no auth required).
+
+**ID:** FED-007 — Priority: Must — Status: Implemented
+
+### Requirement: Federation aggregation uses async HTTP requests to remote directories
+Federation aggregation SHOULD use async HTTP requests to remote directories.
+
+**ID:** FED-008 — Priority: Should — Status: Implemented
+
+### Requirement: Directory listings provide the directory URLs for remote instances
+Directory listings MUST provide the directory URLs for remote instances.
+
+**ID:** FED-009 — Priority: Must — Status: Implemented
+
+### Requirement: Listings with `integrationLevel: "search"` are included in federated search
+Listings with `integrationLevel: "search"` SHOULD be included in federated search.
+
+**ID:** FED-010 — Priority: Should — Status: Implemented
+
+### Requirement: Sort merged results by relevance score (`_score`)
+The system SHOULD sort merged results by relevance score (`_score`).
+
+**ID:** FED-011 — Priority: Should — Status: Implemented
+
+### Requirement: All federation publication endpoints have corresponding routes in routes.php
+All federation publication endpoints MUST have corresponding routes in routes.php.
+
+**ID:** FED-012 — Priority: Must — Status: Implemented
 
 ## Data Model
 

--- a/openspec/specs/federation/spec.md
+++ b/openspec/specs/federation/spec.md
@@ -10,65 +10,65 @@ Federation enables OpenCatalogi to aggregate publications from both local catalo
 
 ## Requirements
 
-### Requirement: List all publications from local and federated sources with merged pagination
+### Requirement: List all publications from local and federated sources with merged pagination (FED-001)
 The system MUST list all publications from local and federated sources with merged pagination.
 
-**ID:** FED-001 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Retrieve a single publication by ID from local or federated sources
+### Requirement: Retrieve a single publication by ID from local or federated sources (FED-002)
 The system MUST retrieve a single publication by ID from local or federated sources.
 
-**ID:** FED-002 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Retrieve outgoing relations (uses) with federation support
+### Requirement: Retrieve outgoing relations (uses) with federation support (FED-003)
 The system MUST retrieve outgoing relations (uses) with federation support.
 
-**ID:** FED-003 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Retrieve incoming relations (used-by) with federation support
+### Requirement: Retrieve incoming relations (used-by) with federation support (FED-004)
 The system MUST retrieve incoming relations (used-by) with federation support.
 
-**ID:** FED-004 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Retrieve publication attachments from local or federated sources
+### Requirement: Retrieve publication attachments from local or federated sources (FED-005)
 The system MUST retrieve publication attachments from local or federated sources.
 
-**ID:** FED-005 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Download publication files from local or federated sources
+### Requirement: Download publication files from local or federated sources (FED-006)
 The system MUST allow downloading publication files from local or federated sources.
 
-**ID:** FED-006 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: All federation endpoints must be public (no auth required)
+### Requirement: All federation endpoints must be public (no auth required) (FED-007)
 All federation endpoints MUST be public (no auth required).
 
-**ID:** FED-007 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Federation aggregation uses async HTTP requests to remote directories
+### Requirement: Federation aggregation uses async HTTP requests to remote directories (FED-008)
 Federation aggregation SHOULD use async HTTP requests to remote directories.
 
-**ID:** FED-008 — Priority: Should — Status: Implemented
+**Priority:** Should **Status:** Implemented
 
-### Requirement: Directory listings provide the directory URLs for remote instances
+### Requirement: Directory listings provide the directory URLs for remote instances (FED-009)
 Directory listings MUST provide the directory URLs for remote instances.
 
-**ID:** FED-009 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Listings with `integrationLevel: "search"` are included in federated search
+### Requirement: Listings with `integrationLevel: "search"` are included in federated search (FED-010)
 Listings with `integrationLevel: "search"` SHOULD be included in federated search.
 
-**ID:** FED-010 — Priority: Should — Status: Implemented
+**Priority:** Should **Status:** Implemented
 
-### Requirement: Sort merged results by relevance score (`_score`)
+### Requirement: Sort merged results by relevance score (`_score`) (FED-011)
 The system SHOULD sort merged results by relevance score (`_score`).
 
-**ID:** FED-011 — Priority: Should — Status: Implemented
+**Priority:** Should **Status:** Implemented
 
-### Requirement: All federation publication endpoints have corresponding routes in routes.php
+### Requirement: All federation publication endpoints have corresponding routes in routes.php (FED-012)
 All federation publication endpoints MUST have corresponding routes in routes.php.
 
-**ID:** FED-012 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
 ## Data Model
 

--- a/openspec/specs/file-management/spec.md
+++ b/openspec/specs/file-management/spec.md
@@ -10,23 +10,80 @@ The File Management service provides all file-related operations for OpenCatalog
 
 ## Requirements
 
-| ID | Requirement | Priority | Status |
-|----|------------|----------|--------|
-| FIL-001 | Create folders in Nextcloud user storage, skip if already exists | Must | Implemented |
-| FIL-002 | Upload new files to Nextcloud user storage (fail if file already exists) | Must | Implemented |
-| FIL-003 | Update/overwrite existing files, optionally create if not exists | Must | Implemented |
-| FIL-004 | Delete files from Nextcloud user storage | Must | Implemented |
-| FIL-005 | Create public share links (IShare type 3) for files with configurable permissions | Must | Implemented |
-| FIL-006 | Find existing share links for a file path | Must | Implemented |
-| FIL-007 | Return full share link URLs including protocol and domain | Must | Implemented |
-| FIL-008 | Handle HTTP file uploads via `_file` key in multipart requests | Must | Implemented |
-| FIL-009 | Create structured folder hierarchy for publications: `Publicaties/{id} {title}/Bijlagen/` | Must | Implemented |
-| FIL-010 | Add file metadata (reference, type, size, title, extension, accessUrl, downloadUrl) to data arrays | Must | Implemented |
-| FIL-011 | Generate PDFs using Twig templates and mPDF library | Must | Implemented |
-| FIL-012 | Create ZIP archives from folder contents | Must | Implemented |
-| FIL-013 | Send ZIP archives as download responses with proper headers | Must | Implemented |
-| FIL-014 | Clean up temporary files after ZIP operations | Should | Implemented |
-| FIL-015 | Memory limit set to 2048M for large file operations | Should | Implemented |
+### Requirement: Create folders in Nextcloud user storage, skip if already exists
+The system MUST create folders in Nextcloud user storage and skip if they already exist.
+
+**ID:** FIL-001 — Priority: Must — Status: Implemented
+
+### Requirement: Upload new files to Nextcloud user storage (fail if file already exists)
+The system MUST upload new files to Nextcloud user storage (and MUST fail if the file already exists).
+
+**ID:** FIL-002 — Priority: Must — Status: Implemented
+
+### Requirement: Update/overwrite existing files, optionally create if not exists
+The system MUST update/overwrite existing files, optionally creating them if not exists.
+
+**ID:** FIL-003 — Priority: Must — Status: Implemented
+
+### Requirement: Delete files from Nextcloud user storage
+The system MUST allow deleting files from Nextcloud user storage.
+
+**ID:** FIL-004 — Priority: Must — Status: Implemented
+
+### Requirement: Create public share links (IShare type 3) for files with configurable permissions
+The system MUST create public share links (IShare type 3) for files with configurable permissions.
+
+**ID:** FIL-005 — Priority: Must — Status: Implemented
+
+### Requirement: Find existing share links for a file path
+The system MUST be able to find existing share links for a file path.
+
+**ID:** FIL-006 — Priority: Must — Status: Implemented
+
+### Requirement: Return full share link URLs including protocol and domain
+The system MUST return full share link URLs including protocol and domain.
+
+**ID:** FIL-007 — Priority: Must — Status: Implemented
+
+### Requirement: Handle HTTP file uploads via `_file` key in multipart requests
+The system MUST handle HTTP file uploads via the `_file` key in multipart requests.
+
+**ID:** FIL-008 — Priority: Must — Status: Implemented
+
+### Requirement: Create structured folder hierarchy for publications: `Publicaties/{id} {title}/Bijlagen/`
+The system MUST create a structured folder hierarchy for publications: `Publicaties/{id} {title}/Bijlagen/`.
+
+**ID:** FIL-009 — Priority: Must — Status: Implemented
+
+### Requirement: Add file metadata (reference, type, size, title, extension, accessUrl, downloadUrl) to data arrays
+The system MUST add file metadata (reference, type, size, title, extension, accessUrl, downloadUrl) to data arrays.
+
+**ID:** FIL-010 — Priority: Must — Status: Implemented
+
+### Requirement: Generate PDFs using Twig templates and mPDF library
+The system MUST generate PDFs using Twig templates and the mPDF library.
+
+**ID:** FIL-011 — Priority: Must — Status: Implemented
+
+### Requirement: Create ZIP archives from folder contents
+The system MUST create ZIP archives from folder contents.
+
+**ID:** FIL-012 — Priority: Must — Status: Implemented
+
+### Requirement: Send ZIP archives as download responses with proper headers
+The system MUST send ZIP archives as download responses with proper headers.
+
+**ID:** FIL-013 — Priority: Must — Status: Implemented
+
+### Requirement: Clean up temporary files after ZIP operations
+The system SHOULD clean up temporary files after ZIP operations.
+
+**ID:** FIL-014 — Priority: Should — Status: Implemented
+
+### Requirement: Memory limit set to 2048M for large file operations
+The system SHOULD set the memory limit to 2048M for large file operations.
+
+**ID:** FIL-015 — Priority: Should — Status: Implemented
 
 ## Architecture
 

--- a/openspec/specs/file-management/spec.md
+++ b/openspec/specs/file-management/spec.md
@@ -10,80 +10,80 @@ The File Management service provides all file-related operations for OpenCatalog
 
 ## Requirements
 
-### Requirement: Create folders in Nextcloud user storage, skip if already exists
+### Requirement: Create folders in Nextcloud user storage, skip if already exists (FIL-001)
 The system MUST create folders in Nextcloud user storage and skip if they already exist.
 
-**ID:** FIL-001 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Upload new files to Nextcloud user storage (fail if file already exists)
+### Requirement: Upload new files to Nextcloud user storage (fail if file already exists) (FIL-002)
 The system MUST upload new files to Nextcloud user storage (and MUST fail if the file already exists).
 
-**ID:** FIL-002 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Update/overwrite existing files, optionally create if not exists
+### Requirement: Update/overwrite existing files, optionally create if not exists (FIL-003)
 The system MUST update/overwrite existing files, optionally creating them if not exists.
 
-**ID:** FIL-003 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Delete files from Nextcloud user storage
+### Requirement: Delete files from Nextcloud user storage (FIL-004)
 The system MUST allow deleting files from Nextcloud user storage.
 
-**ID:** FIL-004 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Create public share links (IShare type 3) for files with configurable permissions
+### Requirement: Create public share links (IShare type 3) for files with configurable permissions (FIL-005)
 The system MUST create public share links (IShare type 3) for files with configurable permissions.
 
-**ID:** FIL-005 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Find existing share links for a file path
+### Requirement: Find existing share links for a file path (FIL-006)
 The system MUST be able to find existing share links for a file path.
 
-**ID:** FIL-006 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Return full share link URLs including protocol and domain
+### Requirement: Return full share link URLs including protocol and domain (FIL-007)
 The system MUST return full share link URLs including protocol and domain.
 
-**ID:** FIL-007 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Handle HTTP file uploads via `_file` key in multipart requests
+### Requirement: Handle HTTP file uploads via `_file` key in multipart requests (FIL-008)
 The system MUST handle HTTP file uploads via the `_file` key in multipart requests.
 
-**ID:** FIL-008 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Create structured folder hierarchy for publications: `Publicaties/{id} {title}/Bijlagen/`
+### Requirement: Create structured folder hierarchy for publications: `Publicaties/{id} {title}/Bijlagen/` (FIL-009)
 The system MUST create a structured folder hierarchy for publications: `Publicaties/{id} {title}/Bijlagen/`.
 
-**ID:** FIL-009 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Add file metadata (reference, type, size, title, extension, accessUrl, downloadUrl) to data arrays
+### Requirement: Add file metadata (reference, type, size, title, extension, accessUrl, downloadUrl) to data arrays (FIL-010)
 The system MUST add file metadata (reference, type, size, title, extension, accessUrl, downloadUrl) to data arrays.
 
-**ID:** FIL-010 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Generate PDFs using Twig templates and mPDF library
+### Requirement: Generate PDFs using Twig templates and mPDF library (FIL-011)
 The system MUST generate PDFs using Twig templates and the mPDF library.
 
-**ID:** FIL-011 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Create ZIP archives from folder contents
+### Requirement: Create ZIP archives from folder contents (FIL-012)
 The system MUST create ZIP archives from folder contents.
 
-**ID:** FIL-012 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Send ZIP archives as download responses with proper headers
+### Requirement: Send ZIP archives as download responses with proper headers (FIL-013)
 The system MUST send ZIP archives as download responses with proper headers.
 
-**ID:** FIL-013 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Clean up temporary files after ZIP operations
+### Requirement: Clean up temporary files after ZIP operations (FIL-014)
 The system SHOULD clean up temporary files after ZIP operations.
 
-**ID:** FIL-014 — Priority: Should — Status: Implemented
+**Priority:** Should **Status:** Implemented
 
-### Requirement: Memory limit set to 2048M for large file operations
+### Requirement: Memory limit set to 2048M for large file operations (FIL-015)
 The system SHOULD set the memory limit to 2048M for large file operations.
 
-**ID:** FIL-015 — Priority: Should — Status: Implemented
+**Priority:** Should **Status:** Implemented
 
 ## Architecture
 

--- a/openspec/specs/publications/spec.md
+++ b/openspec/specs/publications/spec.md
@@ -10,80 +10,80 @@ Publications are the core content objects in OpenCatalogi. They represent indivi
 
 ## Requirements
 
-### Requirement: List publications scoped to a catalog slug with pagination and facets
+### Requirement: List publications scoped to a catalog slug with pagination and facets (PUB-001)
 The system MUST list publications scoped to a catalog slug with pagination and facets.
 
-**ID:** PUB-001 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Retrieve a single publication by catalog slug and object UUID
+### Requirement: Retrieve a single publication by catalog slug and object UUID (PUB-002)
 The system MUST retrieve a single publication by catalog slug and object UUID.
 
-**ID:** PUB-002 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Publication list endpoint must filter by the catalog's configured registers and schemas
+### Requirement: Publication list endpoint must filter by the catalog's configured registers and schemas (PUB-003)
 The publication list endpoint MUST filter by the catalog's configured registers and schemas.
 
-**ID:** PUB-003 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Support multi-schema catalogs with UNION-based search across multiple magic tables
+### Requirement: Support multi-schema catalogs with UNION-based search across multiple magic tables (PUB-004)
 The system MUST support multi-schema catalogs with UNION-based search across multiple magic tables.
 
-**ID:** PUB-004 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Support `_extend` parameter for including related object data
+### Requirement: Support `_extend` parameter for including related object data (PUB-005)
 The system SHOULD support the `_extend` parameter for including related object data.
 
-**ID:** PUB-005 — Priority: Should — Status: Implemented
+**Priority:** Should **Status:** Implemented
 
-### Requirement: Retrieve publication attachments (files linked to a publication)
+### Requirement: Retrieve publication attachments (files linked to a publication) (PUB-006)
 The system MUST retrieve publication attachments (files linked to a publication).
 
-**ID:** PUB-006 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Download publication files
+### Requirement: Download publication files (PUB-007)
 The system MUST allow downloading publication files.
 
-**ID:** PUB-007 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Retrieve outgoing relations (objects this publication references) via `/uses`
+### Requirement: Retrieve outgoing relations (objects this publication references) via `/uses` (PUB-008)
 The system MUST retrieve outgoing relations (objects this publication references) via `/uses`.
 
-**ID:** PUB-008 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Retrieve incoming relations (objects that reference this publication) via `/used`
+### Requirement: Retrieve incoming relations (objects that reference this publication) via `/used` (PUB-009)
 The system MUST retrieve incoming relations (objects that reference this publication) via `/used`.
 
-**ID:** PUB-009 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: All public endpoints must include CORS headers
+### Requirement: All public endpoints must include CORS headers (PUB-010)
 All public endpoints MUST include CORS headers.
 
-**ID:** PUB-010 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Return 404 with descriptive error when catalog slug or publication ID not found
+### Requirement: Return 404 with descriptive error when catalog slug or publication ID not found (PUB-011)
 The system MUST return 404 with a descriptive error when the catalog slug or publication ID is not found.
 
-**ID:** PUB-011 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Publication endpoints use wildcard `{catalogSlug}` routes (must be last in route order)
+### Requirement: Publication endpoints use wildcard `{catalogSlug}` routes (must be last in route order) (PUB-012)
 Publication endpoints MUST use wildcard `{catalogSlug}` routes (which MUST be last in route order).
 
-**ID:** PUB-012 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Support filter parameter extraction from various formats (single, array, OR/AND operators)
+### Requirement: Support filter parameter extraction from various formats (single, array, OR/AND operators) (PUB-013)
 The system SHOULD support filter parameter extraction from various formats (single, array, OR/AND operators).
 
-**ID:** PUB-013 — Priority: Should — Status: Implemented
+**Priority:** Should **Status:** Implemented
 
-### Requirement: Fallback object location lookup across all magic tables when catalog register/schema search fails
+### Requirement: Fallback object location lookup across all magic tables when catalog register/schema search fails (PUB-014)
 The system SHOULD perform a fallback object location lookup across all magic tables when the catalog register/schema search fails.
 
-**ID:** PUB-014 — Priority: Should — Status: Implemented
+**Priority:** Should **Status:** Implemented
 
-### Requirement: Schema authorization (RBAC) is enabled on the publication list for conditional access rules
+### Requirement: Schema authorization (RBAC) is enabled on the publication list for conditional access rules (PUB-015)
 Schema authorization (RBAC) SHOULD be enabled on the publication list for conditional access rules.
 
-**ID:** PUB-015 — Priority: Should — Status: Implemented
+**Priority:** Should **Status:** Implemented
 
 ## Data Model
 

--- a/openspec/specs/publications/spec.md
+++ b/openspec/specs/publications/spec.md
@@ -10,23 +10,80 @@ Publications are the core content objects in OpenCatalogi. They represent indivi
 
 ## Requirements
 
-| ID | Requirement | Priority | Status |
-|----|------------|----------|--------|
-| PUB-001 | List publications scoped to a catalog slug with pagination and facets | Must | Implemented |
-| PUB-002 | Retrieve a single publication by catalog slug and object UUID | Must | Implemented |
-| PUB-003 | Publication list endpoint must filter by the catalog's configured registers and schemas | Must | Implemented |
-| PUB-004 | Support multi-schema catalogs with UNION-based search across multiple magic tables | Must | Implemented |
-| PUB-005 | Support `_extend` parameter for including related object data | Should | Implemented |
-| PUB-006 | Retrieve publication attachments (files linked to a publication) | Must | Implemented |
-| PUB-007 | Download publication files | Must | Implemented |
-| PUB-008 | Retrieve outgoing relations (objects this publication references) via `/uses` | Must | Implemented |
-| PUB-009 | Retrieve incoming relations (objects that reference this publication) via `/used` | Must | Implemented |
-| PUB-010 | All public endpoints must include CORS headers | Must | Implemented |
-| PUB-011 | Return 404 with descriptive error when catalog slug or publication ID not found | Must | Implemented |
-| PUB-012 | Publication endpoints use wildcard `{catalogSlug}` routes (must be last in route order) | Must | Implemented |
-| PUB-013 | Support filter parameter extraction from various formats (single, array, OR/AND operators) | Should | Implemented |
-| PUB-014 | Fallback object location lookup across all magic tables when catalog register/schema search fails | Should | Implemented |
-| PUB-015 | Schema authorization (RBAC) is enabled on the publication list for conditional access rules | Should | Implemented |
+### Requirement: List publications scoped to a catalog slug with pagination and facets
+The system MUST list publications scoped to a catalog slug with pagination and facets.
+
+**ID:** PUB-001 — Priority: Must — Status: Implemented
+
+### Requirement: Retrieve a single publication by catalog slug and object UUID
+The system MUST retrieve a single publication by catalog slug and object UUID.
+
+**ID:** PUB-002 — Priority: Must — Status: Implemented
+
+### Requirement: Publication list endpoint must filter by the catalog's configured registers and schemas
+The publication list endpoint MUST filter by the catalog's configured registers and schemas.
+
+**ID:** PUB-003 — Priority: Must — Status: Implemented
+
+### Requirement: Support multi-schema catalogs with UNION-based search across multiple magic tables
+The system MUST support multi-schema catalogs with UNION-based search across multiple magic tables.
+
+**ID:** PUB-004 — Priority: Must — Status: Implemented
+
+### Requirement: Support `_extend` parameter for including related object data
+The system SHOULD support the `_extend` parameter for including related object data.
+
+**ID:** PUB-005 — Priority: Should — Status: Implemented
+
+### Requirement: Retrieve publication attachments (files linked to a publication)
+The system MUST retrieve publication attachments (files linked to a publication).
+
+**ID:** PUB-006 — Priority: Must — Status: Implemented
+
+### Requirement: Download publication files
+The system MUST allow downloading publication files.
+
+**ID:** PUB-007 — Priority: Must — Status: Implemented
+
+### Requirement: Retrieve outgoing relations (objects this publication references) via `/uses`
+The system MUST retrieve outgoing relations (objects this publication references) via `/uses`.
+
+**ID:** PUB-008 — Priority: Must — Status: Implemented
+
+### Requirement: Retrieve incoming relations (objects that reference this publication) via `/used`
+The system MUST retrieve incoming relations (objects that reference this publication) via `/used`.
+
+**ID:** PUB-009 — Priority: Must — Status: Implemented
+
+### Requirement: All public endpoints must include CORS headers
+All public endpoints MUST include CORS headers.
+
+**ID:** PUB-010 — Priority: Must — Status: Implemented
+
+### Requirement: Return 404 with descriptive error when catalog slug or publication ID not found
+The system MUST return 404 with a descriptive error when the catalog slug or publication ID is not found.
+
+**ID:** PUB-011 — Priority: Must — Status: Implemented
+
+### Requirement: Publication endpoints use wildcard `{catalogSlug}` routes (must be last in route order)
+Publication endpoints MUST use wildcard `{catalogSlug}` routes (which MUST be last in route order).
+
+**ID:** PUB-012 — Priority: Must — Status: Implemented
+
+### Requirement: Support filter parameter extraction from various formats (single, array, OR/AND operators)
+The system SHOULD support filter parameter extraction from various formats (single, array, OR/AND operators).
+
+**ID:** PUB-013 — Priority: Should — Status: Implemented
+
+### Requirement: Fallback object location lookup across all magic tables when catalog register/schema search fails
+The system SHOULD perform a fallback object location lookup across all magic tables when the catalog register/schema search fails.
+
+**ID:** PUB-014 — Priority: Should — Status: Implemented
+
+### Requirement: Schema authorization (RBAC) is enabled on the publication list for conditional access rules
+Schema authorization (RBAC) SHOULD be enabled on the publication list for conditional access rules.
+
+**ID:** PUB-015 — Priority: Should — Status: Implemented
 
 ## Data Model
 

--- a/openspec/specs/search/spec.md
+++ b/openspec/specs/search/spec.md
@@ -10,23 +10,80 @@ The search feature provides an internal search API endpoint that queries publica
 
 ## Requirements
 
-| ID | Requirement | Priority | Status |
-|----|------------|----------|--------|
-| SCH-001 | Provide an internal search endpoint at `/api/search` for authenticated users | Must | Implemented |
-| SCH-002 | Support full-text search via `_search` parameter | Must | Implemented |
-| SCH-003 | Support filtering by catalog ID | Should | Implemented |
-| SCH-004 | Support pagination (_limit, _page, _offset) | Must | Implemented |
-| SCH-005 | Support ordering (_order) | Must | Implemented |
-| SCH-006 | Integrate with ElasticSearch when configured | Should | Not Implemented (no ElasticSearchService in OpenCatalogi) |
-| SCH-007 | Support distributed search across remote directories via async HTTP | Should | Implemented (via PublicationService federation) |
-| SCH-008 | Merge facets/aggregations from multiple sources | Should | Implemented (via PublicationService federation) |
-| SCH-009 | Parse complex query strings with nested parameters | Should | Implemented (via ObjectService.buildSearchQuery) |
-| SCH-010 | Create MySQL/MongoDB-compatible search filters and sort parameters | Must | Not Applicable (no SearchService exists -- search uses OpenRegister's ObjectService directly) |
-| SCH-011 | SearchController has show(), attachments(), download(), uses(), used() methods with no routes | Nice | Dead Code |
-| SCH-012 | Support filter syntax with special query parameters (_search, _order, _limit, _page, _offset, _queries) | Must | Implemented |
-| SCH-013 | Generate dual MySQL and MongoDB filter/sort parameters from request query parameters | Must | Not Applicable (no SearchService exists in OpenCatalogi) |
-| SCH-014 | Parse complex nested query strings with bracket notation (e.g., `_order[title]=asc`, `themes[or]=1,2,3`) | Must | Implemented (via ObjectService.buildSearchQuery in OpenRegister) |
-| SCH-015 | Unset all underscore-prefixed special parameters before passing to database filter layer | Must | Implemented (via ObjectService.buildSearchQuery in OpenRegister) |
+### Requirement: Provide an internal search endpoint at `/api/search` for authenticated users
+The system MUST provide an internal search endpoint at `/api/search` for authenticated users.
+
+**ID:** SCH-001 — Priority: Must — Status: Implemented
+
+### Requirement: Support full-text search via `_search` parameter
+The system MUST support full-text search via the `_search` parameter.
+
+**ID:** SCH-002 — Priority: Must — Status: Implemented
+
+### Requirement: Support filtering by catalog ID
+The system SHOULD support filtering by catalog ID.
+
+**ID:** SCH-003 — Priority: Should — Status: Implemented
+
+### Requirement: Support pagination (_limit, _page, _offset)
+The system MUST support pagination (_limit, _page, _offset).
+
+**ID:** SCH-004 — Priority: Must — Status: Implemented
+
+### Requirement: Support ordering (_order)
+The system MUST support ordering (_order).
+
+**ID:** SCH-005 — Priority: Must — Status: Implemented
+
+### Requirement: Integrate with ElasticSearch when configured
+The system SHOULD integrate with ElasticSearch when configured.
+
+**ID:** SCH-006 — Priority: Should — Status: Not Implemented (no ElasticSearchService in OpenCatalogi)
+
+### Requirement: Support distributed search across remote directories via async HTTP
+The system SHOULD support distributed search across remote directories via async HTTP.
+
+**ID:** SCH-007 — Priority: Should — Status: Implemented (via PublicationService federation)
+
+### Requirement: Merge facets/aggregations from multiple sources
+The system SHOULD merge facets/aggregations from multiple sources.
+
+**ID:** SCH-008 — Priority: Should — Status: Implemented (via PublicationService federation)
+
+### Requirement: Parse complex query strings with nested parameters
+The system SHOULD parse complex query strings with nested parameters.
+
+**ID:** SCH-009 — Priority: Should — Status: Implemented (via ObjectService.buildSearchQuery)
+
+### Requirement: Create MySQL/MongoDB-compatible search filters and sort parameters
+The system MUST create MySQL/MongoDB-compatible search filters and sort parameters.
+
+**ID:** SCH-010 — Priority: Must — Status: Not Applicable (no SearchService exists -- search uses OpenRegister's ObjectService directly)
+
+### Requirement: SearchController has show(), attachments(), download(), uses(), used() methods with no routes
+SearchController SHOULD have show(), attachments(), download(), uses(), used() methods with no routes.
+
+**ID:** SCH-011 — Priority: Nice — Status: Dead Code
+
+### Requirement: Support filter syntax with special query parameters (_search, _order, _limit, _page, _offset, _queries)
+The system MUST support filter syntax with special query parameters (_search, _order, _limit, _page, _offset, _queries).
+
+**ID:** SCH-012 — Priority: Must — Status: Implemented
+
+### Requirement: Generate dual MySQL and MongoDB filter/sort parameters from request query parameters
+The system MUST generate dual MySQL and MongoDB filter/sort parameters from request query parameters.
+
+**ID:** SCH-013 — Priority: Must — Status: Not Applicable (no SearchService exists in OpenCatalogi)
+
+### Requirement: Parse complex nested query strings with bracket notation (e.g., `_order[title]=asc`, `themes[or]=1,2,3`)
+The system MUST parse complex nested query strings with bracket notation (e.g., `_order[title]=asc`, `themes[or]=1,2,3`).
+
+**ID:** SCH-014 — Priority: Must — Status: Implemented (via ObjectService.buildSearchQuery in OpenRegister)
+
+### Requirement: Unset all underscore-prefixed special parameters before passing to database filter layer
+The system MUST unset all underscore-prefixed special parameters before passing them to the database filter layer.
+
+**ID:** SCH-015 — Priority: Must — Status: Implemented (via ObjectService.buildSearchQuery in OpenRegister)
 
 ## Data Model
 

--- a/openspec/specs/search/spec.md
+++ b/openspec/specs/search/spec.md
@@ -10,80 +10,80 @@ The search feature provides an internal search API endpoint that queries publica
 
 ## Requirements
 
-### Requirement: Provide an internal search endpoint at `/api/search` for authenticated users
+### Requirement: Provide an internal search endpoint at `/api/search` for authenticated users (SCH-001)
 The system MUST provide an internal search endpoint at `/api/search` for authenticated users.
 
-**ID:** SCH-001 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Support full-text search via `_search` parameter
+### Requirement: Support full-text search via `_search` parameter (SCH-002)
 The system MUST support full-text search via the `_search` parameter.
 
-**ID:** SCH-002 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Support filtering by catalog ID
+### Requirement: Support filtering by catalog ID (SCH-003)
 The system SHOULD support filtering by catalog ID.
 
-**ID:** SCH-003 — Priority: Should — Status: Implemented
+**Priority:** Should **Status:** Implemented
 
-### Requirement: Support pagination (_limit, _page, _offset)
+### Requirement: Support pagination (_limit, _page, _offset) (SCH-004)
 The system MUST support pagination (_limit, _page, _offset).
 
-**ID:** SCH-004 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Support ordering (_order)
+### Requirement: Support ordering (_order) (SCH-005)
 The system MUST support ordering (_order).
 
-**ID:** SCH-005 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Integrate with ElasticSearch when configured
+### Requirement: Integrate with ElasticSearch when configured (SCH-006)
 The system SHOULD integrate with ElasticSearch when configured.
 
-**ID:** SCH-006 — Priority: Should — Status: Not Implemented (no ElasticSearchService in OpenCatalogi)
+**Priority:** Should **Status:** Not Implemented (no ElasticSearchService in OpenCatalogi)
 
-### Requirement: Support distributed search across remote directories via async HTTP
+### Requirement: Support distributed search across remote directories via async HTTP (SCH-007)
 The system SHOULD support distributed search across remote directories via async HTTP.
 
-**ID:** SCH-007 — Priority: Should — Status: Implemented (via PublicationService federation)
+**Priority:** Should **Status:** Implemented (via PublicationService federation)
 
-### Requirement: Merge facets/aggregations from multiple sources
+### Requirement: Merge facets/aggregations from multiple sources (SCH-008)
 The system SHOULD merge facets/aggregations from multiple sources.
 
-**ID:** SCH-008 — Priority: Should — Status: Implemented (via PublicationService federation)
+**Priority:** Should **Status:** Implemented (via PublicationService federation)
 
-### Requirement: Parse complex query strings with nested parameters
+### Requirement: Parse complex query strings with nested parameters (SCH-009)
 The system SHOULD parse complex query strings with nested parameters.
 
-**ID:** SCH-009 — Priority: Should — Status: Implemented (via ObjectService.buildSearchQuery)
+**Priority:** Should **Status:** Implemented (via ObjectService.buildSearchQuery)
 
-### Requirement: Create MySQL/MongoDB-compatible search filters and sort parameters
+### Requirement: Create MySQL/MongoDB-compatible search filters and sort parameters (SCH-010)
 The system MUST create MySQL/MongoDB-compatible search filters and sort parameters.
 
-**ID:** SCH-010 — Priority: Must — Status: Not Applicable (no SearchService exists -- search uses OpenRegister's ObjectService directly)
+**Priority:** Must **Status:** Not Applicable (no SearchService exists -- search uses OpenRegister's ObjectService directly)
 
-### Requirement: SearchController has show(), attachments(), download(), uses(), used() methods with no routes
+### Requirement: SearchController has show(), attachments(), download(), uses(), used() methods with no routes (SCH-011)
 SearchController SHOULD have show(), attachments(), download(), uses(), used() methods with no routes.
 
-**ID:** SCH-011 — Priority: Nice — Status: Dead Code
+**Priority:** Nice **Status:** Dead Code
 
-### Requirement: Support filter syntax with special query parameters (_search, _order, _limit, _page, _offset, _queries)
+### Requirement: Support filter syntax with special query parameters (_search, _order, _limit, _page, _offset, _queries) (SCH-012)
 The system MUST support filter syntax with special query parameters (_search, _order, _limit, _page, _offset, _queries).
 
-**ID:** SCH-012 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Generate dual MySQL and MongoDB filter/sort parameters from request query parameters
+### Requirement: Generate dual MySQL and MongoDB filter/sort parameters from request query parameters (SCH-013)
 The system MUST generate dual MySQL and MongoDB filter/sort parameters from request query parameters.
 
-**ID:** SCH-013 — Priority: Must — Status: Not Applicable (no SearchService exists in OpenCatalogi)
+**Priority:** Must **Status:** Not Applicable (no SearchService exists in OpenCatalogi)
 
-### Requirement: Parse complex nested query strings with bracket notation (e.g., `_order[title]=asc`, `themes[or]=1,2,3`)
+### Requirement: Parse complex nested query strings with bracket notation (e.g., `_order[title]=asc`, `themes[or]=1,2,3`) (SCH-014)
 The system MUST parse complex nested query strings with bracket notation (e.g., `_order[title]=asc`, `themes[or]=1,2,3`).
 
-**ID:** SCH-014 — Priority: Must — Status: Implemented (via ObjectService.buildSearchQuery in OpenRegister)
+**Priority:** Must **Status:** Implemented (via ObjectService.buildSearchQuery in OpenRegister)
 
-### Requirement: Unset all underscore-prefixed special parameters before passing to database filter layer
+### Requirement: Unset all underscore-prefixed special parameters before passing to database filter layer (SCH-015)
 The system MUST unset all underscore-prefixed special parameters before passing them to the database filter layer.
 
-**ID:** SCH-015 — Priority: Must — Status: Implemented (via ObjectService.buildSearchQuery in OpenRegister)
+**Priority:** Must **Status:** Implemented (via ObjectService.buildSearchQuery in OpenRegister)
 
 ## Data Model
 

--- a/openspec/specs/woo-compliance/spec.md
+++ b/openspec/specs/woo-compliance/spec.md
@@ -10,55 +10,55 @@ OpenCatalogi supports Dutch WOO (Wet Open Overheid) compliance by generating XML
 
 ## Requirements
 
-### Requirement: Generate XML sitemap index per catalog per WOO information category
+### Requirement: Generate XML sitemap index per catalog per WOO information category (WOO-001)
 The system MUST generate an XML sitemap index per catalog per WOO information category.
 
-**ID:** WOO-001 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Generate XML sitemap with DIWOO Document metadata for publications
+### Requirement: Generate XML sitemap with DIWOO Document metadata for publications (WOO-002)
 The system MUST generate an XML sitemap with DIWOO Document metadata for publications.
 
-**ID:** WOO-002 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Support all 17 WOO information categories (informatiecategorieen)
+### Requirement: Support all 17 WOO information categories (informatiecategorieen) (WOO-003)
 The system MUST support all 17 WOO information categories (informatiecategorieen).
 
-**ID:** WOO-003 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Generate robots.txt with sitemap URLs for all WOO-enabled catalogs
+### Requirement: Generate robots.txt with sitemap URLs for all WOO-enabled catalogs (WOO-004)
 The system MUST generate a robots.txt with sitemap URLs for all WOO-enabled catalogs.
 
-**ID:** WOO-004 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Paginate sitemaps (max 1000 entries per page)
+### Requirement: Paginate sitemaps (max 1000 entries per page) (WOO-005)
 The system MUST paginate sitemaps (max 1000 entries per page).
 
-**ID:** WOO-005 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Map publication + file metadata to DIWOO Document XML structure
+### Requirement: Map publication + file metadata to DIWOO Document XML structure (WOO-006)
 The system MUST map publication + file metadata to the DIWOO Document XML structure.
 
-**ID:** WOO-006 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Validate that requested category belongs to the catalog's schemas
+### Requirement: Validate that requested category belongs to the catalog's schemas (WOO-007)
 The system MUST validate that the requested category belongs to the catalog's schemas.
 
-**ID:** WOO-007 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Only catalogs with `hasWooSitemap: true` appear in robots.txt
+### Requirement: Only catalogs with `hasWooSitemap: true` appear in robots.txt (WOO-008)
 Only catalogs with `hasWooSitemap: true` MUST appear in robots.txt.
 
-**ID:** WOO-008 — Priority: Must — Status: Bug (RobotsController does NOT check hasWooSitemap)
+**Priority:** Must **Status:** Bug (RobotsController does NOT check hasWooSitemap)
 
-### Requirement: All sitemap/robots endpoints are public
+### Requirement: All sitemap/robots endpoints are public (WOO-009)
 All sitemap/robots endpoints MUST be public.
 
-**ID:** WOO-009 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
-### Requirement: Include file metadata: download URL, format, creation date, publisher, handling type
+### Requirement: Include file metadata: download URL, format, creation date, publisher, handling type (WOO-010)
 The system MUST include file metadata: download URL, format, creation date, publisher, handling type.
 
-**ID:** WOO-010 — Priority: Must — Status: Implemented
+**Priority:** Must **Status:** Implemented
 
 ## Data Model
 

--- a/openspec/specs/woo-compliance/spec.md
+++ b/openspec/specs/woo-compliance/spec.md
@@ -10,18 +10,55 @@ OpenCatalogi supports Dutch WOO (Wet Open Overheid) compliance by generating XML
 
 ## Requirements
 
-| ID | Requirement | Priority | Status |
-|----|------------|----------|--------|
-| WOO-001 | Generate XML sitemap index per catalog per WOO information category | Must | Implemented |
-| WOO-002 | Generate XML sitemap with DIWOO Document metadata for publications | Must | Implemented |
-| WOO-003 | Support all 17 WOO information categories (informatiecategorieen) | Must | Implemented |
-| WOO-004 | Generate robots.txt with sitemap URLs for all WOO-enabled catalogs | Must | Implemented |
-| WOO-005 | Paginate sitemaps (max 1000 entries per page) | Must | Implemented |
-| WOO-006 | Map publication + file metadata to DIWOO Document XML structure | Must | Implemented |
-| WOO-007 | Validate that requested category belongs to the catalog's schemas | Must | Implemented |
-| WOO-008 | Only catalogs with `hasWooSitemap: true` appear in robots.txt | Must | Bug (RobotsController does NOT check hasWooSitemap) |
-| WOO-009 | All sitemap/robots endpoints are public | Must | Implemented |
-| WOO-010 | Include file metadata: download URL, format, creation date, publisher, handling type | Must | Implemented |
+### Requirement: Generate XML sitemap index per catalog per WOO information category
+The system MUST generate an XML sitemap index per catalog per WOO information category.
+
+**ID:** WOO-001 — Priority: Must — Status: Implemented
+
+### Requirement: Generate XML sitemap with DIWOO Document metadata for publications
+The system MUST generate an XML sitemap with DIWOO Document metadata for publications.
+
+**ID:** WOO-002 — Priority: Must — Status: Implemented
+
+### Requirement: Support all 17 WOO information categories (informatiecategorieen)
+The system MUST support all 17 WOO information categories (informatiecategorieen).
+
+**ID:** WOO-003 — Priority: Must — Status: Implemented
+
+### Requirement: Generate robots.txt with sitemap URLs for all WOO-enabled catalogs
+The system MUST generate a robots.txt with sitemap URLs for all WOO-enabled catalogs.
+
+**ID:** WOO-004 — Priority: Must — Status: Implemented
+
+### Requirement: Paginate sitemaps (max 1000 entries per page)
+The system MUST paginate sitemaps (max 1000 entries per page).
+
+**ID:** WOO-005 — Priority: Must — Status: Implemented
+
+### Requirement: Map publication + file metadata to DIWOO Document XML structure
+The system MUST map publication + file metadata to the DIWOO Document XML structure.
+
+**ID:** WOO-006 — Priority: Must — Status: Implemented
+
+### Requirement: Validate that requested category belongs to the catalog's schemas
+The system MUST validate that the requested category belongs to the catalog's schemas.
+
+**ID:** WOO-007 — Priority: Must — Status: Implemented
+
+### Requirement: Only catalogs with `hasWooSitemap: true` appear in robots.txt
+Only catalogs with `hasWooSitemap: true` MUST appear in robots.txt.
+
+**ID:** WOO-008 — Priority: Must — Status: Bug (RobotsController does NOT check hasWooSitemap)
+
+### Requirement: All sitemap/robots endpoints are public
+All sitemap/robots endpoints MUST be public.
+
+**ID:** WOO-009 — Priority: Must — Status: Implemented
+
+### Requirement: Include file metadata: download URL, format, creation date, publisher, handling type
+The system MUST include file metadata: download URL, format, creation date, publisher, handling type.
+
+**ID:** WOO-010 — Priority: Must — Status: Implemented
 
 ## Data Model
 


### PR DESCRIPTION
## Summary

Phase 1c migration: normalize all opencatalogi spec requirement headings to ADR-037 canonical Form A (`### Requirement: <title>`).

- 12 of 14 specs migrated from **Form B** (table-style `| ID | Requirement |`) to **Form A** (one `### Requirement:` heading per requirement, with REQ-ID in body as `**ID:**` metadata).
- `cms-tool` keeps its `CMS-T-NNN` 5-char prefix (now valid under ADR-037's relaxed regex `[A-Z]{2,5}-[0-9]+[a-z]*`).
- `prometheus-metrics` already canonical (Form A) — not modified.
- `org-archimate-export` skipped per coordination — being relocated by PR #666.

Scenarios, body prose, and section ordering are preserved per migration constraints.

## Per-spec tally

| Spec | Before | After |
|---|---|---|
| admin-settings | Form B (14 SET-NNN table rows) | Form A (14 headings) |
| auto-publishing | Form B (15 APB-NNN) | Form A (15) |
| catalogs | Form B (12 CAT-NNN) | Form A (12) |
| cms-tool | Form B/E (15 CMS-T-NNN, 5-prefix) | Form A (15, IDs preserved) |
| content-management | Form B grouped (24 CMS-NNN across 4 sub-sections) | Form A (24) |
| dashboard | Form B grouped (25 DSH/LST/DIR-NNN) | Form A (25) |
| download-service | Form B (10 DWN-NNN) | Form A (10) |
| federation | Form B (12 FED-NNN) | Form A (12) |
| file-management | Form B (15 FIL-NNN) | Form A (15) |
| publications | Form B (15 PUB-NNN) | Form A (15) |
| search | Form B (15 SCH-NNN) | Form A (15) |
| woo-compliance | Form B (10 WOO-NNN) | Form A (10) |
| prometheus-metrics | Form A (canonical) | unchanged |
| org-archimate-export | not touched (PR #666 relocates) | unchanged |

Total: **182 requirements** promoted across 12 specs.

## Test plan
- [x] All 12 specs use `### Requirement: <title>` heading shape
- [x] REQ-IDs preserved in body as `**ID:** XX-NNN — Priority: ... — Status: ...`
- [x] Scenarios, frontmatter, and section ordering untouched
- [x] `openspec validate --specs --strict` runs — Form A heading recognition works; remaining strict-mode issues are pre-existing structural debt (Should-only requirements lacking MUST/SHALL, scenarios not nested under each requirement, pre-existing `## MODIFIED Requirements` delta headers in `prometheus-metrics`) — out of scope for the heading-format migration
- [x] No conflict with PR #666 — only modified specs that PR #666 leaves alone

Refs: #664, hydra#326 (ADR-037)

---

## Amended 2026-05-24

Revised ADR-037 canonical form (hydra commit `0bd4cda`) moves the REQ-ID from a body `**ID:**` line into a heading-suffix `(REQ-XX-NNN)` so the openspec validator's first-non-empty-body-line check picks up the SHALL/MUST line instead of the metadata. All 12 amended specs rewritten:

- 182 headings rewritten across `admin-settings` (14) + `auto-publishing` (15) + `catalogs` (12) + `cms-tool` (15) + `content-management` (24) + `dashboard` (25) + `download-service` (10) + `federation` (12) + `file-management` (15) + `publications` (15) + `search` (15) + `woo-compliance` (10).
- `CMS-T-NNN` 5-char prefix preserved verbatim per ADR-037 (`### Requirement: <title> (CMS-T-001)` through `(CMS-T-015)`).
- Trailing `Priority`/`Status` metadata kept as `**Priority:** ... **Status:** ...` body line (one per requirement).
- `openspec validate --specs --strict` totals unchanged (2 passed / 12 failed) — remaining failures are scenario-coverage debt (`Requirement must have at least one scenario`), not heading-form related, and pre-date this PR.

Commit: `4e625ad3`.
