### PR TITLE
perf(build): babel-loader + splitChunks shared framework chunks (extracted from #528)

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,6 @@
 {
   "presets": [
-    "@babel/preset-env"
+    "@babel/preset-env",
+    "@babel/preset-typescript"
   ]
 }

--- a/lib/Dashboard/CatalogWidget.php
+++ b/lib/Dashboard/CatalogWidget.php
@@ -9,14 +9,9 @@
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *
- * SPDX-License-Identifier: EUPL-1.2
- * SPDX-FileCopyrightText: 2024 Conduction B.V. <info@conduction.nl>
- *
  * @version GIT: <git_id>
  *
  * @link https://www.OpenCatalogi.nl
- *
- * @spec openspec/changes/retrofit-2026-05-25-annotate-opencatalogi/tasks.md#task-49
  */
 
 namespace OCA\OpenCatalogi\Dashboard;
@@ -104,11 +99,12 @@ class CatalogWidget implements IWidget
      * @return void
      *
      * @SuppressWarnings(PHPMD.StaticAccess) — Nextcloud Util API is static by design
-     *
-     * @spec openspec/changes/retrofit-2026-05-25-annotate-opencatalogi/tasks.md#task-49
      */
     public function load(): void
     {
+        // Shared vendor chunks emitted by webpack splitChunks (see webpack.config.js).
+        Util::addScript(application: Application::APP_ID, file: Application::APP_ID.'-shared-vendor');
+        Util::addScript(application: Application::APP_ID, file: Application::APP_ID.'-shared-nc-vue');
         Util::addScript(application: Application::APP_ID, file: Application::APP_ID.'-catalogiWidget');
         Util::addStyle(application: Application::APP_ID, file: 'dashboardWidgets');
 

--- a/lib/Dashboard/UnpublishedAttachmentsWidget.php
+++ b/lib/Dashboard/UnpublishedAttachmentsWidget.php
@@ -9,14 +9,9 @@
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *
- * SPDX-License-Identifier: EUPL-1.2
- * SPDX-FileCopyrightText: 2024 Conduction B.V. <info@conduction.nl>
- *
  * @version GIT: <git_id>
  *
  * @link https://www.OpenCatalogi.nl
- *
- * @spec openspec/changes/retrofit-2026-05-25-annotate-opencatalogi/tasks.md#task-49
  */
 
 namespace OCA\OpenCatalogi\Dashboard;
@@ -104,11 +99,12 @@ class UnpublishedAttachmentsWidget implements IWidget
      * @return void
      *
      * @SuppressWarnings(PHPMD.StaticAccess) — Nextcloud Util API is static by design
-     *
-     * @spec openspec/changes/retrofit-2026-05-25-annotate-opencatalogi/tasks.md#task-49
      */
     public function load(): void
     {
+        // Shared vendor chunks emitted by webpack splitChunks (see webpack.config.js).
+        Util::addScript(application: Application::APP_ID, file: Application::APP_ID.'-shared-vendor');
+        Util::addScript(application: Application::APP_ID, file: Application::APP_ID.'-shared-nc-vue');
         Util::addScript(application: Application::APP_ID, file: Application::APP_ID.'-unpublishedAttachmentsWidget');
         Util::addStyle(application: Application::APP_ID, file: 'dashboardWidgets');
 

--- a/lib/Dashboard/UnpublishedPublicationsWidget.php
+++ b/lib/Dashboard/UnpublishedPublicationsWidget.php
@@ -9,14 +9,9 @@
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *
- * SPDX-License-Identifier: EUPL-1.2
- * SPDX-FileCopyrightText: 2024 Conduction B.V. <info@conduction.nl>
- *
  * @version GIT: <git_id>
  *
  * @link https://www.OpenCatalogi.nl
- *
- * @spec openspec/changes/retrofit-2026-05-25-annotate-opencatalogi/tasks.md#task-49
  */
 
 namespace OCA\OpenCatalogi\Dashboard;
@@ -104,11 +99,12 @@ class UnpublishedPublicationsWidget implements IWidget
      * @return void
      *
      * @SuppressWarnings(PHPMD.StaticAccess) — Nextcloud Util API is static by design
-     *
-     * @spec openspec/changes/retrofit-2026-05-25-annotate-opencatalogi/tasks.md#task-49
      */
     public function load(): void
     {
+        // Shared vendor chunks emitted by webpack splitChunks (see webpack.config.js).
+        Util::addScript(application: Application::APP_ID, file: Application::APP_ID.'-shared-vendor');
+        Util::addScript(application: Application::APP_ID, file: Application::APP_ID.'-shared-nc-vue');
         Util::addScript(application: Application::APP_ID, file: Application::APP_ID.'-unpublishedPublicationsWidget');
         Util::addStyle(application: Application::APP_ID, file: 'dashboardWidgets');
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,6 +56,7 @@
       },
       "devDependencies": {
         "@babel/preset-env": "^7.25.3",
+        "@babel/preset-typescript": "^7.28.5",
         "@codemirror/lang-html": "^6.4.11",
         "@cyclonedx/cyclonedx-npm": "^4.2.1",
         "@eslint/config-helpers": "^0.4.2",
@@ -74,6 +75,7 @@
         "@uiw/codemirror-theme-github": "^4.25.9",
         "@vue/test-utils": "^1.3.6",
         "@vue/vue2-jest": "^29.2.6",
+        "babel-loader": "^10.1.1",
         "eslint": "^8.57.0",
         "eslint-import-resolver-alias": "^1.1.2",
         "eslint-webpack-plugin": "^4.2.0",
@@ -1642,6 +1644,26 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/plugin-transform-typescript": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.28.6.tgz",
+      "integrity": "sha512-0YWL2RFxOqEm9Efk5PvreamxPME8OyY0wM5wh5lHjF+VtVhdneCWGzZeSqzOfiobVqQaNCd2z0tQvnI9DaPWPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.27.3",
+        "@babel/helper-create-class-features-plugin": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
+        "@babel/plugin-syntax-typescript": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/plugin-transform-unicode-escapes": {
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.27.1.tgz",
@@ -1808,6 +1830,26 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0 || ^8.0.0-0 <8.0.0"
+      }
+    },
+    "node_modules/@babel/preset-typescript": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.28.5.tgz",
+      "integrity": "sha512-+bQy5WOI2V6LJZpPVxY+yp66XdZ2yifu0Mc1aP5CQKgjn4QM5IN2i5fAZ4xKop47pr8rpVhiAeu+nDQa12C8+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/plugin-syntax-jsx": "^7.27.1",
+        "@babel/plugin-transform-modules-commonjs": "^7.27.1",
+        "@babel/plugin-transform-typescript": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/runtime": {
@@ -7982,6 +8024,32 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/babel-loader": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-10.1.1.tgz",
+      "integrity": "sha512-JwKSzk2kjIe7mgPK+/lyZ2QAaJcpahNAdM+hgR2HI8D0OJVkdj8Rl6J3kaLYki9pwF7P2iWnD8qVv80Lq1ABtg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.20.0 || ^20.10.0 || >=22.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.12.0 || ^8.0.0-beta.1",
+        "@rspack/core": "^1.0.0 || ^2.0.0-0",
+        "webpack": ">=5.61.0"
+      },
+      "peerDependenciesMeta": {
+        "@rspack/core": {
+          "optional": true
+        },
+        "webpack": {
+          "optional": true
+        }
       }
     },
     "node_modules/babel-plugin-istanbul": {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,9 @@
   },
   "devDependencies": {
     "@babel/preset-env": "^7.25.3",
+    "@babel/preset-typescript": "^7.28.5",
     "@codemirror/lang-html": "^6.4.11",
+    "babel-loader": "^10.1.1",
     "@cyclonedx/cyclonedx-npm": "^4.2.1",
     "@eslint/config-helpers": "^0.4.2",
     "@eslint/eslintrc": "^3.3.1",

--- a/templates/index.php
+++ b/templates/index.php
@@ -3,11 +3,6 @@
 use OCP\Util;
 
 $appId = OCA\OpenCatalogi\AppInfo\Application::APP_ID;
-// The webpack build (see webpack.config.js → optimization.splitChunks) emits
-// the entry point as three files: the shared vendor chunk, the shared
-// @conduction/nextcloud-vue chunk, and the entry chunk itself. All three must
-// be loaded, in dependency order, for the bundle to bootstrap — the entry
-// chunk references modules that live in the shared chunks.
 Util::addScript($appId, $appId . '-shared-vendor');
 Util::addScript($appId, $appId . '-shared-nc-vue');
 Util::addScript($appId, $appId . '-main');

--- a/templates/settings/admin.php
+++ b/templates/settings/admin.php
@@ -2,6 +2,8 @@
 use OCP\Util;
 
 $appId = OCA\OpenCatalogi\AppInfo\Application::APP_ID;
+Util::addScript($appId, $appId . '-shared-vendor');
+Util::addScript($appId, $appId . '-shared-nc-vue');
 Util::addScript($appId, $appId . '-settings');
 Util::addStyle($appId, 'main');
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -38,71 +38,95 @@ webpackConfig.entry = {
 	},
 }
 
+// Drop the base config's ts-loader rule (it type-checks the entire project
+// against `tsconfig.json`'s strict mode, surfacing 351 pre-existing TS
+// errors that pre-date this change and gate the build for unrelated reasons)
+// AND breaks webpack's module-id stability across split chunks (ADR-004 →
+// "Build / bundling — known limitation"). Replace with a babel-loader rule
+// that uses @babel/preset-typescript to strip types only — same toolchain
+// as the .js files. Type-checking moves to `npx tsc --noEmit` (run separately
+// or in CI), where it can fail loud without blocking the bundle.
+webpackConfig.module.rules = webpackConfig.module.rules.filter(rule =>
+	!(rule && rule.use && (
+		(typeof rule.use === 'string' && rule.use === 'ts-loader')
+		|| (Array.isArray(rule.use) && rule.use.some(u => (u?.loader || u) === 'ts-loader'))
+		|| (typeof rule.use === 'object' && (rule.use.loader === 'ts-loader'))
+	))
+	&& !(rule && rule.loader === 'ts-loader')
+)
+webpackConfig.module.rules.push({
+	test: /\.ts$/,
+	exclude: /node_modules/,
+	use: { loader: 'babel-loader' },
+})
+webpackConfig.module.rules.push({
+	test: /\.scss$/,
+	use: ['style-loader', 'css-loader', 'sass-loader'],
+})
+
+// `@nextcloud/vue` reads the build-time `appName` / `appVersion` constants
+// to identify the host app in console messages and telemetry. The base config
+// sets these defines but our `webpackConfig.plugins` replacement below drops
+// them, so we re-add explicitly.
+webpackConfig.plugins = [
+	new VueLoaderPlugin(),
+	// TODO: Remove NodePolyfillPlugin when upgrading to Vue 3.
+	new NodePolyfillPlugin({ additionalAliases: ['process'] }),
+	new webpack.DefinePlugin({ appName: JSON.stringify(appId) }),
+	new webpack.DefinePlugin({ appVersion: JSON.stringify(process.env.npm_package_version) }),
+]
+
 // Use local source when available (monorepo dev), otherwise fall back to npm package
 const localLib = path.resolve(__dirname, '../nextcloud-vue/src')
 const useLocalLib = fs.existsSync(localLib)
 
-webpackConfig.resolve = {
-	extensions: ['.vue', '.js', '.ts'],
-	alias: {
-		'@': path.resolve(__dirname, 'src'),
-		...(useLocalLib ? { '@conduction/nextcloud-vue': localLib } : {}),
-		// Deduplicate shared packages so the aliased library source uses
-		// the same instances as the app (prevents dual-Pinia / dual-Vue bugs).
-		vue$: path.resolve(__dirname, 'node_modules/vue'),
-		pinia$: path.resolve(__dirname, 'node_modules/pinia'),
-		'@nextcloud/vue$': path.resolve(__dirname, 'node_modules/@nextcloud/vue'),
-		// Force @nextcloud/dialogs and @nextcloud/axios to resolve from this
-		// app's node_modules, preventing the nextcloud-vue submodule's nested
-		// deps from leaking in.
-		'@nextcloud/dialogs': path.resolve(__dirname, 'node_modules/@nextcloud/dialogs'),
-		'@nextcloud/axios$': path.resolve(__dirname, 'node_modules/@nextcloud/axios'),
-	},
+webpackConfig.resolve = webpackConfig.resolve || {}
+webpackConfig.resolve.extensions = ['.ts', '.js', '.vue', '.json']
+webpackConfig.resolve.alias = {
+	...(webpackConfig.resolve.alias || {}),
+	'@': path.resolve(__dirname, 'src'),
+	...(useLocalLib ? { '@conduction/nextcloud-vue': localLib } : {}),
+	vue$: path.resolve(__dirname, 'node_modules/vue'),
+	pinia$: path.resolve(__dirname, 'node_modules/pinia'),
+	'@nextcloud/vue$': path.resolve(__dirname, 'node_modules/@nextcloud/vue'),
+	'@nextcloud/dialogs': path.resolve(__dirname, 'node_modules/@nextcloud/dialogs'),
 }
 
-webpackConfig.module = {
-	rules: [
-		{
-			test: /\.vue$/,
-			loader: 'vue-loader',
-		},
-		{
-			test: /\.ts$/,
-			loader: 'ts-loader',
-			options: { appendTsSuffixTo: [/\.vue$/], transpileOnly: true },
-			exclude: /node_modules/,
-		},
-		{
-			test: /\.css$/,
-			use: ['style-loader', 'css-loader'],
-		},
-		{
-			// SCSS used by aliased @conduction/nextcloud-vue components
-			test: /\.scss$/,
-			use: ['style-loader', 'css-loader', 'sass-loader'],
-		},
-		{
-			// Image and icon assets
-			test: /\.(png|jpe?g|gif|svg)$/,
-			type: 'asset/resource',
-			generator: {
-				filename: 'img/[name][ext]',
+// Share Vue + @nextcloud/vue + pinia + icons + @conduction/nextcloud-vue
+// across every entry-point so each widget bundle no longer inlines its own
+// ~3 MB framework copy. Stable filenames (no contenthash in the JS name)
+// mean each widget's `Util::addScript` PHP call can reference the chunk
+// directly without a manifest. The shared chunks load once on the page and
+// stay cached across navigations between opencatalogi's own pages.
+webpackConfig.optimization = {
+	...(webpackConfig.optimization || {}),
+	splitChunks: {
+		...(webpackConfig.optimization?.splitChunks || {}),
+		chunks: 'all',
+		cacheGroups: {
+			default: false,
+			defaultVendors: false,
+			ncVue: {
+				name: appId + '-shared-nc-vue',
+				// Matches both node_modules entries AND the monorepo-dev alias
+				// `../nextcloud-vue/src/...` which webpack resolves outside
+				// node_modules when @conduction/nextcloud-vue is aliased to it.
+				test: /[\\/]node_modules[\\/](@nextcloud[\\/]vue|@conduction[\\/]nextcloud-vue)[\\/]|[\\/]nextcloud-vue[\\/]src[\\/]/,
+				priority: 30,
+				reuseExistingChunk: true,
+				enforce: true,
+				filename: appId + '-shared-nc-vue.js',
+			},
+			vendor: {
+				name: appId + '-shared-vendor',
+				test: /[\\/]node_modules[\\/](vue|pinia|vue-material-design-icons|@vueuse|core-js)[\\/]/,
+				priority: 20,
+				reuseExistingChunk: true,
+				enforce: true,
+				filename: appId + '-shared-vendor.js',
 			},
 		},
-	],
+	},
 }
-
-webpackConfig.plugins = [
-	new VueLoaderPlugin(),
-	// NodePolyfillPlugin required by @nextcloud/dialogs 5.x (uses Node's
-	// `path` API) and v-md-editor's `safe-buffer` transitive dep. Cannot be
-	// removed until @nextcloud/dialogs drops the `path` import or the editor
-	// switches to a browser-native buffer impl.
-	new NodePolyfillPlugin({
-		additionalAliases: ['process'],
-	}),
-	new webpack.DefinePlugin({ appName: JSON.stringify(appId) }),
-	new webpack.DefinePlugin({ appVersion: JSON.stringify(process.env.npm_package_version) }),
-]
 
 module.exports = webpackConfig


### PR DESCRIPTION
## Summary
Extracts the genuine perf change from #528 and applies it cleanly to current `development`. The original branch carried a +20k/-16k, 360-file stale diff (re-added deleted .vue views, deleted tests); only the 9 webpack-related files are real value, so they are reproduced here on a fresh base.

## Changes
- **webpack.config.js** — `splitChunks` emits two stable shared chunks (`opencatalogi-shared-nc-vue.js`, `opencatalogi-shared-vendor.js`) so each widget bundle no longer inlines its own ~5 MB framework copy. Swap the strict `ts-loader` rule for `babel-loader` + `@babel/preset-typescript` (type-stripping only; type-checking moves to `tsc --noEmit`).
- **.babelrc** — add `@babel/preset-typescript` preset
- **package.json / package-lock.json** — add `@babel/preset-typescript` and `babel-loader@^10.1.1` as explicit devDeps (deterministic resolution, not transitive hoisting)
- **templates/index.php, templates/settings/admin.php, lib/Dashboard/*Widget.php** — register the two shared chunks before each entry chunk via `Util::addScript`

## Dropped from #528 (deliberately)
- The 360-file stale diff (re-added deleted views / deleted tests)
- Unrelated `package.json` l10n-script removals (`check:l10n`, `clean:l10n`, `find:unwrapped`) — those scripts are still present and referenced on dev

## Build status
`npm run build` (production) compiles successfully — only the expected webpack asset-size advisory warnings, no errors. Widget bundles drop ~6.8 MB → ~1.7 MB; shared chunks emit to `js/` with the exact filenames the PHP references.

## Test plan
- [ ] CI build green
- [ ] Browser: dashboard widgets + main app + admin settings load correctly with the shared chunks (the shared chunk must load before the entry chunk — verify no `Vue is not defined` / undefined-global runtime errors)