### PR TITLE
chore(woo-transparency): consume OR deck/flow leaves instead of bespoke queue + workflow (ADR-022)

### DIFF
--- a/openspec/changes/woo-transparency/design.md
+++ b/openspec/changes/woo-transparency/design.md
@@ -2,5 +2,105 @@
 
 ## Architecture Overview
 
-See specs/woo-transparency/spec.md for detailed requirements and scenarios.
-Design details to be elaborated during implementation planning.
+This change follows **hydra ADR-022** (apps consume OpenRegister abstractions
+over local duplication). The WOO feature is decomposed into three layers:
+
+1. **Shared mechanics → consumed from OpenRegister leaves** (queue/board, workflow
+   state, approval gates). Built by OpenRegister, consumed here. Not reimplemented.
+2. **WOO-specific domain logic → built in OpenCatalogi** (weigeringsgronden,
+   redaction metadata + audit, inventarislijst). Genuinely WOO; no leaf exists.
+3. **Public reading-room rendering → built in OpenCatalogi** on the existing
+   Catalog/Publication/Listing CMS surface. A public website, not a leaf.
+
+See `specs/woo-transparency/spec.md` for the detailed requirements and scenarios;
+each requirement now states whether it is *consumed* or *in-app*.
+
+## Layer 1 — Consumed OpenRegister abstractions
+
+### Document queue / board → the deck leaf
+The WOO document processing queue is **not** a bespoke table + kanban UI. It
+consumes the OpenRegister **deck leaf** documented in the
+`nextcloud-entity-relations` spec (`DeckCardService`, `openregister_deck_links`,
+`nl.openregister.object.deck.*` events):
+
+- A **disclosure batch** is represented as a **Deck board** (stacks =
+  assessment stages: *Te beoordelen → Openbaar / Deels openbaar / Niet openbaar*).
+- Each **document** is a **Deck card** linked to its OpenRegister
+  `wooDocumentAssessment` object via
+  `POST /api/objects/{register}/{schema}/{id}/deck`.
+- Moving a card between stacks reflects/drives the assessment status on the linked
+  object (the deck spec already supports "moving a card between stacks can trigger
+  status changes on the object").
+- The queue UI is the existing OpenRegister deck **widget on the assessment /
+  batch object detail page** (ADR-019 integration registry + ADR-024 app
+  manifest), not a hand-built OpenCatalogi table.
+- Bulk assessment, progress summary, sort/filter/search are board/widget concerns
+  delivered by the leaf; WOO only contributes the status vocabulary and the
+  per-card assessment metadata stored on the linked object.
+
+Graceful degradation when the Deck app is absent is the leaf's responsibility
+(it returns `501 APP_NOT_AVAILABLE`).
+
+### Disclosure workflow / state engine → approval-workflow + workflow-integration
+The disclosure workflow is **not** a bespoke state machine. It is split across two
+OpenRegister abstractions:
+
+- **Human review / sign-off gate → OpenRegister `approval-workflow`.** Batch
+  transitions that require a person (e.g. `ready_for_review → published`) are
+  modelled as a role-gated approval chain (`/api/approval-chains`,
+  `ApprovalStep` records). The reviewer role maps to a Nextcloud group; each
+  decision is persisted to the workflow execution history (giving the legally
+  required decision trail for free).
+- **Automation rules → `workflow-integration` (flow / n8n).** Status-driven side
+  effects — notifications when a batch is ready for review, deadline reminders
+  (WOO 4+2-week besluit term), publish triggers — are configured as
+  workflow-integration triggers on OpenRegister register events / schema hooks,
+  not coded as bespoke listeners in OpenCatalogi.
+- The batch-status field still lives on the WOO batch object, but the
+  *transitions and their gating* are owned by the consumed abstractions.
+
+### Object detail surfacing (ADR-024 / ADR-019)
+The deck board widget and the approval-chain state are surfaced via the app
+manifest as a widget/tab on the WOO batch (and document assessment) object detail
+page, rather than a custom-built admin screen. OpenCatalogi contributes the
+WOO-specific tabs only (weigeringsgronden, redaction review, inventarislijst).
+
+## Layer 2 — WOO-specific domain logic (built in OpenCatalogi)
+
+These have no OpenRegister leaf and remain in-app:
+
+- **Weigeringsgronden** (WOO Art. 5.1/5.2 refusal grounds) data model, selection
+  UI, and entity→ground redaction mapping.
+- **Redaction metadata + immutable audit trail.** (Document processing —
+  detection, anonymization, PDF — is delegated to Docudesk `anonymization` via
+  API; OpenCatalogi stores the WOO redaction instructions, ground attribution,
+  and the audit record.) The audit trail itself MAY reuse OpenRegister's
+  immutable audit-trail abstraction for the assessment objects (ADR-022 audit
+  abstraction) rather than a private events table.
+- **Inventarislijst generation** (PDF/A + CSV) in the standard municipal format.
+- WOO batch / document-assessment **schemas** (stored in OpenRegister registers).
+
+## Layer 3 — Public reading room (built in OpenCatalogi)
+
+The reading room is a **public CMS rendering surface**, not an integration leaf.
+It reuses OpenCatalogi's existing Catalog / Publication / Listing infrastructure
+and the public catalog website, SitemapService, and SearchService. WOO publication
+metadata and the `woo_reading_room` catalog type are WOO-specific additions to
+that existing infrastructure.
+
+## What changed from the original intent (ADR-022 interception)
+
+| Original plan | Re-pointed to |
+|---|---|
+| Bespoke WOO document queue/board + kanban UI | **deck leaf** (board=batch, card=document) |
+| Bespoke batch state machine + review gates | **approval-workflow** (role-gated sign-off chain) |
+| Bespoke notification/deadline listeners | **workflow-integration** (flow / n8n triggers) |
+| Bespoke per-action audit events table | OpenRegister **audit-trail** abstraction (ADR-022) |
+| Weigeringsgronden, redaction metadata, inventarislijst | **kept in-app** (WOO-specific, no leaf) |
+| Public reading room | **kept in-app** (public CMS, not a leaf) |
+
+## Open questions (unchanged, still WOO-domain)
+1. Manual redaction region representation (Docudesk implementation detail).
+2. Municipal inventarislijst template standard.
+3. PLOOI national-platform publishing contract.
+4. OpenCatalogi ↔ Docudesk redaction API contract.

--- a/openspec/changes/woo-transparency/proposal.md
+++ b/openspec/changes/woo-transparency/proposal.md
@@ -1,14 +1,65 @@
 # Proposal: woo-transparency
 
 ## Summary
-Implement WOO (Wet open overheid) transparency features in OpenCatalogi, including document inventory lists, exemption grounds management, reading room functionality, and public document disclosure workflows.
+Implement WOO (Wet open overheid) transparency features in OpenCatalogi: document
+inventory lists, exemption-grounds management, reading-room publication, and the
+public document-disclosure workflow.
+
+Per **hydra ADR-022** ("integrate, don't build" — apps consume OpenRegister
+abstractions over local duplication), this change does **not** build a bespoke
+document queue/board or a bespoke workflow/state engine. The parts that overlap
+with existing OpenRegister integration leaves are re-pointed to consume those
+leaves:
+
+- The **document queue / board** (track documents to disclose, move them through
+  assessment stages) consumes the OpenRegister **deck leaf**
+  (`nextcloud-entity-relations` `DeckCardService`, `openregister_deck_links`,
+  `nl.openregister.object.deck.*` events). Each disclosure batch is a Deck board;
+  each document is a Deck card linked to its assessment object. This replaces a
+  hand-rolled queue table + kanban UI.
+- The **disclosure workflow / state engine** (assessment transitions, "ready for
+  review" / "published" gates, deadline rules) consumes OpenRegister's
+  **approval-workflow** abstraction (role-gated approval chains) for the
+  human review/sign-off gate, and the **workflow-integration** leaf (flow / n8n,
+  via schema hooks on register events) for automation rules (notifications,
+  deadline reminders, status-driven side effects). This replaces a bespoke
+  in-app workflow engine.
+
+Genuinely WOO-specific logic stays in OpenCatalogi: the legal disclosure
+categories and weigeringsgronden (WOO Art. 5.1/5.2) data model, redaction
+metadata and audit trail, inventarislijst generation, and the **public
+reading-room rendering** (a public CMS surface built on the existing
+Catalog/Publication/Listing infrastructure — not a leaf).
 
 ## Motivation
-The WOO requires Dutch government organizations to proactively publish government information. OpenCatalogi needs to support the complete WOO disclosure workflow from document inventory through publication.
+The WOO requires Dutch government organizations to proactively publish government
+information. OpenCatalogi needs to support the complete WOO disclosure workflow
+from document inventory through publication — reusing the shared kanban (deck) and
+workflow (flow/approval) abstractions instead of duplicating them (ADR-022).
 
 ## Scope
-- WOO document queue and inventory lists
-- Exemption grounds (weigeringsgronden) management
-- Public reading room interface
-- Document disclosure workflow
-- Integration with Procest for case-driven disclosure
+- WOO document queue / board — **consumes the OpenRegister deck leaf** (board per
+  disclosure batch, card per document); WOO-specific assessment metadata lives on
+  the linked OpenRegister assessment object.
+- Disclosure workflow & state transitions — **consumes OpenRegister
+  approval-workflow** (human sign-off chain) + **workflow-integration** (flow/n8n
+  automation rules); no bespoke state engine.
+- Exemption grounds (weigeringsgronden) management — WOO-specific, in-app.
+- Redaction metadata + immutable audit trail — WOO-specific, in-app (document
+  processing delegated to Docudesk `anonymization`).
+- Inventarislijst generation — WOO-specific, in-app.
+- Public reading-room interface — WOO-specific public CMS surface on existing
+  Catalog/Publication/Listing infrastructure (not a leaf).
+- Integration with Procest for case-driven disclosure.
+
+## Out of scope (consumed, not built)
+- Kanban/queue/board mechanics — owned by the deck leaf.
+- Workflow rule engine + approval-chain mechanics — owned by
+  workflow-integration (flow) + approval-workflow.
+
+## References
+- hydra ADR-022 — Apps consume OpenRegister abstractions.
+- hydra ADR-019 / ADR-024 — Integration registry + app manifest (widget/tab on
+  the relevant object detail page).
+- OpenRegister `nextcloud-entity-relations` (deck leaf), `approval-workflow`,
+  `workflow-integration` specs.

--- a/openspec/changes/woo-transparency/specs/woo-transparency/spec.md
+++ b/openspec/changes/woo-transparency/specs/woo-transparency/spec.md
@@ -1,5 +1,5 @@
 ---
-status: implemented
+status: draft
 ---
 
 # woo-transparency Specification
@@ -7,8 +7,13 @@ status: implemented
 ## Purpose
 WOO (Wet open overheid) / FOIA compliance features in OpenCatalogi: publication decision tracking, document redaction workflow, publication to a public reading room, and redaction audit trail. Builds on OpenCatalogi's existing Publication, Catalog, and Listing entities to add WOO-specific workflow and publication capabilities. Document-level operations (PDF generation, anonymization, entity detection) are delegated to Docudesk.
 
+Per **hydra ADR-022** (apps consume OpenRegister abstractions over local duplication), this spec consumes existing OpenRegister integration leaves for the parts that overlap them rather than building bespoke equivalents:
+- The **document queue / board** consumes the OpenRegister **deck leaf** (`nextcloud-entity-relations` `DeckCardService`, `openregister_deck_links`, `nl.openregister.object.deck.*` events): a disclosure batch is a Deck board, each document a Deck card linked to its assessment object.
+- The **disclosure workflow / state engine** consumes OpenRegister **approval-workflow** (role-gated sign-off chains) for human review gates and **workflow-integration** (flow / n8n) for automation rules (notifications, deadline reminders).
+- WOO-specific logic — weigeringsgronden, redaction metadata + audit, inventarislijst, and the public reading-room rendering — stays in OpenCatalogi.
+
 ## Context
-OpenCatalogi already serves as the "regieomgeving" (orchestration environment) for WOO publications: it manages catalogs, publications, listings, and public-facing catalog websites. This spec adds the WOO-specific workflow layer on top of those existing entities: managing a queue of documents that need assessment and redaction, tracking which redaction grounds (weigeringsgronden) apply, and publishing the final set of redacted documents through the existing publication infrastructure.
+OpenCatalogi already serves as the "regieomgeving" (orchestration environment) for WOO publications: it manages catalogs, publications, listings, and public-facing catalog websites. This spec adds the WOO-specific workflow layer on top of those existing entities: orchestrating a queue of documents that need assessment and redaction (via the **deck leaf**), tracking which redaction grounds (weigeringsgronden) apply, gating the disclosure workflow (via **approval-workflow** + **workflow-integration**), and publishing the final set of redacted documents through the existing publication infrastructure.
 
 The document processing pipeline (entity detection, anonymization, PDF conversion) remains in Docudesk via the `anonymization` spec. OpenCatalogi orchestrates the WOO workflow and calls Docudesk for document-level operations. The case management side lives in Procest's `woo-case-type` spec.
 
@@ -16,51 +21,61 @@ The document processing pipeline (entity detection, anonymization, PDF conversio
 - Docudesk `anonymization` spec: provides the entity detection and redaction engine (ANON-001 through ANON-056). OpenCatalogi delegates document processing to Docudesk but manages the WOO assessment and publication workflow.
 - Procest `woo-case-type` spec: manages the WOO case lifecycle. This spec handles the publication workflow that Procest delegates to OpenCatalogi.
 
+**Relation to consumed OpenRegister leaves (ADR-022):**
+- OpenRegister `nextcloud-entity-relations` (deck leaf): the WOO document queue/board is a Deck board + cards consumed from this leaf — NOT a bespoke queue table or kanban UI.
+- OpenRegister `approval-workflow`: human review/sign-off gates in the disclosure workflow are role-gated approval chains consumed from this abstraction — NOT a bespoke state machine.
+- OpenRegister `workflow-integration` (flow / n8n): notifications, deadline reminders, and status-driven side effects are workflow triggers consumed from this leaf — NOT bespoke in-app listeners.
+
 **Relation to existing OpenCatalogi entities:**
 - **Publication**: WOO document packages are published as Publication objects with WOO-specific metadata (besluit, inventarislijst, weigeringsgronden).
 - **Catalog**: WOO reading rooms are implemented as dedicated Catalogs, enabling public access through the existing catalog website infrastructure.
 - **Listing**: Individual WOO documents (openbaar and redacted deels-openbaar) become Listings within the WOO publication Catalog.
 - **Organization**: Links WOO publications to the responsible bestuursorgaan.
 
-## Requirements
+## ADDED Requirements
 
-### Requirement: WOO document queue
-The system MUST provide a document processing queue for WOO requests, enabling users to track and manage the assessment status of all documents in a WOO request.
+### Requirement: WOO document queue (consumes the OpenRegister deck leaf)
+The system MUST provide the WOO document processing queue by **consuming the OpenRegister deck leaf** (`nextcloud-entity-relations` `DeckCardService`, `openregister_deck_links`, `nl.openregister.object.deck.*` events) — NOT by building a bespoke queue table or kanban UI (hydra ADR-022). A disclosure batch is represented as a Deck board whose stacks are the assessment stages; each document is a Deck card linked to its OpenRegister assessment object. WOO contributes only the assessment status vocabulary and the per-document assessment metadata stored on the linked object; board/card mechanics (drag, bulk move, progress, sort/filter/search) are delivered by the leaf and surfaced as the deck widget on the batch object detail page (ADR-019 / ADR-024).
 
 #### Scenario: Receive documents from Procest
 - GIVEN a WOO case in Procest with 20 collected documents
 - WHEN Procest sends the documents to OpenCatalogi for WOO processing
-- THEN a WOO processing batch MUST be created in OpenCatalogi
-- AND all 20 documents MUST appear in the processing queue
-- AND each document MUST have initial status "Te beoordelen"
+- THEN a WOO processing batch MUST be created in OpenCatalogi as a Deck board (via the deck leaf)
+- AND a Deck card MUST be created for each of the 20 documents, linked to its assessment object via `POST /api/objects/{register}/{schema}/{id}/deck`
+- AND each card MUST start in the "Te beoordelen" stack (initial status "Te beoordelen")
 
-#### Scenario: Document assessment statuses
-- GIVEN a document in the WOO queue
-- THEN the following assessment statuses MUST be supported:
+#### Scenario: Document assessment statuses map to deck stacks
+- GIVEN a document card on the WOO Deck board
+- THEN the assessment status MUST be represented as the Deck stack the card is in, supporting:
   - **Te beoordelen** -- not yet assessed
   - **Openbaar** -- fully disclosable, no redaction needed
   - **Deels openbaar** -- needs redaction before disclosure
   - **Niet openbaar** -- withheld entirely
-- AND transitioning to "Niet openbaar" MUST require selecting weigeringsgrond(en)
+- AND moving a card to the "Niet openbaar" stack MUST require selecting weigeringsgrond(en) on the linked assessment object before the move is accepted
+- AND the assessment status on the linked OpenRegister object MUST stay in sync with the card's stack (the deck leaf supports stack-move-driven status changes)
 
-#### Scenario: Bulk assessment
-- GIVEN 20 documents in the queue
-- WHEN the user selects 5 documents and sets status "Openbaar"
-- THEN all 5 MUST be updated in one action
+#### Scenario: Bulk assessment via the deck board
+- GIVEN 20 document cards in the "Te beoordelen" stack
+- WHEN the user multi-selects 5 cards and moves them to the "Openbaar" stack
+- THEN all 5 linked assessment objects MUST be updated to "Openbaar" in one action (via the deck leaf bulk-move)
 - AND the remaining 15 MUST retain their current status
 
-#### Scenario: Queue displays progress summary
-- GIVEN a WOO batch with 20 documents where 8 are assessed and 12 are "Te beoordelen"
-- WHEN the user views the batch overview
-- THEN the UI MUST show a progress bar or counter indicating 8/20 assessed
-- AND the breakdown by status MUST be visible (e.g., 5 openbaar, 2 deels openbaar, 1 niet openbaar)
+#### Scenario: Queue progress summary (deck widget)
+- GIVEN a WOO Deck board with 20 cards where 8 are assessed and 12 are in "Te beoordelen"
+- WHEN the user views the batch object detail page
+- THEN the deck widget MUST show the per-stack counts (e.g., 5 openbaar, 2 deels openbaar, 1 niet openbaar, 12 te beoordelen)
+- AND a progress indicator of 8/20 assessed MUST be derivable from those stack counts
 
-#### Scenario: Queue supports sorting and filtering
-- GIVEN a WOO batch with 50 documents
-- WHEN the user interacts with the queue table
-- THEN they MUST be able to sort by document name, date, status, and file type
-- AND they MUST be able to filter by assessment status
-- AND they MUST be able to search by document name
+#### Scenario: Queue sorting, filtering, and search (deck widget)
+- GIVEN a WOO Deck board with 50 cards
+- WHEN the user interacts with the deck widget
+- THEN sorting, filtering by stack/status, and searching by card title MUST be provided by the deck leaf widget
+- AND OpenCatalogi MUST NOT reimplement these as a bespoke table
+
+#### Scenario: Deck app unavailable
+- GIVEN the Nextcloud Deck app is not installed or disabled
+- WHEN the WOO queue is requested
+- THEN the deck leaf's graceful-degradation behaviour applies (HTTP 501 `APP_NOT_AVAILABLE`) and OpenCatalogi surfaces a clear "Deck integration required for the WOO queue" message — OpenCatalogi MUST NOT fall back to a bespoke queue implementation
 
 ### Requirement: Weigeringsgronden (refusal grounds)
 The system MUST support tagging documents with legal grounds for withholding, covering all grounds specified in WOO Articles 5.1 and 5.2.
@@ -125,11 +140,12 @@ Document redaction MUST be coordinated through Docudesk's anonymization pipeline
 - AND redacted areas MUST show black bars (standard WOO convention)
 - AND the original document MUST be preserved unchanged
 
-#### Scenario: Redaction audit trail
+#### Scenario: Redaction audit trail (via OpenRegister audit-trail abstraction)
 - GIVEN a document with 5 redacted entities
 - WHEN the redaction is finalized
 - THEN an audit record MUST be created listing each redacted entity, its page/position, the weigeringsgrond applied, and the user who approved the redaction
-- AND the audit record MUST be immutable after creation
+- AND immutability MUST be provided by the OpenRegister immutable audit-trail abstraction on the assessment object (ADR-022) — NOT a bespoke immutable events table in OpenCatalogi
+- AND the WOO-specific entity→ground→position payload is the in-app contribution recorded against that audit event
 
 #### Scenario: Redaction of multi-page document
 - GIVEN a 50-page PDF document with entities detected on 12 pages
@@ -168,11 +184,13 @@ The system MUST store WOO batch and document assessment data in OpenRegister usi
   - `assessedBy`: user who performed the assessment
   - `assessedAt`: ISO 8601 assessment timestamp
 
-#### Scenario: Batch status transitions
+#### Scenario: Batch status transitions (gated by approval-workflow)
 - GIVEN a WOO batch in "in_progress" status
 - WHEN all documents have been assessed (no "Te beoordelen" remaining)
 - THEN the batch status MAY transition to "ready_for_review"
-- AND transitioning to "published" MUST require explicit user action
+- AND the transition from "ready_for_review" to "published" MUST be gated by an OpenRegister **approval-workflow** role-gated approval chain (consumed, not a bespoke state machine — ADR-022)
+- AND the approval decision MUST be persisted to the approval-workflow execution history (providing the legally required decision trail)
+- AND OpenCatalogi MUST NOT implement its own transition-authorization or approval-step machinery
 
 ### Requirement: Inventarislijst generation
 The system MUST generate a document inventory (inventarislijst) for the WOO decision, conforming to the standard municipal format.
@@ -265,19 +283,21 @@ The system MUST support publishing WOO documents to a public reading room using 
   - `publishedCount`: number of published documents (openbaar + deels openbaar)
 
 ### Requirement: WOO API endpoints
-The system MUST expose API endpoints for WOO batch management, document assessment, and publication.
+The system MUST expose API endpoints for WOO batch management, document assessment, and publication. Queue/board mechanics MUST be delegated to the deck leaf and workflow gating to approval-workflow / workflow-integration (ADR-022); the WOO endpoints orchestrate those leaves and own only the WOO-specific metadata.
 
-#### Scenario: Create WOO batch endpoint
+#### Scenario: Create WOO batch endpoint (provisions a deck board)
 - GIVEN authenticated admin user
 - WHEN `POST /api/woo/batches` is called with case reference and documents
-- THEN a new WOO batch MUST be created
-- AND the response MUST include the batch ID and initial document assessments
+- THEN a new WOO batch MUST be created and a corresponding Deck board provisioned via the deck leaf
+- AND a Deck card MUST be created and linked for each document
+- AND the response MUST include the batch ID, the deck board reference, and initial document assessments
 
-#### Scenario: Update document assessment endpoint
+#### Scenario: Update document assessment endpoint (moves the deck card)
 - GIVEN a WOO batch with document ID "doc-123"
 - WHEN `PUT /api/woo/batches/{batchId}/documents/{docId}` is called with assessment data
-- THEN the document assessment MUST be updated
+- THEN the document assessment MUST be updated and the linked Deck card moved to the matching stack via the deck leaf
 - AND if the assessment is "niet_openbaar", weigeringsgronden MUST be required in the request body
+- AND OpenCatalogi MUST NOT maintain a parallel queue-state store separate from the deck links + assessment object
 
 #### Scenario: Get batch status endpoint
 - GIVEN a WOO batch ID
@@ -300,7 +320,7 @@ The system MUST expose API endpoints for WOO batch management, document assessme
 - AND the response MUST include the public reading room URL
 
 ### Requirement: WOO frontend components
-The system MUST provide Vue components for the WOO workflow in the OpenCatalogi admin interface.
+The system MUST provide Vue components for the WOO-specific parts of the workflow in the OpenCatalogi admin interface. The queue/board view itself MUST be the deck leaf widget surfaced on the batch object detail page (ADR-019 / ADR-024), not a bespoke queue table; OpenCatalogi builds only the WOO-specific surfaces (weigeringsgronden, redaction review, inventarislijst).
 
 #### Scenario: WOO batch list view
 - GIVEN an admin user navigates to the WOO section
@@ -309,12 +329,13 @@ The system MUST provide Vue components for the WOO workflow in the OpenCatalogi 
 - AND each row MUST show: case reference, status, document count, progress, creation date
 - AND the user MUST be able to click a batch to view its details
 
-#### Scenario: WOO document assessment view
+#### Scenario: WOO document queue view (deck widget)
 - GIVEN an admin user opens a WOO batch
-- WHEN the document queue loads
-- THEN all documents MUST be listed with their current assessment status
-- AND the user MUST be able to select documents and change their assessment
-- AND a document preview MUST be available by clicking on a document
+- WHEN the batch object detail page loads
+- THEN the document queue MUST be rendered by the OpenRegister deck leaf widget (board + stacks + cards) surfaced via the app manifest
+- AND the user MUST be able to move cards between stacks (changing assessment) and multi-select for bulk moves through that widget
+- AND a document preview MUST be available from a card
+- AND OpenCatalogi MUST NOT build a bespoke assessment table to duplicate the deck widget
 
 #### Scenario: WOO redaction view
 - GIVEN a document assessed as "Deels openbaar"
@@ -346,40 +367,50 @@ WOO reading rooms MUST be implemented as a special catalog type within OpenCatal
 - THEN the WOO reading room URL MUST be included in the sitemap
 - AND individual published documents MUST have their own sitemap entries
 
-### Requirement: Notification and communication
-The system MUST support notifications for WOO workflow events.
+### Requirement: Notification and communication (consumes workflow-integration / flow)
+The system MUST support notifications for WOO workflow events by **consuming the OpenRegister `workflow-integration` (flow / n8n) leaf** — configuring workflow triggers on OpenRegister register events / schema hooks — NOT by coding bespoke notification listeners in OpenCatalogi (hydra ADR-022). OpenCatalogi provides the WOO-specific trigger configuration and message templates; dispatch, scheduling, and delivery are owned by the workflow leaf.
 
 #### Scenario: Notification when batch is ready for review
 - GIVEN a WOO batch where all documents have been assessed
 - WHEN the batch transitions to "ready_for_review"
-- THEN the responsible reviewer MUST receive a Nextcloud notification
+- THEN a `workflow-integration` trigger on that status-change event MUST notify the responsible reviewer
 - AND the notification MUST link to the batch review page
+- AND OpenCatalogi MUST NOT register a bespoke event listener for this
 
 #### Scenario: Notification when batch is published
 - GIVEN a WOO batch that has been published
 - WHEN publication completes
-- THEN the batch creator and reviewer MUST receive notifications
+- THEN a `workflow-integration` trigger MUST notify the batch creator and reviewer
 - AND the notification MUST include the public reading room URL
 
 #### Scenario: Notification on assessment deadline approaching
 - GIVEN a WOO batch with a configured besluit deadline (typically 4+2 weeks per WOO)
 - WHEN the deadline is 5 days away and assessment is incomplete
-- THEN a warning notification MUST be sent to assigned users
+- THEN a scheduled `workflow-integration` (flow / n8n) workflow MUST send a warning to assigned users
 - AND the notification MUST indicate how many documents remain unassessed
+- AND the deadline-timer logic MUST live in the workflow leaf, not as bespoke in-app cron code
 
 ## Non-Requirements
 - This spec does NOT cover the WOO case lifecycle (managed by Procest woo-case-type spec)
 - This spec does NOT cover WOO decision registration (managed by Procest besluiten-management spec)
 - This spec does NOT cover proactive WOO publication (actieve openbaarmaking) -- future spec
 - This spec does NOT cover document-level PDF generation, anonymization, or entity detection (managed by Docudesk anonymization spec)
+- This spec does NOT build a bespoke document queue/board — that is **consumed** from the OpenRegister deck leaf (ADR-022)
+- This spec does NOT build a bespoke workflow/state engine or approval-step machinery — that is **consumed** from OpenRegister approval-workflow + workflow-integration (ADR-022)
 
 ## Dependencies
 - Docudesk anonymization pipeline (entity detection, redaction engine) -- called via API for document processing
 - Procest woo-case-type spec (case management, document collection)
 - OpenRegister for batch and assessment data storage
+- **OpenRegister deck leaf** (`nextcloud-entity-relations`: `DeckCardService`, `openregister_deck_links`, `nl.openregister.object.deck.*` events) -- consumed for the WOO document queue/board (ADR-022)
+- **OpenRegister approval-workflow** abstraction -- consumed for the human review/sign-off gate on batch publication (ADR-022)
+- **OpenRegister workflow-integration** (flow / n8n) leaf -- consumed for notifications, deadline reminders, and status-driven automation (ADR-022)
+- **OpenRegister immutable audit-trail** abstraction -- consumed for the redaction audit record's immutability (ADR-022)
+- Nextcloud Deck app (required by the deck leaf at runtime; queue degrades to a clear "integration required" message if absent)
 - OpenCatalogi Publication, Catalog, Listing, and Organization entities (existing infrastructure)
 - OpenCatalogi SitemapService (for WOO reading room sitemap inclusion)
 - OpenCatalogi SearchService (for reading room document search)
+- OpenCatalogi app manifest (ADR-024) -- to surface the deck widget + approval state on the batch object detail page
 
 ### Current Implementation Status
 - **Not yet implemented**: This is an entirely planned spec. Zero WOO-specific implementation exists in the codebase.
@@ -404,19 +435,27 @@ The system MUST support notifications for WOO workflow events.
   - `AnonymizationService.php` -- entity detection and document anonymization pipeline
   - `AnonymizationController.php` -- upload, extract, anonymize endpoints
   - Anonymization UI components -- drag-and-drop upload and processing
-- **Key gaps**:
-  - No WOO document processing queue or batch management
+- **Building blocks consumed from OpenRegister leaves (ADR-022 — NOT built in OpenCatalogi)**:
+  - Deck leaf (`nextcloud-entity-relations` `DeckCardService`, `openregister_deck_links`) -- the WOO document queue/board
+  - `approval-workflow` abstraction -- the publication review/sign-off gate
+  - `workflow-integration` (flow / n8n) leaf -- WOO notifications, deadline reminders, status automation
+  - Immutable audit-trail abstraction -- redaction audit immutability
+- **Key gaps (WOO-specific, in-app work)**:
   - No weigeringsgronden (refusal grounds) data model or selection UI
   - No selective entity redaction coordination (current Docudesk anonymization is all-or-nothing per entity list)
   - No manual redaction region support
   - No redaction preview functionality
   - No inventarislijst generation
   - No WOO-specific reading room catalog type
-  - No WOO-specific API endpoints
-  - No WOO frontend components
+  - No WOO-specific API endpoints (orchestrating the leaves + WOO metadata)
+  - No WOO-specific frontend surfaces (weigeringsgronden / redaction / inventarislijst)
   - No integration with Procest woo-case-type
   - No integration with Docudesk anonymization API from OpenCatalogi
-  - No WOO notification workflow
+- **Integration gaps (wiring the consumed leaves)**:
+  - WOO batch is not yet wired to provision/consume a deck board + cards
+  - Batch publication gate not yet wired to an approval-workflow chain
+  - WOO notifications/deadlines not yet configured as workflow-integration triggers
+  - Deck widget + approval state not yet surfaced on the batch object detail page via the app manifest (ADR-024)
 
 ### Standards & References
 - **WOO (Wet open overheid)**: Primary law governing government transparency in the Netherlands (effective May 1, 2022, replacing WOB)

--- a/openspec/changes/woo-transparency/tasks.md
+++ b/openspec/changes/woo-transparency/tasks.md
@@ -1,6 +1,48 @@
 # Tasks: woo-transparency
 
+This change consumes OpenRegister leaves for the queue/board and workflow parts
+(hydra ADR-022). Tasks are split into "consume a leaf" wiring vs WOO-specific
+in-app build.
+
 ## Task 1: Implementation planning
 - **Spec ref**: specs/woo-transparency/spec.md
 - **Status**: todo
-- **Acceptance criteria**: Requirements from spec are decomposed into implementable tasks
+- **Acceptance criteria**: Requirements from spec are decomposed into implementable tasks, respecting the consume-vs-build split below.
+
+## Task 2: Consume the deck leaf for the WOO document queue/board
+- **Spec ref**: specs/woo-transparency/spec.md — "WOO document queue (consumes the OpenRegister deck leaf)", "WOO API endpoints", "WOO frontend components"
+- **Status**: todo
+- **Acceptance criteria**:
+  - Creating a WOO batch provisions a Deck board (stacks = assessment statuses) via the deck leaf; each document becomes a linked Deck card (`POST /api/objects/{register}/{schema}/{id}/deck`).
+  - Assessment changes move the linked Deck card between stacks; status stays in sync with the linked assessment object.
+  - The queue UI is the deck leaf widget surfaced on the batch object detail page via the app manifest (ADR-019 / ADR-024) — NO bespoke queue table.
+  - Graceful "Deck integration required" handling when the Deck app is absent.
+
+## Task 3: Consume approval-workflow for the publication review/sign-off gate
+- **Spec ref**: specs/woo-transparency/spec.md — "Batch status transitions (gated by approval-workflow)"
+- **Status**: todo
+- **Acceptance criteria**:
+  - The `ready_for_review → published` transition is gated by an OpenRegister approval-workflow role-gated chain; decisions persist to the workflow execution history. NO bespoke state machine.
+
+## Task 4: Consume workflow-integration (flow / n8n) for notifications & deadlines
+- **Spec ref**: specs/woo-transparency/spec.md — "Notification and communication (consumes workflow-integration / flow)"
+- **Status**: todo
+- **Acceptance criteria**:
+  - Ready-for-review, published, and deadline-approaching notifications are configured as workflow-integration triggers on register events/schema hooks. NO bespoke in-app listeners or cron.
+
+## Task 5: Build WOO-specific domain logic (in-app)
+- **Spec ref**: specs/woo-transparency/spec.md — weigeringsgronden, redaction, audit trail, inventarislijst, schemas
+- **Status**: todo
+- **Acceptance criteria**:
+  - Weigeringsgronden (WOO Art. 5.1/5.2) data model + selection UI + entity→ground mapping.
+  - Redaction coordination with Docudesk anonymization (selective entities, manual regions, preview) and redaction metadata.
+  - Redaction audit immutability via the OpenRegister audit-trail abstraction (ADR-022), not a bespoke immutable table.
+  - Inventarislijst generation (PDF/A + CSV).
+  - WOO batch + document-assessment schemas in OpenRegister registers.
+
+## Task 6: Build the public reading room (in-app CMS surface)
+- **Spec ref**: specs/woo-transparency/spec.md — "Reading room publication", "WOO catalog type"
+- **Status**: todo
+- **Acceptance criteria**:
+  - Reading room built on existing Catalog/Publication/Listing infrastructure + SitemapService + SearchService.
+  - `woo_reading_room` catalog type, WOO publication metadata, public sharable URL. (Public CMS surface — not a leaf.)


### PR DESCRIPTION
## Why

Intercepts the **not-yet-implemented** `woo-transparency` OpenSpec change so it
**consumes existing OpenRegister integration leaves** rather than building
bespoke UI/engines, per **hydra ADR-022** ("integrate, don't build"). No code is
implemented here — only the change artifacts (proposal / design / spec / tasks)
are re-pointed.

## Re-pointed (was bespoke → now consumes a leaf)

| Was building | Now consumes |
|---|---|
| Bespoke WOO document queue + kanban table | **deck leaf** (`nextcloud-entity-relations`: `DeckCardService`, `openregister_deck_links`, `nl.openregister.object.deck.*`). Batch = Deck board, document = linked Deck card; queue UI = deck widget on the object detail page (ADR-019 / ADR-024). |
| Bespoke batch state machine + review gate | **approval-workflow** role-gated approval chain (decisions persisted to workflow execution history → legal decision trail for free). |
| Bespoke notification/deadline listeners + cron | **workflow-integration** (flow / n8n) triggers on register events / schema hooks. |
| Bespoke immutable audit events table | OpenRegister **immutable audit-trail** abstraction. |

## Kept in-app (WOO-specific, no leaf)

- **weigeringsgronden** (WOO Art. 5.1/5.2) data model + selection UI + entity→ground mapping
- **redaction metadata + audit payload** (document processing delegated to Docudesk `anonymization`)
- **inventarislijst** generation (PDF/A + CSV)
- **public reading room** — a public CMS rendering surface on the existing Catalog/Publication/Listing infrastructure (explicitly *not* a leaf)

## Also fixed (pre-existing artifact bugs)

- Spec frontmatter said `status: implemented` on a zero-implementation change → `draft`.
- Spec used a non-delta `## Requirements` header → `## ADDED Requirements`, so the change now passes `openspec validate woo-transparency --strict` (previously errored: "No delta sections found").

## Validation

`openspec validate woo-transparency --strict` → **valid**.

Do not merge — intercept review only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)