### PR TITLE
fix(ui): bump @nextcloud/vue to ^8.39.0 (nav corner sliver on NC<34)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@nextcloud/initial-state": "^2.2.0",
         "@nextcloud/l10n": "^3.1.0",
         "@nextcloud/router": "^3.0.1",
-        "@nextcloud/vue": "^8.17.0",
+        "@nextcloud/vue": "^8.39.0",
         "@toast-ui/editor": "^3.2.2",
         "@toast-ui/vue-editor": "^3.2.3",
         "@uiw/codemirror-theme-vscode": "^4.23.6",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@nextcloud/initial-state": "^2.2.0",
     "@nextcloud/l10n": "^3.1.0",
     "@nextcloud/router": "^3.0.1",
-    "@nextcloud/vue": "^8.17.0",
+    "@nextcloud/vue": "^8.39.0",
     "@toast-ui/editor": "^3.2.2",
     "@toast-ui/vue-editor": "^3.2.3",
     "@uiw/codemirror-theme-vscode": "^4.23.6",


### PR DESCRIPTION
## What

Bumps `@nextcloud/vue` to `^8.39.0`.

## Why

`@nextcloud/vue` < 8.39.0 unconditionally renders the NC34 rounded `.app-content` layout. On Nextcloud < 34 the rounded white corner pokes past the square `.app-navigation`, creating a white sliver near the navigation toggle.

8.39.0 adds an `isLegacy34` (NC major < 34) guard that restores the square layout on older Nextcloud versions, eliminating the sliver.

## Changes

- Bumped the direct `@nextcloud/vue` dependency pin to `^8.39.0`.
- This repo has no `@nextcloud/vue` entry in `overrides`/`resolutions`, so only the direct dep pin required updating.
- Lockfile regenerated; root resolves to 8.39.0.

Part of a fleet-wide sweep.