### PR TITLE
[change request] opencatalogi notifications

### DIFF
--- a/lib/Settings/publication_register.json
+++ b/lib/Settings/publication_register.json
@@ -145,6 +145,18 @@
       },
       "catalog": {
         "slug": "catalog",
+        "x-openregister-notifications": {
+          "catalog-stable": {
+            "trigger": { "type": "transition", "action": "stable" },
+            "enabled": true,
+            "channels": ["nc-notification"],
+            "recipients": [ { "kind": "object-acl", "permission": "manage" } ],
+            "subject": {
+              "nl": "Catalogus {{title}} is gepubliceerd (stabiel)",
+              "en": "Catalogue {{title}} is published (stable)"
+            }
+          }
+        },
         "title": "Catalog",
         "version": "0.1.0",
         "published": "2025-01-01T00:00:00+00:00",
@@ -296,6 +308,18 @@
       },
       "listing": {
         "slug": "listing",
+        "x-openregister-notifications": {
+          "listing-sync-failed": {
+            "trigger": { "type": "transition", "action": "obsolete" },
+            "enabled": true,
+            "channels": ["nc-notification"],
+            "recipients": [ { "kind": "groups", "groups": ["publication-officers"] } ],
+            "subject": {
+              "nl": "Synchronisatie van listing {{title}} mislukt: {{statusMessage}}",
+              "en": "Sync of listing {{title}} failed: {{statusMessage}}"
+            }
+          }
+        },
         "title": "Listing",
         "version": "0.1.0",
         "published": "2025-01-01T00:00:00+00:00",

--- a/openspec/changes/opencatalogi-notifications/.openspec.yaml
+++ b/openspec/changes/opencatalogi-notifications/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-25

--- a/openspec/changes/opencatalogi-notifications/proposal.md
+++ b/openspec/changes/opencatalogi-notifications/proposal.md
@@ -1,0 +1,133 @@
+---
+kind: config
+---
+
+# OpenCatalogi — schema-declared notifications
+
+## Why
+
+OpenCatalogi is a publication / federated-catalogue app for government
+publication officers and portal editors. The events they care about are
+**a catalogue going stable** (publication milestone) and **a federated
+listing's sync failing or going stale** (operational health — a broken
+listing silently drops content from the portal).
+
+The OpenRegister notification engine (shipped in the `openregister`
+change `notification-schema-rules-and-userconfig-prefs`, archived
+2026-05-26) consumes a top-level `x-openregister-notifications` key on a
+schema and dispatches `nc-notification` on the configured trigger.
+Declaring rules on the domain schemas (`catalog`, `listing`) gives
+editors timely feedback with no per-app notification code.
+
+This is a configuration change to
+`lib/Settings/publication_register.json`. No PHP/Vue changes.
+
+## What Changes
+
+Add `x-openregister-notifications` to the **domain** schemas only. The
+register also holds CMS-config objects (`page`, `menu`, `theme`,
+`glossary`, `organization`) — these are configuration, not domain data,
+and are deliberately **not** notified on.
+
+Neither `catalog` nor `listing` carries a structured owner-uid field, so
+recipients use `object-acl` (manage ACL holders) for ownership-scoped
+rules and `groups` for ops-team rules.
+
+### `catalog` — published to stable
+
+`catalog.status` is an enum `development | beta | stable | obsolete`.
+Reaching `stable` is the publication milestone. Expressed via
+`transition` (no engine-gap dependency).
+
+```jsonc
+"x-openregister-notifications": {
+  "catalog-stable": {
+    "trigger": { "type": "transition", "action": "stable" },
+    "enabled": true,
+    "channels": ["nc-notification"],
+    "recipients": [ { "kind": "object-acl", "permission": "manage" } ],
+    "subject": {
+      "nl": "Catalogus {{title}} is gepubliceerd (stabiel)",
+      "en": "Catalogue {{title}} is published (stable)"
+    }
+  }
+}
+```
+
+### `listing` — federation sync failed
+
+`listing` carries `status` (enum `development | beta | stable |
+obsolete`), `statusMessage`, `statusCode`, and `lastSync`. A failed
+federation sync is the operational event editors must hear about. The
+sync process drives the listing to an `obsolete` (failed/stale) state;
+expressed via `transition` to that action so no `updated`-field-change
+engine gap is needed. Routed to the publication-ops group.
+
+```jsonc
+"x-openregister-notifications": {
+  "listing-sync-failed": {
+    "trigger": { "type": "transition", "action": "obsolete" },
+    "enabled": true,
+    "channels": ["nc-notification"],
+    "recipients": [ { "kind": "groups", "groups": ["publication-officers"] } ],
+    "subject": {
+      "nl": "Synchronisatie van listing {{title}} mislukt: {{statusMessage}}",
+      "en": "Sync of listing {{title}} failed: {{statusMessage}}"
+    }
+  }
+}
+```
+
+### `publication` — not notified on (deliberate)
+
+`publication` has no `status`/lifecycle field (only `title`, `summary`,
+`description`, `organization`, `themes`) and no structured owner uid, so
+neither a `transition` nor a precise `field`-recipient rule resolves
+today. A `created` notification on every publication would be noisy and
+mis-targeted. Left out until a lifecycle field and/or owner uid exists —
+see Caveats.
+
+## Capabilities
+
+- Catalogue manage-ACL holders are notified when a catalogue reaches
+  `stable`.
+- The `publication-officers` group is notified when a federated listing
+  sync fails, with the failure message inlined.
+- All rules ship `enabled: true`; users override per `(schema, rule)`
+  via OpenRegister's override-only user-config prefs.
+- Subjects ship in Dutch and English (ADR-007 / ADR-025).
+- CMS-config schemas (page/menu/theme/glossary/organization) are not
+  notified on.
+
+## Impact
+
+- Affected file: `lib/Settings/publication_register.json` (`catalog`
+  and `listing` schemas gain a `x-openregister-notifications` key).
+- No PHP, Vue, route, or migration changes.
+- Runtime dependency on the OpenRegister notification engine
+  (`notification-schema-rules-and-userconfig-prefs`, already archived).
+- The `listing-sync-failed` rule fires only if the sync process drives
+  status through a named transition action — see Caveats.
+
+## Caveats
+
+- **Transition actions must be wired by the sync/publish flows.** The
+  `transition` trigger fires on a named lifecycle action, not a raw
+  `status` write. For `catalog-stable` and `listing-sync-failed` to
+  fire, the catalogue-publish and listing-sync code must drive status
+  through OpenRegister transition actions named `stable` and `obsolete`
+  respectively. If they write `status` directly, these rules are
+  declared-but-dormant.
+- **No structured owner uid on `catalog` / `listing`.** Recipients use
+  `object-acl` (catalog) and `groups` (listing ops) rather than
+  `field`. The `publication-officers` group is assumed to exist in the
+  deployment; adjust the group name to match the operator's directory.
+- **`publication` is intentionally excluded** — no lifecycle field and
+  no owner uid to target. Revisit if a `status` or `ownerUid` field is
+  added to the `publication` schema.
+- **CMS-config schemas excluded by design** — `page`, `menu`, `theme`,
+  `glossary`, `organization` are configuration objects, not domain
+  data; no notifications declared on them.
+- The `updated` trigger has no field-changed condition yet (the engine
+  change `notification-updated-field-change-condition` adds it); this
+  change uses only `transition` to avoid that dependency.

--- a/openspec/changes/opencatalogi-notifications/specs/notifications/spec.md
+++ b/openspec/changes/opencatalogi-notifications/specs/notifications/spec.md
@@ -1,0 +1,38 @@
+# Notifications
+
+## ADDED Requirements
+
+### Requirement: Catalogue publication notification
+
+The OpenCatalogi `catalog` schema SHALL declare an
+`x-openregister-notifications` rule that notifies the catalogue's
+manage-ACL holders when it transitions to `stable`, with bilingual
+(nl/en) subjects.
+
+#### Scenario: Catalogue reaches stable
+
+- **WHEN** a `catalog` object transitions through the `stable` action
+- **THEN** the OpenRegister notification engine dispatches an `nc-notification` to the object's manage-ACL holders with a nl/en subject referencing `{{title}}`
+
+### Requirement: Listing sync-failure notification
+
+The OpenCatalogi `listing` schema SHALL declare an
+`x-openregister-notifications` rule that notifies the
+`publication-officers` group when a federated listing sync fails
+(transition to `obsolete`), with bilingual (nl/en) subjects.
+
+#### Scenario: Listing sync fails
+
+- **WHEN** a `listing` object transitions through the `obsolete` action
+- **THEN** the engine dispatches an `nc-notification` to the `publication-officers` group with a nl/en subject referencing `{{title}}` and `{{statusMessage}}`
+
+### Requirement: CMS-config and ownerless schemas are not notified
+
+OpenCatalogi SHALL NOT declare `x-openregister-notifications` on the
+CMS-config schemas (`page`, `menu`, `theme`, `glossary`, `organization`)
+or on `publication` (which has no lifecycle or owner field).
+
+#### Scenario: No notifications on config schemas
+
+- **WHEN** the publication register JSON is inspected
+- **THEN** no `x-openregister-notifications` key is present on `page`, `menu`, `theme`, `glossary`, `organization`, or `publication`

--- a/openspec/changes/opencatalogi-notifications/tasks.md
+++ b/openspec/changes/opencatalogi-notifications/tasks.md
@@ -1,11 +1,11 @@
 # Tasks — OpenCatalogi schema-declared notifications
 
-- [ ] Add `x-openregister-notifications` to the `catalog` schema in `lib/Settings/publication_register.json` with a `catalog-stable` rule (transition action `stable`, `object-acl` manage recipient)
-- [ ] Add `x-openregister-notifications` to the `listing` schema in `lib/Settings/publication_register.json` with a `listing-sync-failed` rule (transition action `obsolete`, `groups` recipient `publication-officers`)
+- [x] Add `x-openregister-notifications` to the `catalog` schema in `lib/Settings/publication_register.json` with a `catalog-stable` rule (transition action `stable`, `object-acl` manage recipient)
+- [x] Add `x-openregister-notifications` to the `listing` schema in `lib/Settings/publication_register.json` with a `listing-sync-failed` rule (transition action `obsolete`, `groups` recipient `publication-officers`)
 - [ ] Confirm the `publication-officers` group name matches the target deployment, or adjust the recipient group
-- [ ] Do NOT add notifications to CMS-config schemas (`page`, `menu`, `theme`, `glossary`, `organization`) or to `publication` (no lifecycle/owner field)
-- [ ] Provide nl + en subjects on every rule (ADR-007 / ADR-025)
-- [ ] Validate that `lib/Settings/publication_register.json` is still well-formed JSON after the edits
+- [x] Do NOT add notifications to CMS-config schemas (`page`, `menu`, `theme`, `glossary`, `organization`) or to `publication` (no lifecycle/owner field)
+- [x] Provide nl + en subjects on every rule (ADR-007 / ADR-025)
+- [x] Validate that `lib/Settings/publication_register.json` is still well-formed JSON after the edits
 - [ ] Confirm the catalogue-publish and listing-sync flows drive `status` through named OpenRegister transition actions (`stable`, `obsolete`) (prerequisite; see Caveats)
 
 ## Acceptance criteria

--- a/openspec/changes/opencatalogi-notifications/tasks.md
+++ b/openspec/changes/opencatalogi-notifications/tasks.md
@@ -1,0 +1,18 @@
+# Tasks — OpenCatalogi schema-declared notifications
+
+- [ ] Add `x-openregister-notifications` to the `catalog` schema in `lib/Settings/publication_register.json` with a `catalog-stable` rule (transition action `stable`, `object-acl` manage recipient)
+- [ ] Add `x-openregister-notifications` to the `listing` schema in `lib/Settings/publication_register.json` with a `listing-sync-failed` rule (transition action `obsolete`, `groups` recipient `publication-officers`)
+- [ ] Confirm the `publication-officers` group name matches the target deployment, or adjust the recipient group
+- [ ] Do NOT add notifications to CMS-config schemas (`page`, `menu`, `theme`, `glossary`, `organization`) or to `publication` (no lifecycle/owner field)
+- [ ] Provide nl + en subjects on every rule (ADR-007 / ADR-025)
+- [ ] Validate that `lib/Settings/publication_register.json` is still well-formed JSON after the edits
+- [ ] Confirm the catalogue-publish and listing-sync flows drive `status` through named OpenRegister transition actions (`stable`, `obsolete`) (prerequisite; see Caveats)
+
+## Acceptance criteria
+
+- `lib/Settings/publication_register.json` parses as valid JSON.
+- `catalog` declares a `catalog-stable` rule with a `transition` trigger and `object-acl` recipient.
+- `listing` declares a `listing-sync-failed` rule with a `transition` trigger and `groups` recipient.
+- No `x-openregister-notifications` key appears on `publication`, `page`, `menu`, `theme`, `glossary`, or `organization`.
+- Every rule has both `nl` and `en` subject strings.
+- No PHP, Vue, route, or migration files are changed.


### PR DESCRIPTION
OpenSpec change request (proposal + tasks + spec delta) for schema-declared notifications on OpenCatalogi's domain schemas.

- **catalog**: notify manage-ACL holders on transition to `stable` (publication milestone).
- **listing**: notify the `publication-officers` group when a federated sync fails (transition to `obsolete`, message inlined).
- **publication** and CMS-config schemas (page/menu/theme/glossary/organization) are deliberately NOT notified on.
- Subjects in nl + en. Config-only change to `lib/Settings/publication_register.json`.

**Caveat**: publish/sync flows must drive status through named OpenRegister transition actions; `publication` excluded (no lifecycle/owner field).

Source plan: `hydra/openspec/fleet-notification-plan.md`. Change request only — DRAFT, do not merge.