### PR TITLE
chore(openspec): leaf-migration + consume specs (ADR-022)

### DIFF
--- a/openspec/changes/migrate-activity-to-activity-leaf/design.md
+++ b/openspec/changes/migrate-activity-to-activity-leaf/design.md
@@ -1,0 +1,83 @@
+# Design: migrate-activity-to-activity-leaf
+
+## Context
+
+OpenCatalogi's two object-lifecycle listeners:
+
+| Listener | Reacts to | Today's behaviour |
+|---|---|---|
+| `lib/Listener/ObjectCreatedEventListener.php` | OR `ObjectCreatedEvent` | If auto-publish options enabled, converts the entity to an array and runs auto-publish + share-link logic via `EventService`. |
+| `lib/Listener/ObjectUpdatedEventListener.php` | OR `ObjectUpdatedEvent` | Same, on update, with a `shouldProcessUpdate()` gate. |
+
+These listeners are the only place object-change events are observed in
+OpenCatalogi, and there is **no user-facing per-object activity feed** — a user
+viewing a publication cannot see its create/update/publish history.
+
+## Decision: consume the OR activity leaf for the feed
+
+Per **hydra ADR-022**, a per-object activity feed is an OR abstraction (the
+activity leaf, ADR-019), sourced from OR's event stream + audit trail. OpenCatalogi
+MUST consume it rather than build a parallel listener-driven feed:
+
+1. **Frontend** — place the activity leaf widget on the publication detail page
+   via the manifest (`detail.config.sidebarTabs[].widgets[].type: "activity"`,
+   ADR-024 / ADR-036). The widget renders the publication's create / update /
+   publish / file-change history from the leaf.
+2. **Backend** — the listeners are no longer the de-facto "what happened"
+   surface; that is the leaf's job. The listeners are reduced to the genuinely
+   app-specific *side effect* that has no leaf equivalent.
+
+## The keep / migrate split (important)
+
+There are two distinct concerns tangled in the current listeners:
+
+- **The activity *feed* (observation / display)** — "show me what happened to
+  this publication." This is what the OR activity leaf provides and what this
+  change consumes. OpenCatalogi stops being the activity surface.
+- **The auto-publishing *side effect* (an action)** — "when an object in a
+  catalogue is created/updated, publish it and its attachments." This is
+  OpenCatalogi-specific business logic (catalogue membership + WOO publishing
+  policy) with **no OR leaf equivalent**, so the listener that triggers it stays.
+  Its *share-link* call is migrated separately by the
+  `migrate-share-links-to-shares-leaf` change; its *publish* decision is
+  app-specific and stays.
+
+So this change does NOT delete the auto-publish trigger; it removes the implicit
+"these listeners are our activity log" responsibility and adds the leaf-backed
+user-facing feed. The listeners also lose their debug `OPENCATALOGI_EVENT_*`
+logging noise as part of the cleanup.
+
+## Why not keep a bespoke feed
+
+- OpenCatalogi has no real feed today — building one now would be a brand-new
+  ADR-022 violation (home-grown activity trail on OR-owned objects).
+- The leaf's feed is hash-chained / replayable via OR's audit trail; a hand-built
+  feed would drift and miss file/share/relation events the leaf tracks.
+
+## Kept in-app (documented ADR-022 exceptions)
+
+Stated so reviewers do not flag them as un-migrated:
+
+- **Auto-publishing trigger + catalogue-membership / WOO publishing policy.**
+  No OR leaf decides "this catalogue auto-publishes its objects"; this is
+  OpenCatalogi domain logic. The listener that triggers it stays (its share call
+  migrates via the shares-leaf change).
+- **Public-facing CMS layer (Pages / Menus / Themes / Glossary).** Anonymous web
+  rendering of catalogue websites — not an authenticated object-detail tab, no
+  leaf equivalent. Stays in-app.
+- **PDF / ZIP `DownloadService`.** No OR leaf equivalent (DocuDesk partner).
+  Stays in-app.
+
+## Migration / sequencing
+
+1. Land the OR activity leaf (upstream, ADR-019). Apply is blocked on it.
+2. Add the activity widget to the publication detail manifest entry.
+3. Trim the listeners to the auto-publish trigger only; remove debug logging and
+   any implicit activity-recording responsibility.
+
+## Risks
+
+- **Don't break auto-publishing.** The publish-on-create/update behaviour must
+  keep working after the listeners are trimmed — verify auto-publish E2E.
+- **Feed completeness.** Confirm the leaf surfaces publish/depublish events
+  (OpenCatalogi sets `@self.published` / `@self.depublished`), not just CRUD.

--- a/openspec/changes/migrate-activity-to-activity-leaf/proposal.md
+++ b/openspec/changes/migrate-activity-to-activity-leaf/proposal.md
@@ -1,0 +1,53 @@
+# Change: migrate-activity-to-activity-leaf
+
+## Why
+
+OpenCatalogi maintains bespoke object-lifecycle listeners —
+`lib/Listener/ObjectCreatedEventListener.php` and
+`lib/Listener/ObjectUpdatedEventListener.php` — that react to OpenRegister's
+`ObjectCreatedEvent` / `ObjectUpdatedEvent` and drive in-app side effects
+(currently auto-publishing). These listeners are also the only place
+object-change activity is observed in OpenCatalogi: there is no user-facing
+"what happened to this publication" feed, and the listeners reimplement
+object-lifecycle reaction logic that OpenRegister now owns.
+
+OpenRegister exposes an **activity leaf** in its integration registry (ADR-019):
+a per-object activity feed (created / updated / published / file-changed events)
+sourced from OR's own event stream and audit trail, surfaced as an activity
+widget/tab on the object detail page (ADR-024). Per **hydra ADR-022**, an app
+that needs a per-object activity feed MUST consume the OR activity leaf rather
+than roll its own listener-driven feed.
+
+This change:
+
+- **Surfaces the OR activity leaf feed** on the publication detail page so users
+  see the publication's create/update/publish history — a capability OpenCatalogi
+  has no user-facing equivalent for today.
+- **Retires the bespoke activity-reaction responsibility** of
+  `ObjectCreatedEventListener` / `ObjectUpdatedEventListener`: object-change
+  *observation/feed* is consumed from the activity leaf, not reimplemented in-app.
+
+## What Changes
+
+- **Consume the OR activity leaf** for the per-publication activity feed, placed
+  as the activity widget/tab on `src/views/publications/PublicationDetail.vue` via
+  the app manifest (ADR-024 / ADR-036).
+- **Reduce the bespoke listeners** to only the genuinely app-specific side effect
+  that has no leaf equivalent — see design.md for the exact keep/migrate split
+  (the auto-publishing *side effect* is a separate concern from the activity
+  *feed*, and the `migrate-share-links-to-shares-leaf` change handles its share
+  call). The listeners stop being the de-facto activity surface.
+- **Add an activity capability** to the `auto-publishing` spec documenting that
+  object-change activity is consumed from the OR activity leaf, NOT from bespoke
+  in-app listeners.
+
+## Impact
+
+- Affected specs: `auto-publishing` (adds a consumed-from-leaf activity feed
+  requirement; clarifies the listeners' scope).
+- Affected code: `lib/Listener/ObjectCreatedEventListener.php`,
+  `lib/Listener/ObjectUpdatedEventListener.php` (scope reduced to non-leaf side
+  effects), `src/views/publications/PublicationDetail.vue` + `src/manifest.json`
+  (activity widget placement).
+- Dependency: OpenRegister activity leaf (integration registry, ADR-019). Apply
+  is blocked until the leaf is available; this is a SPEC-ONLY change.

--- a/openspec/changes/migrate-activity-to-activity-leaf/specs/auto-publishing/spec.md
+++ b/openspec/changes/migrate-activity-to-activity-leaf/specs/auto-publishing/spec.md
@@ -1,0 +1,68 @@
+---
+status: draft
+---
+
+# auto-publishing Specification (delta)
+
+This delta consumes the **OpenRegister activity leaf** (integration registry,
+ADR-019) for the per-publication activity feed and clarifies that OpenCatalogi's
+object-lifecycle listeners are NOT the user-facing activity surface (hydra
+ADR-022). The auto-publishing *side effect* — an OpenCatalogi-specific publishing
+policy with no OR leaf equivalent — is explicitly kept in-app; only the activity
+*feed* responsibility moves to the leaf.
+
+## ADDED Requirements
+
+### Requirement: Per-publication activity feed consumes the OpenRegister activity leaf (APB-ACT-001)
+The system MUST provide the per-publication activity feed (create / update /
+publish / depublish / file-change history) by **consuming the OpenRegister
+activity leaf** sourced from OR's event stream and audit trail — NOT by building
+a bespoke in-app activity log on top of `ObjectCreatedEventListener` /
+`ObjectUpdatedEventListener` (hydra ADR-022). The feed is surfaced as the activity
+widget on the publication detail page via the app manifest (ADR-024 / ADR-036).
+
+#### Scenario: View a publication's activity history
+- GIVEN a publication that has been created, updated, and published
+- WHEN a user opens the publication detail page and views the activity widget
+- THEN the create / update / publish events are listed from the OpenRegister
+  activity leaf
+- AND OpenCatalogi does NOT maintain a separate in-app activity table for these
+  events
+
+#### Scenario: Activity leaf absent
+- GIVEN the OpenRegister activity leaf / integration is not available
+- WHEN the publication detail page renders
+- THEN the activity widget degrades gracefully ("activity integration required")
+  rather than falling back to a bespoke feed
+
+## MODIFIED Requirements
+
+### Requirement: Listen to OpenRegister `ObjectCreatedEvent` and trigger auto-publishing logic (APB-001)
+The system MUST listen to OpenRegister `ObjectCreatedEvent` and trigger
+auto-publishing logic. This listener's responsibility is limited to the
+OpenCatalogi-specific **auto-publishing side effect** (catalogue-membership +
+WOO publishing policy), which has NO OpenRegister leaf equivalent and is
+explicitly kept in-app per hydra ADR-022. The listener MUST NOT serve as a
+bespoke activity feed — object-change activity is consumed from the OR activity
+leaf (APB-ACT-001). Debug `OPENCATALOGI_EVENT_*` logging is removed.
+
+#### Scenario: Created object triggers auto-publish only
+- GIVEN `auto_publish_objects` is enabled and a catalogue object is created
+- WHEN `ObjectCreatedEventListener` handles the event
+- THEN it performs only the auto-publishing side effect
+- AND it does NOT write to a bespoke activity log (the activity feed is the
+  OR activity leaf)
+
+### Requirement: Listen to OpenRegister `ObjectUpdatedEvent` and trigger auto-publishing logic (APB-002)
+The system MUST listen to OpenRegister `ObjectUpdatedEvent` and trigger
+auto-publishing logic. As with APB-001, the listener's scope is the
+OpenCatalogi-specific auto-publishing side effect only; the per-object activity
+feed is consumed from the OR activity leaf (APB-ACT-001), NOT reimplemented here.
+Debug `OPENCATALOGI_EVENT_*` logging is removed.
+
+#### Scenario: Updated object triggers auto-publish only
+- GIVEN `auto_publish_objects` is enabled and a catalogue object is updated such
+  that `shouldProcessUpdate()` passes
+- WHEN `ObjectUpdatedEventListener` handles the event
+- THEN it performs only the auto-publishing side effect
+- AND it does NOT write to a bespoke activity log

--- a/openspec/changes/migrate-activity-to-activity-leaf/tasks.md
+++ b/openspec/changes/migrate-activity-to-activity-leaf/tasks.md
@@ -1,0 +1,46 @@
+# Tasks: migrate-activity-to-activity-leaf
+
+This change consumes the OpenRegister activity leaf (hydra ADR-022) for the
+per-publication activity feed and trims the bespoke object-lifecycle listeners to
+the auto-publishing side effect only. SPEC-ONLY — apply runs through Hydra once
+the activity leaf is available upstream.
+
+## Task 1: Implementation planning
+- **Spec ref**: specs/auto-publishing/spec.md
+- **Status**: todo
+- **Acceptance criteria**: Requirements decomposed respecting the keep/migrate
+  split (feed → leaf; auto-publish side effect → stays); OR activity-leaf
+  availability confirmed as the apply gate.
+
+## Task 2: Surface the OR activity leaf feed on the publication detail page
+- **Spec ref**: specs/auto-publishing/spec.md — APB-ACT-001; ADR-024 / ADR-036
+- **Status**: todo
+- **Acceptance criteria**:
+  - Activity widget declared on the `PublicationDetail` manifest entry
+    (`src/manifest.json`) and rendered in `PublicationDetail.vue`.
+  - Feed lists create / update / publish / depublish / file-change events from
+    the activity leaf.
+  - Graceful "activity integration required" handling when the leaf is absent.
+  - NO bespoke in-app activity table is introduced.
+
+## Task 3: Trim ObjectCreatedEventListener to the auto-publish side effect (APB-001)
+- **Spec ref**: specs/auto-publishing/spec.md — APB-001
+- **Status**: todo
+- **Acceptance criteria**:
+  - Listener performs only the OpenCatalogi-specific auto-publish side effect.
+  - Debug `OPENCATALOGI_EVENT_*` logging removed.
+  - No implicit activity-recording responsibility remains.
+
+## Task 4: Trim ObjectUpdatedEventListener to the auto-publish side effect (APB-002)
+- **Spec ref**: specs/auto-publishing/spec.md — APB-002
+- **Status**: todo
+- **Acceptance criteria**:
+  - Listener performs only the auto-publish side effect behind `shouldProcessUpdate()`.
+  - Debug `OPENCATALOGI_EVENT_*` logging removed.
+
+## Task 5: Verify auto-publishing continuity and feed completeness
+- **Spec ref**: specs/auto-publishing/spec.md — APB-001, APB-002, APB-ACT-001
+- **Status**: todo
+- **Acceptance criteria**:
+  - Auto-publish on create/update still works end-to-end after the trim.
+  - The activity leaf feed includes publish/depublish events (not just CRUD).

--- a/openspec/changes/migrate-share-links-to-shares-leaf/design.md
+++ b/openspec/changes/migrate-share-links-to-shares-leaf/design.md
@@ -1,0 +1,71 @@
+# Design: migrate-share-links-to-shares-leaf
+
+## Context
+
+`lib/Service/FileService.php` carries three share methods:
+
+| Method | Spec | Behaviour |
+|---|---|---|
+| `createShareLink(string $path, ?int $shareType=3, ?int $permissions=null)` | FIL-005 | Resolves the user folder, fetches the file, calls private `createShare()` against `OCP\Share\IManager`, returns the URL. Defaults: type 3 (public), permissions 1 (read-only). |
+| `findShare(string $path, ?int $shareType=3)` | FIL-006 | Looks up an existing `IShare` for a path. |
+| `getShareLink(IShare $share)` | FIL-007 | Assembles `{protocol}://{host}/index.php/s/{token}`. |
+
+These are called from the auto-publishing path (`EventService` →
+`handleObjectCreateEvents` / `handleObjectUpdateEvents`) to make attachment files
+publicly downloadable, and indirectly by the publication/attachment views.
+
+## Decision: consume the OR shares leaf
+
+Per **hydra ADR-022**, sharing files attached to OR objects is an OR
+abstraction (shares leaf, ADR-019). OpenCatalogi MUST consume it:
+
+1. **Backend** — replace the bespoke `IManager` calls with calls to the shares
+   leaf's PHP service via DI (thin adapter only if needed). The leaf owns share
+   creation, lookup, and URL resolution for files attached to an OR object.
+2. **Frontend** — place the shares leaf widget on the publication detail page
+   via the manifest (`detail.config.sidebarTabs[].widgets[].type: "shares"`,
+   ADR-024 / ADR-036), giving users a real share-management surface.
+3. **Auto-publishing** — when `auto_publish_attachments` is enabled, the listener
+   requests a public share through the leaf instead of `createShareLink()`.
+
+The bespoke `createShareLink()` / `findShare()` / `getShareLink()` and the
+private `createShare()` helper are removed once all callers route through the leaf.
+
+## Why not keep the bespoke path
+
+- The leaf gains expiry / password / download-limit / internal-recipient shares
+  that the bespoke method will never track (ADR-022 "missed features").
+- Hand-built URL assembly drifts from the leaf's canonical resolution.
+- A second sharing mechanism on OR-owned files is a review-blocking anti-pattern
+  under ADR-022 ("app-local linked-files mechanism that mirrors an OR integration").
+
+## Kept in-app (documented ADR-022 exceptions)
+
+These are stated here so reviewers do not flag them as un-migrated:
+
+- **Public-facing CMS layer (Pages / Menus / Themes / Glossary).** This is
+  anonymous web rendering of catalogue websites, NOT an authenticated
+  object-detail tab. There is no shares-leaf equivalent for "render a public CMS
+  page"; it stays in OpenCatalogi.
+- **PDF / ZIP `DownloadService`.** Bundling a publication into a downloadable
+  PDF/ZIP archive has no OR leaf equivalent (DocuDesk is the document-generation
+  partner). The DownloadService keeps its own file orchestration; only the
+  *share-link* primitives migrate.
+
+## Migration / sequencing
+
+1. Land the OR shares leaf (upstream, ADR-019). This change's apply is blocked
+   on it.
+2. Re-point auto-publishing and any view callers to the leaf service.
+3. Remove `createShareLink()` / `findShare()` / `getShareLink()` / `createShare()`
+   from `FileService`.
+4. Add the shares widget to the publication detail manifest entry.
+
+## Risks
+
+- **Public anonymous download must keep working.** WOO requires unauthenticated
+  download of published attachments; verify the leaf's public-share output yields
+  the same anonymous-accessible URL the bespoke path produced.
+- **Existing live shares.** Links already minted by the bespoke path must remain
+  resolvable; the leaf's `findShare`-equivalent must discover them (they are
+  ordinary NC type-3 shares, so this should hold — verify at apply).

--- a/openspec/changes/migrate-share-links-to-shares-leaf/proposal.md
+++ b/openspec/changes/migrate-share-links-to-shares-leaf/proposal.md
@@ -1,0 +1,51 @@
+# Change: migrate-share-links-to-shares-leaf
+
+## Why
+
+OpenCatalogi rolls its own public share-link creation in
+`lib/Service/FileService.php` — `createShareLink()` (FIL-005), `findShare()`
+(FIL-006), and `getShareLink()` (FIL-007) directly drive Nextcloud's
+`OCP\Share\IManager` to mint type-3 public links, resolve permissions, and
+assemble the public URL. This is exactly the "app-local linked-files /
+sharing mechanism that mirrors an OR integration" anti-pattern called out in
+**hydra ADR-022**: OpenRegister now exposes a **shares leaf** in its
+integration registry (ADR-019) that owns public/internal share creation,
+discovery, expiry, and password protection for files attached to OR objects,
+and surfaces them as a share widget/tab on the object detail page (ADR-024).
+
+Keeping a parallel `IManager` path in OpenCatalogi means:
+
+- **Missed features** — the shares leaf gains expiry, password, download-limit,
+  and per-recipient internal shares; the bespoke `createShareLink()` never does.
+- **Drift** — OpenCatalogi's hand-built `{protocol}://{host}/index.php/s/{token}`
+  URL assembly diverges from the leaf's canonical link resolution.
+- **No UI parity** — share management is buried in the auto-publishing code path
+  with no user-facing surface on the attachment/publication detail page.
+
+This change migrates OpenCatalogi to **consume the OR shares leaf** for
+attachment/publication file sharing, surfaced as the shares widget on the
+publication detail page, and retires the bespoke `FileService` share methods.
+
+## What Changes
+
+- **Consume the OR shares leaf** for creating, finding, and resolving public
+  share links on files attached to Attachment / Publication objects, replacing
+  `FileService::createShareLink()`, `findShare()`, and `getShareLink()`.
+- **Surface the shares leaf widget** on the publication detail page
+  (`src/views/publications/PublicationDetail.vue`) via the app manifest
+  (ADR-024) so users manage shares from the object, not from buried service code.
+- **Re-point auto-publishing** (`EventService` / the auto-publish listeners) to
+  request shares through the leaf instead of the bespoke method when
+  `auto_publish_attachments` mints a public link.
+- **Retire** FIL-005 / FIL-006 / FIL-007 from the `file-management` spec, marking
+  them consumed-from-leaf rather than in-app.
+
+## Impact
+
+- Affected specs: `file-management` (FIL-005/006/007 → consumed from shares leaf).
+- Affected code: `lib/Service/FileService.php` (share methods removed),
+  `lib/Service/EventService.php` (auto-publish share call re-pointed),
+  `src/views/publications/PublicationDetail.vue` + `src/manifest.json` (shares
+  widget placement).
+- Dependency: OpenRegister shares leaf (integration registry, ADR-019). Apply is
+  blocked until the leaf is available; this is a SPEC-ONLY change.

--- a/openspec/changes/migrate-share-links-to-shares-leaf/specs/file-management/spec.md
+++ b/openspec/changes/migrate-share-links-to-shares-leaf/specs/file-management/spec.md
@@ -1,0 +1,66 @@
+---
+status: draft
+---
+
+# file-management Specification (delta)
+
+This delta migrates OpenCatalogi's bespoke public share-link creation
+(FIL-005/006/007) to the **OpenRegister shares leaf** per hydra ADR-022. Share
+creation, lookup, and URL resolution for files attached to Attachment /
+Publication objects are consumed from the leaf — NOT reimplemented against
+`OCP\Share\IManager` in `lib/Service/FileService.php`. The shares leaf widget is
+surfaced on the publication detail page via the app manifest (ADR-024 / ADR-036).
+
+## MODIFIED Requirements
+
+### Requirement: Create public share links (IShare type 3) for files with configurable permissions (FIL-005)
+The system MUST create public share links for files attached to Attachment /
+Publication objects by **consuming the OpenRegister shares leaf** (integration
+registry, ADR-019) — NOT by calling `OCP\Share\IManager` directly from a bespoke
+`FileService::createShareLink()` method (hydra ADR-022). The leaf owns share-type
+and permission semantics; OpenCatalogi requests a public (type-3, read-only by
+default) share through the leaf and the bespoke `createShareLink()` /
+`createShare()` methods are removed.
+
+#### Scenario: Auto-publish requests a public share via the leaf
+- GIVEN `auto_publish_attachments` is enabled
+- AND an attachment file is published for a catalogue object
+- WHEN the auto-publishing path needs a public download link
+- THEN the share is created by calling the OpenRegister shares leaf service
+- AND NO call is made to a bespoke `FileService::createShareLink()` /
+  `createShare()` against `OCP\Share\IManager`
+- AND the file remains anonymously downloadable (WOO public-access requirement)
+
+#### Scenario: Shares leaf absent
+- GIVEN the OpenRegister shares leaf / integration is not available
+- WHEN a share is requested
+- THEN OpenCatalogi degrades gracefully with a "sharing integration required"
+  signal rather than minting a parallel bespoke share
+
+### Requirement: Find existing share links for a file path (FIL-006)
+The system MUST discover existing share links for a file attached to an
+Attachment / Publication object by **consuming the OpenRegister shares leaf's
+lookup capability** — NOT via a bespoke `FileService::findShare()` that queries
+`OCP\Share\IManager` directly (hydra ADR-022). Shares previously minted as
+ordinary Nextcloud type-3 shares MUST remain discoverable through the leaf.
+
+#### Scenario: Resolve an already-shared attachment
+- GIVEN an attachment file already has a public share (whether minted by the
+  leaf or by the legacy bespoke path)
+- WHEN OpenCatalogi resolves the share for that file
+- THEN the existing share is returned via the shares leaf
+- AND no duplicate share is created
+
+### Requirement: Return full share link URLs including protocol and domain (FIL-007)
+The system MUST obtain the full public share URL for an attachment from the
+**OpenRegister shares leaf** rather than hand-assembling
+`{protocol}://{host}/index.php/s/{token}` in a bespoke `FileService::getShareLink()`
+(hydra ADR-022). The leaf is the single source of truth for canonical share-link
+resolution.
+
+#### Scenario: Surface share URL on the publication detail page
+- GIVEN a publication with attachments that have public shares
+- WHEN the publication detail page renders the shares widget
+- THEN the share URLs are resolved by the shares leaf and shown in the
+  shares widget placed via the app manifest (ADR-024 / ADR-036)
+- AND OpenCatalogi does NOT hand-assemble the share URL in PHP

--- a/openspec/changes/migrate-share-links-to-shares-leaf/tasks.md
+++ b/openspec/changes/migrate-share-links-to-shares-leaf/tasks.md
@@ -1,0 +1,55 @@
+# Tasks: migrate-share-links-to-shares-leaf
+
+This change consumes the OpenRegister shares leaf (hydra ADR-022) for public
+share-link creation/lookup/resolution on Attachment / Publication files, and
+retires the bespoke `FileService` share methods. SPEC-ONLY — apply runs through
+Hydra once the shares leaf is available upstream.
+
+## Task 1: Implementation planning
+- **Spec ref**: specs/file-management/spec.md
+- **Status**: todo
+- **Acceptance criteria**: Requirements decomposed into implementable tasks
+  respecting the consume-the-leaf approach; OR shares-leaf availability confirmed
+  as the apply gate.
+
+## Task 2: Consume the shares leaf for share creation (FIL-005)
+- **Spec ref**: specs/file-management/spec.md — FIL-005
+- **Status**: todo
+- **Acceptance criteria**:
+  - Public (type-3, read-only default) shares for attachment files are created by
+    calling the OpenRegister shares leaf service via DI.
+  - Auto-publishing (`auto_publish_attachments`) routes through the leaf.
+  - `FileService::createShareLink()` and private `createShare()` are removed.
+  - Published attachments remain anonymously downloadable.
+  - Graceful "sharing integration required" handling when the leaf is absent.
+
+## Task 3: Consume the shares leaf for share lookup (FIL-006)
+- **Spec ref**: specs/file-management/spec.md — FIL-006
+- **Status**: todo
+- **Acceptance criteria**:
+  - Existing shares (leaf-minted and legacy NC type-3) are discovered via the leaf.
+  - `FileService::findShare()` is removed; no duplicate shares are created.
+
+## Task 4: Consume the shares leaf for URL resolution (FIL-007)
+- **Spec ref**: specs/file-management/spec.md — FIL-007
+- **Status**: todo
+- **Acceptance criteria**:
+  - Full share URLs are obtained from the leaf; no PHP-side `{protocol}://{host}/...`
+    assembly remains.
+  - `FileService::getShareLink()` is removed.
+
+## Task 5: Surface the shares widget on the publication detail page
+- **Spec ref**: specs/file-management/spec.md — FIL-007; ADR-024 / ADR-036
+- **Status**: todo
+- **Acceptance criteria**:
+  - The shares leaf widget is declared on the `PublicationDetail` manifest entry
+    (`src/manifest.json`) and renders in `PublicationDetail.vue`.
+  - Users can create/view/revoke shares for a publication's attachments from the
+    object, not from buried service code.
+
+## Task 6: Verify WOO public-download and legacy-share continuity
+- **Spec ref**: specs/file-management/spec.md — FIL-005, FIL-006
+- **Status**: todo
+- **Acceptance criteria**:
+  - Anonymous download of a published attachment works end-to-end via the leaf.
+  - Links minted by the legacy bespoke path remain resolvable after migration.

--- a/openspec/changes/publication-detail-leaf-widgets/design.md
+++ b/openspec/changes/publication-detail-leaf-widgets/design.md
@@ -1,0 +1,77 @@
+# Design: publication-detail-leaf-widgets
+
+## Context
+
+OpenCatalogi detail pages render OR-backed objects via the manifest-driven
+`CnDetailPage` (ADR-024 / ADR-036). Today the `PublicationDetail` manifest entry
+(`src/manifest.json`) places only built-in `data` / `file-manager` / `metadata`
+widgets. The Organisation detail is likewise a plain object detail.
+
+Two pieces of existing data are ripe for a leaf widget:
+
+- **`Publication.geo`** — GeoJSON, defined by
+  `lib/Migration/Version6Date20241011085015.php` (`name: 'geo'`) and typed in
+  `src/entities/publication/publication.ts`. Currently shown (if at all) as raw
+  JSON.
+- **Organisation** — the contactable bestuursorgaan behind publications, with
+  ad-hoc contact text rather than structured linked contacts.
+
+## Decision: place leaf widgets declaratively via the manifest
+
+Per **hydra ADR-022** + **ADR-024 / ADR-036**, these capabilities are added by
+referencing OR integration leaves as manifest widgets — NOT by writing bespoke
+Vue map / contact components:
+
+1. **Maps leaf → publication detail.** Add a maps widget to the
+   `PublicationDetail` manifest entry, bound to `publication.geo`. Renders the
+   GeoJSON geometry (point / area / route) on a Leaflet-backed map. For
+   publications without `geo`, the widget hides / shows an empty state. Placement
+   form follows the existing `widgets[].widgetKey` / `sidebarTabs[].widgets[].type`
+   convention already used in `src/manifest.json`.
+2. **Contacts leaf → Organisation detail.** Add a contacts widget to the
+   Organisation object-detail manifest surface, binding to the Organisation's
+   linked OR contacts. Replaces free-text contact fields with the structured
+   contacts leaf.
+3. **Optional: photos + bookmarks → publication detail.** Photos surfaces image
+   attachments as a gallery; bookmarks surfaces curated external links per
+   publication. Optional placements — reviewers MAY omit either if its leaf is
+   not yet available.
+
+All placements are manifest-declared. No new PHP, no bespoke map/contact JS.
+
+## Why declarative leaf widgets, not bespoke components
+
+- A hand-built Leaflet map or contact card on OR objects is the ADR-022
+  "app-local mechanism that mirrors an OR integration" anti-pattern.
+- Manifest placement means OpenCatalogi inherits future leaf improvements
+  (clustering, WMS/WFS layers for maps; address validation for contacts) with
+  zero per-app work.
+
+## Kept in-app (documented ADR-022 exceptions)
+
+Stated so reviewers do not flag them as un-migrated:
+
+- **Public-facing CMS layer (Pages / Menus / Themes / Glossary).** This is
+  anonymous web rendering of catalogue websites — NOT an authenticated
+  object-detail tab — and has no leaf equivalent. It is NOT migrated to a leaf
+  and stays in OpenCatalogi.
+- **PDF / ZIP `DownloadService`.** Bundling a publication into a downloadable
+  PDF/ZIP archive has no OR leaf equivalent (DocuDesk is the document-generation
+  partner). Stays in-app.
+
+## Dependencies / sequencing
+
+- Maps leaf, contacts leaf (required); photos / bookmarks leaves (optional) — all
+  from the OR integration registry (ADR-019). Each widget's apply is gated on its
+  leaf being available; widgets land incrementally as leaves ship.
+
+## Risks
+
+- **`geo` shape variance.** `publication.geo` may hold point vs polygon vs
+  feature-collection; the maps widget must handle each or show a clean empty
+  state. Verify against `publication.mock.ts` fixtures at apply.
+- **Public/anonymous rendering.** Publication detail is reachable by anonymous
+  WOO consumers; confirm the maps widget renders (or cleanly hides) without an
+  authenticated session, consistent with the rest of the public publication view.
+- **Optional widgets gated independently.** Photos / bookmarks must not block the
+  maps + contacts placements if their leaves are not yet available.

--- a/openspec/changes/publication-detail-leaf-widgets/proposal.md
+++ b/openspec/changes/publication-detail-leaf-widgets/proposal.md
@@ -1,0 +1,57 @@
+# Change: publication-detail-leaf-widgets
+
+## Why
+
+OpenCatalogi's detail pages (Publication, Organisation) render OR-backed objects
+but surface none of OpenRegister's integration **leaves** that fit their data
+shape. Per **hydra ADR-022** (apps consume OR abstractions over local
+duplication) and **ADR-024 / ADR-036** (declarative manifest widget placement),
+the way to add these capabilities is to *place leaf widgets via the app
+manifest* — not to build bespoke map / contact components in-app.
+
+Two leaves map directly onto existing OpenCatalogi data:
+
+- **Maps leaf** — `Publication.geo` already carries GeoJSON
+  (`lib/Migration/Version6Date20241011085015.php` defines the `geo` property;
+  `publication.ts` types it). Geo publications (locations, areas, routes) should
+  show their geometry on a map widget instead of a raw JSON blob.
+- **Contacts leaf** — an Organisation is a contactable entity (the
+  responsible bestuursorgaan behind publications). The OR contacts leaf surfaces
+  linked contact persons / addresses on the Organisation detail, replacing
+  ad-hoc free-text contact fields.
+
+Optionally, **photos** (image attachments as a gallery) and **bookmarks**
+(curated external links per object) are leaves that also fit Publications and may
+be placed in the same change where they add value.
+
+This is a **net-new consume** change (no bespoke code is being replaced — these
+capabilities don't exist yet), placing leaf widgets on the relevant detail pages
+via the manifest.
+
+## What Changes
+
+- **Place the maps leaf widget** on the publication detail page for publications
+  that carry `geo` GeoJSON, via the `PublicationDetail` manifest entry
+  (`detail.config.sidebarTabs[].widgets[].type: "maps"` / a `type: "map-viewer"`
+  widget bound to `publication.geo`), surfaced in
+  `src/views/publications/PublicationDetail.vue`.
+- **Place the contacts leaf widget** on the Organisation detail (the
+  manifest-driven Organisation object detail / `OrganizationIndex` surface),
+  binding to the Organisation's linked contacts.
+- **Optionally place the photos and bookmarks leaf widgets** on the publication
+  detail page where they add value (image-gallery + curated links). Included as
+  optional manifest placements; reviewers may drop them if a leaf is unavailable.
+- **No bespoke map/contact/photo/bookmark code** is added — all placements are
+  manifest-declared leaf widgets (ADR-024 / ADR-036).
+
+## Impact
+
+- Affected specs: `publications` (adds geo-map + optional photos/bookmarks widget
+  placement requirements); a small `content-management`/organisation requirement
+  for the contacts widget on the Organisation detail.
+- Affected code: `src/manifest.json` (widget placements), and the detail views
+  they render in (`src/views/publications/PublicationDetail.vue`, the Organisation
+  detail surface). No new PHP.
+- Dependency: OpenRegister maps / contacts (and optional photos / bookmarks)
+  leaves (integration registry, ADR-019). Apply per-widget is blocked on each
+  leaf's availability; this is a SPEC-ONLY change.

--- a/openspec/changes/publication-detail-leaf-widgets/specs/publications/spec.md
+++ b/openspec/changes/publication-detail-leaf-widgets/specs/publications/spec.md
@@ -1,0 +1,81 @@
+---
+status: draft
+---
+
+# publications Specification (delta)
+
+This delta places OpenRegister integration **leaf widgets** on OpenCatalogi
+detail pages via the app manifest (hydra ADR-022, ADR-024 / ADR-036): the **maps
+leaf** on geo publications, the **contacts leaf** on the Organisation detail, and
+optionally the **photos** and **bookmarks** leaves on publications. These are
+net-new consume placements — no bespoke map / contact / photo / bookmark code is
+added.
+
+## ADDED Requirements
+
+### Requirement: Maps leaf widget on geo publications (PUB-MAP-001)
+The system MUST surface the geometry of a publication's `geo` GeoJSON property by
+**placing the OpenRegister maps leaf widget** on the publication detail page via
+the app manifest (`detail.config` widgets, ADR-024 / ADR-036) — NOT by building a
+bespoke Leaflet/map component in OpenCatalogi (hydra ADR-022). The widget binds to
+`publication.geo` and renders points / areas / routes on a map.
+
+#### Scenario: Publication with geo data shows a map
+- GIVEN a publication whose `geo` property contains valid GeoJSON
+- WHEN a user opens the publication detail page
+- THEN the maps leaf widget renders the geometry on a map
+- AND OpenCatalogi does NOT ship a bespoke map component for this
+
+#### Scenario: Publication without geo data
+- GIVEN a publication with no `geo` data (or invalid GeoJSON)
+- WHEN the publication detail page renders
+- THEN the maps widget hides or shows a clean empty state (no error)
+
+#### Scenario: Maps leaf absent
+- GIVEN the OpenRegister maps leaf / integration is not available
+- WHEN the publication detail page renders
+- THEN the maps widget degrades gracefully ("maps integration required")
+
+### Requirement: Contacts leaf widget on the Organisation detail (PUB-CON-001)
+The system MUST surface an Organisation's contact persons / addresses by
+**placing the OpenRegister contacts leaf widget** on the Organisation
+object-detail surface via the app manifest (ADR-024 / ADR-036) — NOT via ad-hoc
+free-text contact fields or a bespoke contact component (hydra ADR-022). The
+Organisation is the contactable bestuursorgaan behind publications.
+
+#### Scenario: View an Organisation's linked contacts
+- GIVEN an Organisation with linked OR contacts
+- WHEN a user opens the Organisation detail page
+- THEN the contacts leaf widget lists the linked contact persons / addresses
+- AND OpenCatalogi does NOT maintain a parallel contact model for this
+
+#### Scenario: Contacts leaf absent
+- GIVEN the OpenRegister contacts leaf / integration is not available
+- WHEN the Organisation detail page renders
+- THEN the contacts widget degrades gracefully ("contacts integration required")
+
+### Requirement: Optional photos and bookmarks leaf widgets on publications (PUB-MEDIA-001)
+The system MUST surface any publication image-attachment gallery or curated
+external-link list on the publication detail page by **placing the OpenRegister
+photos and bookmarks leaf widgets** via the app manifest (ADR-024 / ADR-036) —
+NOT by building bespoke gallery / link components (hydra ADR-022). These
+placements are optional and each MUST be gated independently on its leaf's
+availability; neither placement MUST block the maps (PUB-MAP-001) or contacts
+(PUB-CON-001) placements.
+
+#### Scenario: Photos widget shows an image gallery
+- GIVEN a publication with image attachments
+- AND the photos leaf is available
+- WHEN a user opens the publication detail page
+- THEN the photos leaf widget renders the images as a gallery
+
+#### Scenario: Bookmarks widget shows curated links
+- GIVEN a publication with curated external links
+- AND the bookmarks leaf is available
+- WHEN a user opens the publication detail page
+- THEN the bookmarks leaf widget lists the links
+
+#### Scenario: Optional leaf absent
+- GIVEN the photos or bookmarks leaf is not available
+- WHEN the publication detail page renders
+- THEN that optional widget is omitted without affecting the required widgets

--- a/openspec/changes/publication-detail-leaf-widgets/tasks.md
+++ b/openspec/changes/publication-detail-leaf-widgets/tasks.md
@@ -1,0 +1,52 @@
+# Tasks: publication-detail-leaf-widgets
+
+This change places OpenRegister integration leaf widgets on OpenCatalogi detail
+pages via the app manifest (hydra ADR-022, ADR-024 / ADR-036): maps on geo
+publications, contacts on the Organisation detail, optional photos / bookmarks on
+publications. SPEC-ONLY — apply runs through Hydra; each widget is gated on its
+leaf's availability upstream.
+
+## Task 1: Implementation planning
+- **Spec ref**: specs/publications/spec.md
+- **Status**: todo
+- **Acceptance criteria**: Requirements decomposed into per-widget manifest
+  placements; per-leaf availability confirmed as the apply gate; required (maps,
+  contacts) vs optional (photos, bookmarks) split respected.
+
+## Task 2: Place the maps leaf widget on geo publications (PUB-MAP-001)
+- **Spec ref**: specs/publications/spec.md — PUB-MAP-001; ADR-024 / ADR-036
+- **Status**: todo
+- **Acceptance criteria**:
+  - Maps widget declared on the `PublicationDetail` manifest entry
+    (`src/manifest.json`), bound to `publication.geo`.
+  - Renders points / areas / routes in `PublicationDetail.vue`.
+  - Clean empty state when `geo` is absent/invalid; graceful "maps integration
+    required" when the leaf is absent.
+  - NO bespoke map component added.
+
+## Task 3: Place the contacts leaf widget on the Organisation detail (PUB-CON-001)
+- **Spec ref**: specs/publications/spec.md — PUB-CON-001; ADR-024 / ADR-036
+- **Status**: todo
+- **Acceptance criteria**:
+  - Contacts widget declared on the Organisation object-detail manifest surface.
+  - Lists linked contact persons / addresses; graceful "contacts integration
+    required" when the leaf is absent.
+  - NO parallel contact model / bespoke contact component added.
+
+## Task 4: Optionally place photos + bookmarks leaf widgets on publications (PUB-MEDIA-001)
+- **Spec ref**: specs/publications/spec.md — PUB-MEDIA-001; ADR-024 / ADR-036
+- **Status**: todo
+- **Acceptance criteria**:
+  - Photos widget (image gallery) and bookmarks widget (curated links) declared
+    on the `PublicationDetail` manifest entry where their leaves are available.
+  - Each gated independently; omitting either does NOT affect the maps/contacts
+    widgets.
+
+## Task 5: Verify public/anonymous rendering and geo-shape variance
+- **Spec ref**: specs/publications/spec.md — PUB-MAP-001
+- **Status**: todo
+- **Acceptance criteria**:
+  - Maps widget renders or cleanly hides for anonymous WOO consumers (no auth
+    session), consistent with the public publication view.
+  - Point / polygon / feature-collection `geo` shapes (per
+    `publication.mock.ts`) all render or fall back cleanly.


### PR DESCRIPTION
## Summary

Three **SPEC-ONLY** OpenSpec changes for opencatalogi to consume OpenRegister integration **leaves** per hydra **ADR-022** (leaf-first + catalogue). No code is implemented — apply runs through Hydra later, gated on each leaf's upstream availability.

| Change | Scope |
|---|---|
| `migrate-share-links-to-shares-leaf` | Replace bespoke `FileService` public-share methods (FIL-005/006/007, `OCP\Share\IManager`) with the OR **shares** leaf; surface the shares widget on the publication detail page. |
| `migrate-activity-to-activity-leaf` | Surface the OR **activity** leaf feed on the publication detail page; trim the bespoke `ObjectCreated/UpdatedEventListener` to the auto-publish side effect only (no in-app activity log). |
| `publication-detail-leaf-widgets` | Net-new consume: place **maps** (on `publication.geo` GeoJSON), **contacts** (Organisation detail), and optional **photos**/**bookmarks** leaf widgets via the app manifest (ADR-024/036). |

All three pass `openspec validate <change> --strict`.

## Kept in-app (documented ADR-022 exceptions, stated in each design.md)
- **Public-facing CMS layer (Pages/Menus/Themes/Glossary)** — anonymous web rendering of catalogue websites, not an authenticated object tab; no leaf equivalent.
- **PDF/ZIP `DownloadService`** — no OR leaf equivalent (DocuDesk is the document-generation partner).

## Not touched
- `woo-transparency` change — already re-pointed to deck+flow in a separate PR; untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)