### PR TITLE
fix: add accessible labels to NcSelect components (hydra nc-input-labels gate)

### DIFF
--- a/src/components/FacetComponent.vue
+++ b/src/components/FacetComponent.vue
@@ -44,6 +44,7 @@
 								:value="getActiveFacetType(`@self.${fieldName}`)"
 								:options="getFacetTypeOptions(fieldInfo.facet_types)"
 								label="label"
+								:input-label="t('opencatalogi', 'Facet type')"
 								:placeholder="t('opencatalogi', 'Select facet type')"
 								@update:value="(option) => updateFacetType(`@self.${fieldName}`, option.value, fieldInfo)" />
 						</div>
@@ -55,6 +56,7 @@
 								:value="getActiveFacetInterval(`@self.${fieldName}`)"
 								:options="getIntervalOptions(fieldInfo.intervals)"
 								label="label"
+								:input-label="t('opencatalogi', 'Date histogram interval')"
 								:placeholder="t('opencatalogi', 'Select interval')"
 								@update:value="(option) => updateFacetInterval(`@self.${fieldName}`, option.value)" />
 						</div>
@@ -89,6 +91,7 @@
 								:value="getActiveFacetType(fieldName)"
 								:options="getFacetTypeOptions(fieldInfo.facet_types)"
 								label="label"
+								:input-label="t('opencatalogi', 'Facet type')"
 								:placeholder="t('opencatalogi', 'Select facet type')"
 								@update:value="(option) => updateFacetType(fieldName, option.value, fieldInfo)" />
 						</div>

--- a/src/modals/attachment/EditAttachmentModal.vue
+++ b/src/modals/attachment/EditAttachmentModal.vue
@@ -94,6 +94,7 @@ const handleCancel = () => {
 				<NcSelectTags
 					v-model="attachment.tags"
 					label="Tags"
+					:aria-label-combobox="t('opencatalogi', 'Tags')"
 					:disabled="loading" />
 				<NcCheckboxRadioSwitch
 					:checked.sync="attachment.published"

--- a/src/modals/generic/UploadFiles.vue
+++ b/src/modals/generic/UploadFiles.vue
@@ -13,6 +13,7 @@ import { catalogStore, navigationStore, objectStore } from '../../store/store.js
 			<div class="labelAndShareContainer">
 				<NcSelect v-bind="labelOptions"
 					v-model="labelOptions.value"
+					:input-label="t('opencatalogi', 'Labels')"
 					:disabled="loading || retryLoading || tagsLoading"
 					:loading="tagsLoading"
 					:taggable="true"

--- a/src/modals/object/MergeObject.vue
+++ b/src/modals/object/MergeObject.vue
@@ -107,6 +107,7 @@ import { objectStore, navigationStore, catalogStore } from '../../store/store.js
 										:options="getMergeOptions(property)"
 										label="label"
 										track-by="value"
+										:input-label="t('opencatalogi', 'Merge value')"
 										:placeholder="t('opencatalogi', 'Choose value for {property}', { property })"
 										@input="onPropertySelectionChange(property, $event)" />
 									<NcTextField

--- a/src/modals/object/MigrationObject.vue
+++ b/src/modals/object/MigrationObject.vue
@@ -107,6 +107,7 @@ import { objectStore, navigationStore } from '../../store/store.js'
 					:options="availableRegisters"
 					label="title"
 					track-by="id"
+					:aria-label-combobox="t('opencatalogi', 'Target Register')"
 					:placeholder="t('opencatalogi', 'Select a register...')"
 					@update:model-value="onRegisterChange" />
 			</div>
@@ -119,6 +120,7 @@ import { objectStore, navigationStore } from '../../store/store.js'
 					:options="availableSchemas"
 					label="title"
 					track-by="id"
+					:aria-label-combobox="t('opencatalogi', 'Target Schema')"
 					:placeholder="t('opencatalogi', 'Select a schema...')"
 					@update:model-value="onSchemaChange" />
 			</div>
@@ -165,6 +167,7 @@ import { objectStore, navigationStore } from '../../store/store.js'
 								:options="targetPropertyOptions"
 								label="label"
 								track-by="value"
+								:input-label="t('opencatalogi', 'Target property')"
 								:placeholder="t('opencatalogi', 'Map to target property...')"
 								:clearable="true"
 								@update:model-value="updateMappingFromUI(sourceProperty.name)" />

--- a/src/modals/object/ObjectModal.vue
+++ b/src/modals/object/ObjectModal.vue
@@ -37,6 +37,7 @@ import { objectStore, navigationStore, catalogStore } from '../../store/store.js
 								<NcSelect v-if="!selectedCatalogus"
 									v-model="selectedCatalogus"
 									:options="catalogOptions"
+									:aria-label-combobox="t('opencatalogi', 'Catalogus')"
 									label-outside
 									:disabled="objectStore.isLoading('object')"
 									required
@@ -59,6 +60,7 @@ import { objectStore, navigationStore, catalogStore } from '../../store/store.js
 								<NcSelect v-if="!selectedRegister"
 									v-model="selectedRegister"
 									:options="registerOptions"
+									:aria-label-combobox="t('opencatalogi', 'Register')"
 									label-outside
 									:disabled="objectStore.isLoading('object') || !selectedCatalogus"
 									required
@@ -80,6 +82,7 @@ import { objectStore, navigationStore, catalogStore } from '../../store/store.js
 								<NcSelect v-if="!selectedSchema"
 									v-model="selectedSchema"
 									:options="schemaOptions"
+									:aria-label-combobox="t('opencatalogi', 'Schema')"
 									label-outside
 									:disabled="objectStore.isLoading('object') || !selectedRegister"
 									required

--- a/src/modals/theme/AddPublicationThemeModal.vue
+++ b/src/modals/theme/AddPublicationThemeModal.vue
@@ -22,6 +22,7 @@ import { navigationStore, objectStore } from '../../store/store.js'
 					:items="themeOptions"
 					:value.sync="selectedTheme"
 					label="Choose a theme"
+					:input-label="t('opencatalogi', 'Theme')"
 					:disabled="isSaving || !themeOptions.length" />
 			</div>
 

--- a/src/sidebars/search/SearchSideBar.vue
+++ b/src/sidebars/search/SearchSideBar.vue
@@ -338,6 +338,7 @@ watch([
 								:value="getSelectedFilterValue(fieldName)"
 								:options="getFacetOptions(facetResult)"
 								label="label"
+								:aria-label-combobox="t('opencatalogi', 'Filter results')"
 								:placeholder="t('opencatalogi', 'Select a filter...')"
 								:clearable="true"
 								@option:selected="(option) => handleFilterSelect(fieldName, option)"
@@ -357,6 +358,7 @@ watch([
 							:value="currentSortOption"
 							:options="sortOptions"
 							label="label"
+							:aria-label-combobox="t('opencatalogi', 'Sort by')"
 							:label-outside="true"
 							:placeholder="t('opencatalogi', 'Choose sorting')"
 							@update:value="handleSortChange" />


### PR DESCRIPTION
Bucket-A safe fix from the fleet-wide hydra-gates sweep: adds input-label/aria-label-combobox to NcSelect components for WCAG a11y wiring. No behavior change. Security-semantic findings tracked in a separate backlog issue.