### PR TITLE
fix: real findings from fleet quality sweep (debug logging, license, stylelint, publiccode)

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -65,6 +65,7 @@ Create a [feature request](https://github.com/OpenCatalogi/.github/issues/new/ch
 
 	<background-jobs>
 		<job>OCA\OpenCatalogi\Cron\DirectorySync</job>
+		<job>OCA\OpenCatalogi\Cron\Broadcast</job>
 	</background-jobs>
 
 	<navigations>

--- a/lib/Controller/GlossaryController.php
+++ b/lib/Controller/GlossaryController.php
@@ -45,7 +45,6 @@ use RuntimeException;
  * @package   opencatalogi
  * @author    Ruben van der Linde
  * @copyright 2024
- * @license   AGPL-3.0-or-later
  * @version   1.0.0
  * @link      https://github.com/opencatalogi/opencatalogi
  */

--- a/lib/Listener/ObjectUpdatedEventListener.php
+++ b/lib/Listener/ObjectUpdatedEventListener.php
@@ -70,17 +70,10 @@ class ObjectUpdatedEventListener implements IEventListener
             // Get logger first for all logging.
             $logger = \OC::$server->get(\Psr\Log\LoggerInterface::class);
 
-            // Test logging to verify listener works.
-            $logger->debug("OPENCATALOGI_EVENT_LISTENER_CALLED_AT_".date('Y-m-d_H:i:s'));
-            $logger->debug("OPENCATALOGI_EVENT_CLASS: ".get_class($event));
-
             // Verify this is the correct event type.
             if ($event instanceof ObjectUpdatedEvent === false) {
-                $logger->debug("OPENCATALOGI_NOT_OBJECTUPDATEDEVENT_SKIPPING");
                 return;
             }
-
-            $logger->debug("OPENCATALOGI_CONFIRMED_OBJECTUPDATEDEVENT_PROCESSING");
 
             // Get services from the server container.
             $settingsService = \OC::$server->get(

--- a/publiccode.yml
+++ b/publiccode.yml
@@ -1,0 +1,61 @@
+publiccodeYmlVersion: "0.4"
+
+name: OpenCatalogi
+url: "https://github.com/ConductionNL/opencatalogi"
+softwareVersion: "0.7.34"
+releaseDate: "2026-05-26"
+developmentStatus: stable
+
+platforms:
+  - nextcloud
+
+categories:
+  - content-management
+  - knowledge-management
+
+description:
+  nl:
+    shortDescription: "Framework voor gefedereerde catalogi in Nextcloud"
+    longDescription: |
+      OpenCatalogi biedt een framework waarmee gefedereerde catalogi samenwerken
+      in een open data ecosysteem. De app synchroniseert bronnen met meerdere
+      catalogi en ondersteunt automatische publicatie van open data conform het
+      DIWOO-standaard.
+    features:
+      - Gefedereerde catalogi
+      - Automatische publicatie van open data
+      - DIWOO-sitemaps voor WOO-documenten
+      - Integratie met OpenRegister
+  en:
+    shortDescription: "Framework for federated catalogs in Nextcloud"
+    longDescription: |
+      OpenCatalogi provides a framework for federated catalogs to work together
+      in an open data ecosystem. The app synchronises sources with multiple
+      catalogs and supports automatic publication of open data following the
+      DIWOO metadata standard.
+    features:
+      - Federated catalogs
+      - Automatic open data publication
+      - DIWOO sitemaps for WOO documents
+      - OpenRegister integration
+
+legal:
+  license: EUPL-1.2
+
+localisation:
+  localisationReady: true
+  availableLanguages:
+    - nl
+    - en
+
+maintenance:
+  type: internal
+  contacts:
+    - name: Conduction Development Team
+      email: info@conduction.nl
+      affiliation: Conduction B.V.
+
+dependsOn:
+  open:
+    - name: OpenRegister
+      versionMin: "0.1.0"

--- a/src/dialogs/page/DeletePageContentDialog.vue
+++ b/src/dialogs/page/DeletePageContentDialog.vue
@@ -117,6 +117,3 @@ export default {
 	},
 }
 </script>
-
-<style scoped>
-</style>

--- a/src/modals/generic/UploadFiles.vue
+++ b/src/modals/generic/UploadFiles.vue
@@ -954,7 +954,7 @@ div[class='modal-container']:has(.TestMappingMainModal) .modal__content {
 }
 
 .success {
-	color: green;
+	color: var(--color-element-success);
 }
 
 .folderLink {
@@ -1071,7 +1071,7 @@ div[class='modal-container']:has(.TestMappingMainModal) .modal__content {
 	display: flex;
 	justify-content: center;
 	align-items: center;
-	min-width: calc(var(--min-size)* 2);
+	min-width: calc(var(--min-size) * 2);
 	max-width: 300px;
 }
 
@@ -1114,10 +1114,6 @@ div[class='modal-container']:has(.TestMappingMainModal) .modal__content {
 	align-items: end;
 	margin-block-end: 15px;
 	gap: 10px;
-}
-
-.success {
-	color: var(--color-element-success);
 }
 
 .failed {

--- a/src/modals/object/MergeObject.vue
+++ b/src/modals/object/MergeObject.vue
@@ -841,6 +841,7 @@ export default {
 .object-id {
 	color: var(--color-text-maxcontrast);
 	font-size: 0.9em;
+	font-family: monospace;
 	margin: 0;
 }
 
@@ -1022,12 +1023,6 @@ export default {
 	flex-direction: column;
 	gap: 4px;
 	margin-top: 8px;
-}
-
-.object-id {
-	color: var(--color-text-maxcontrast);
-	font-size: 0.9em;
-	font-family: monospace;
 }
 
 .object-title {

--- a/src/modals/object/ObjectModal.vue
+++ b/src/modals/object/ObjectModal.vue
@@ -732,6 +732,7 @@ export default {
 
 .codeMirrorContainer :deep(.cm-editor) {
 	height: 100%;
+	outline: none !important;
 }
 
 .codeMirrorContainer :deep(.cm-scroller) {
@@ -804,22 +805,9 @@ export default {
 	padding: 16px;
 }
 
-.form-field {
-	margin-bottom: 16px;
-}
-
-/* CodeMirror */
-.codeMirrorContainer {
-	margin-block-start: 6px;
-}
-
 .codeMirrorContainer :deep(.cm-content) {
 	border-radius: 0 !important;
 	border: none !important;
-}
-
-.codeMirrorContainer :deep(.cm-editor) {
-	outline: none !important;
 }
 
 .codeMirrorContainer.light > .vue-codemirror {

--- a/src/modals/object/ViewObject.vue
+++ b/src/modals/object/ViewObject.vue
@@ -2165,11 +2165,15 @@ export default {
 	justify-content: space-between;
 	text-align: left;
 	width: 100%;
+	flex-wrap: wrap;
 }
 
 .value-input-container {
 	flex: 1;
 	text-align: left;
+	padding: 0;
+	margin: 0;
+	width: 100%;
 }
 
 .drop-property-btn {
@@ -2218,14 +2222,6 @@ export default {
 .value-cell {
 	position: relative;
 	text-align: left;
-}
-
-.value-input-container {
-	flex: 1;
-	text-align: left;
-	padding: 0;
-	margin: 0;
-	width: 100%;
 }
 
 .value-input-container .text-field {
@@ -2561,10 +2557,6 @@ export default {
 .viewObjectDialog .viewTable td.td-labels {
 	white-space: nowrap;
 	word-break: unset;
-}
-
-.value-cell-content {
-	flex-wrap: wrap;
 }
 
 .viewObjectDialog .viewTable td.table-row-type {


### PR DESCRIPTION
## Summary

Real, clear findings from the fleet quality sweep — all safe to merge independently of larger refactors.

### Fixed

- **Remove debug logging** (`lib/Listener/ObjectUpdatedEventListener.php`): deleted 4 temporary `$logger->debug("OPENCATALOGI_EVENT_LISTENER_CALLED_AT_...")` lines and the conditional `OPENCATALOGI_NOT_OBJECTUPDATEDEVENT_SKIPPING` debug call that the spec marked as temporary/pre-production. Real `info`/`error` logging is untouched.
- **Competing license docblock** (`lib/Controller/GlossaryController.php`): removed `@license AGPL-3.0-or-later` from the class docblock; the file header is correctly EUPL-1.2.
- **Stylelint 0 errors** (was 9 errors across 5 files):
  - `src/dialogs/page/DeletePageContentDialog.vue`: remove empty `<style scoped>` block (`no-empty-source`)
  - `src/modals/generic/UploadFiles.vue`: fix `calc(var(--min-size)* 2)` → `calc(var(--min-size) * 2)` operator spacing; merge duplicate `.success` selector (upgrade from hardcoded `green` to `var(--color-element-success)`)
  - `src/modals/object/MergeObject.vue`: merge duplicate `.object-id` blocks (first gains `font-family: monospace` from second; second removed)
  - `src/modals/object/ObjectModal.vue`: merge duplicate `.form-field`, `.codeMirrorContainer`, `.codeMirrorContainer :deep(.cm-editor)` blocks (first gains `outline: none !important` from second set; second set removed)
  - `src/modals/object/ViewObject.vue`: merge duplicate `.value-input-container` (first gains `padding: 0; margin: 0; width: 100%`) and `.value-cell-content` (first gains `flex-wrap: wrap`) selector blocks
- **Register Broadcast cron job** (`appinfo/info.xml`): `OCA\OpenCatalogi\Cron\Broadcast` is a fully implemented `TimedJob` (4-hour interval, `BroadcastService`, `TIME_INSENSITIVE`, parallel-runs disabled) but was not registered in `<background-jobs>`. Added.
- **Add `publiccode.yml`**: minimal valid publiccode 0.4 file at repo root (name, url, version, releaseDate, developmentStatus stable, platforms: nextcloud, categories, EUPL-1.2, nl+en localisation, maintainer contact).

### Assessed / Deferred

- **`RobotsController` missing `hasWooSitemap` guard (WOO-008)**: `SitemapService::isValidSitemapRequest()` is a private method requiring `$catalogSlug` context that `RobotsController` does not have — the guard logic is not safe to add without a broader refactor. Left as-is; noted for reviewer.

### Verification

- `php -l` clean on both edited PHP files
- `npx stylelint "src/**/*.vue"`: **0 errors** (was 9)
- `npm run build`: **webpack exit 0** (pre-existing entrypoint size warnings only — not introduced by this PR)

PRODUCTION app — please review before merging.