### PR TITLE
ci(release-notes): publish stable releases to openwoo-app-website

### DIFF
--- a/.github/workflows/release-notes-publish.yml
+++ b/.github/workflows/release-notes-publish.yml
@@ -1,0 +1,77 @@
+name: Release notes publish
+
+# Phase-1 of deliverable #1 from hydra#279: every stable GitHub Release
+# of opencatalogi fires a repository_dispatch at openwoo-app-website so
+# the docs site can write a new docs/releases/vX.Y.Z.md page and rebuild.
+#
+# Pre-releases (beta / unstable) are skipped — Remco's call in
+# hydra#279, comment 4543711830: "Alleen op stable release-tag".
+#
+# Prerequisites (one-time, set by a repo admin):
+#
+#   1. Provision a fine-grained PAT or GitHub App token with
+#      `contents:read` on this repo and `contents:write` on
+#      ConductionNL/openwoo-app-website.
+#   2. Store it as the repo secret `RELEASE_NOTES_DISPATCH_TOKEN`.
+#
+# The listener lives in openwoo-app-website's
+# .github/workflows/release-notes-listener.yml.
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  dispatch-release-notes:
+    if: ${{ !github.event.release.prerelease && !github.event.release.draft }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Fire repository_dispatch at openwoo-app-website
+        env:
+          DISPATCH_TOKEN: ${{ secrets.RELEASE_NOTES_DISPATCH_TOKEN }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_NAME: ${{ github.event.release.name }}
+          RELEASE_BODY: ${{ github.event.release.body }}
+          RELEASE_URL: ${{ github.event.release.html_url }}
+          RELEASE_PUBLISHED_AT: ${{ github.event.release.published_at }}
+        run: |
+          set -euo pipefail
+
+          # Compose the client_payload as a JSON object. jq -n with --arg
+          # ensures every string is escaped correctly (newlines in
+          # RELEASE_BODY in particular need to land as JSON-escaped \n,
+          # not raw newlines in the request body).
+          payload=$(jq -n \
+            --arg source_repo "${{ github.repository }}" \
+            --arg source_app "opencatalogi" \
+            --arg tag "$RELEASE_TAG" \
+            --arg name "$RELEASE_NAME" \
+            --arg body "$RELEASE_BODY" \
+            --arg url "$RELEASE_URL" \
+            --arg published_at "$RELEASE_PUBLISHED_AT" \
+            '{event_type: "opencatalogi-release-published",
+              client_payload: {
+                source_repo: $source_repo,
+                source_app: $source_app,
+                tag: $tag,
+                name: $name,
+                body: $body,
+                html_url: $url,
+                published_at: $published_at
+              }}')
+
+          # GitHub's repository_dispatch endpoint accepts the
+          # client_payload + event_type via a POST to
+          # /repos/{owner}/{repo}/dispatches. We use the GH REST API
+          # directly via curl rather than `gh` so the workflow does
+          # not depend on the gh CLI being preinstalled with the
+          # right scopes.
+          curl --fail-with-body --silent --show-error \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $DISPATCH_TOKEN" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            -d "$payload" \
+            https://api.github.com/repos/ConductionNL/openwoo-app-website/dispatches


### PR DESCRIPTION
## Summary

Phase-1 of deliverable #1 from [hydra#279](https://github.com/ConductionNL/hydra/issues/279) — release-notes pipeline producer side. Adds `.github/workflows/release-notes-publish.yml` which fires a `repository_dispatch` event at `openwoo-app-website` on every stable GitHub Release of opencatalogi. The listener in openwoo-app-website (separate PR) turns the dispatch into `docs/releases/opencatalogi/<tag>.md` and the docs site rebuilds.

- Triggers on `release: { types: [published] }`
- Skips pre-releases and drafts (Remco's call in hydra#279 [comment 4543711830](https://github.com/ConductionNL/hydra/issues/279#issuecomment-4543711830) — *"alleen op stable release-tag"*)
- Path-traversal-safe payload (listener validates tag + source_app with regex whitelist)

## Setup needed before this workflow runs successfully

A repo admin needs to provision a fine-grained PAT or GitHub App token with `contents:read` on opencatalogi + `contents:write` on openwoo-app-website, and store it as the **\`RELEASE_NOTES_DISPATCH_TOKEN\`** repo secret in opencatalogi. Details in the workflow file header.

## Companion PR

The listener side lives in [openwoo-app-website#?](https://github.com/ConductionNL/openwoo-app-website/pulls) — merge that first so a triggered dispatch lands somewhere.

## Test plan

- [ ] Provision `RELEASE_NOTES_DISPATCH_TOKEN` secret in opencatalogi repo settings
- [ ] Merge the listener PR in openwoo-app-website first
- [ ] After both merged: cut a test stable release on opencatalogi → watch Actions tab here for green run → watch openwoo-app-website for the `release-notes-listener` workflow firing → check `docs/releases/opencatalogi/<tag>.md` lands and the docs deploy

Refs hydra#279.

🤖 Generated with [Claude Code](https://claude.com/claude-code)