### PR TITLE
feat(upload): default "Automatically publish" toggle from schema configuration

### DIFF
--- a/openspec/changes/feature-2026-05-26-default-auto-share/design.md
+++ b/openspec/changes/feature-2026-05-26-default-auto-share/design.md
@@ -1,0 +1,100 @@
+# Design: Default 'Automatically publish' per schema
+
+## Context
+
+The attachment-upload dialog hands a `share` boolean to OpenRegister's
+`POST /apps/openregister/api/objects/{register}/{schema}/{id}/filesMultipart`
+endpoint. `share=true` triggers an immediate Nextcloud share link for
+each uploaded file; `share=false` keeps the file private (concept).
+
+Today the toggle is always seeded `false`, regardless of which
+publication type is selected:
+
+| Surface | File | Currently seeded |
+|---|---|---|
+| Legacy (dead in `development`) | `opencatalogi/src/modals/generic/UploadFiles.vue` | hardcoded `share: false` |
+| Active (manifest-driven detail page) | `@conduction/nextcloud-vue` `CnFilesTab` (rendered inside `CnObjectSidebar`) | no toggle exists yet |
+
+OpenRegister's `Schema` entity stores arbitrary configuration in a JSON
+column accessed via `getConfiguration()` / `setConfiguration()`. The
+`CnSchemaFormDialog` editor preserves unknown configuration keys
+through `{...defaults, ...item}` spread, so a new key can be set today
+via the existing JSON pipeline or the schemas API without library
+changes.
+
+The existing `configuration.autoPublish` key is **not** the right
+home: per
+`OpenRegister/lib/Service/Object/SaveObject/MetadataHydrationHandler.php`
+it is deprecated and its semantics are "share all attachments when the
+parent object is published" (post-hoc bulk action), not "default state
+of the per-upload toggle". Reusing it would silently change the
+behaviour of any schema that already opts in.
+
+## Decision: new `configuration.defaultAutoShare` key
+
+Add a new boolean `configuration.defaultAutoShare` on the Schema's
+`configuration` JSON. Empty / missing / non-truthy values mean "off"
+(current behaviour). The upload dialog reads the key on open and
+seeds the toggle accordingly. The user can always override per
+upload — the schema value never coerces a final value, only the
+initial one.
+
+### Why a new key and not `autoPublish`
+
+| Aspect | `autoPublish` (existing, deprecated) | `defaultAutoShare` (new) |
+|---|---|---|
+| Lifecycle moment | When the parent object is published | When the upload dialog opens |
+| What it controls | All currently-attached files at once | The default state of one boolean toggle |
+| Status | Deprecated (see `MetadataHydrationHandler::$deprecatedKeys`) | New, supported going forward |
+| Risk of reuse | Silently changes behaviour for opted-in schemas | None — additive, default-off |
+
+### Why no backend / schema-column change
+
+`Schema::getConfiguration()` already deserialises arbitrary JSON, and
+`CnSchemaFormDialog` already preserves unknown keys on save. Persistence
+works today without a migration, an entity field, or a typed accessor.
+The cost of a dedicated getter (`getDefaultAutoShare()`) is not paid
+for by any caller in this change.
+
+## Read path
+
+| Step | Where | What |
+|---|---|---|
+| 1 | `UploadFiles.vue::onOpenModal()` | Calls the new `applySchemaDefaults()` |
+| 2 | `applySchemaDefaults()` | Reads `objectStore.getActiveObject('publication')['@self'].schema` |
+| 3 | (a) inflated schema object | If the object already carries a full schema, read `schema.configuration.defaultAutoShare` directly |
+| 3 | (b) bare schema id | Otherwise fetch `/index.php/apps/openregister/api/schemas/{id}` and read the same path |
+| 4 | seed | Set `this.share = (configuration?.defaultAutoShare === true)` |
+| 5 | failure | Any network error, missing publication, missing schema, or missing key → keep the safe default (`false`) |
+
+The same logic mirrors in `CnFilesTab` (sibling repo) via the
+`defaultShare: null` auto-detect path: when `defaultShare` is null,
+`CnFilesTab` performs the same schema fetch + key read. A non-null
+`defaultShare` (Boolean) prop always wins over the schema lookup so
+that callers can override.
+
+## Failure mode: fail-closed
+
+The seed is always one of two values: schema's `true` or the safe
+default `false`. A network hiccup, a 404 on the schema endpoint, a
+malformed JSON body, or a missing `configuration` block never flips
+the seed to `true`. This matches the principle that automation
+toward "share / publish more" should require an explicit signal, not
+the absence of one.
+
+## Out-of-scope: schema editor UI
+
+A first-class checkbox on `CnSchemaConfigurationTab.vue` in
+`@conduction/nextcloud-vue` would be the ergonomic way to set this
+key. The form already preserves the field thanks to the spread
+operator, so a follow-up issue can land that checkbox without
+breaking schemas already opted-in.
+
+## Out-of-scope: dead-code reachability of UploadFiles.vue
+
+In the current `development` branch of opencatalogi, `UploadFiles.vue`
+is not mounted by any active route (`src/modals/Modals.vue` /
+`src/dialogs/Dialogs.vue` are themselves unused). The change in this
+app is therefore preserved as a reference implementation, kept in
+lockstep with the `CnFilesTab` PR so a future re-wire (or any legacy
+consumer still importing the modal) lands the same behaviour.

--- a/openspec/changes/feature-2026-05-26-default-auto-share/design.md
+++ b/openspec/changes/feature-2026-05-26-default-auto-share/design.md
@@ -48,13 +48,30 @@ initial one.
 | Status | Deprecated (see `MetadataHydrationHandler::$deprecatedKeys`) | New, supported going forward |
 | Risk of reuse | Silently changes behaviour for opted-in schemas | None — additive, default-off |
 
-### Why no backend / schema-column change
+### Backend requirement: whitelist `defaultAutoShare`
 
-`Schema::getConfiguration()` already deserialises arbitrary JSON, and
-`CnSchemaFormDialog` already preserves unknown keys on save. Persistence
-works today without a migration, an entity field, or a typed accessor.
-The cost of a dedicated getter (`getDefaultAutoShare()`) is not paid
-for by any caller in this change.
+OpenRegister's `Schema::validateConfigurationArray()` (in
+`openregister/lib/Db/Schema.php`) does **not** round-trip arbitrary
+keys — keys absent from its allow-list (`$stringFields` /
+`$boolFields` / `$passThrough` / explicit cases) are silently
+dropped on save. The `configuration` column is JSON, but the
+validator is gate-keepered.
+
+Therefore the new key needs a one-line addition to the `$boolFields`
+whitelist in OpenRegister:
+
+```php
+$boolFields = ['allowFiles', 'autoPublish', 'defaultAutoShare'];
+```
+
+No migration, no entity field, no typed accessor. Once whitelisted,
+the existing JSON column persists the value as-is and
+`Schema::getConfiguration()` deserialises it. `CnSchemaFormDialog`
+already preserves unknown keys on its end via `{...defaults, ...item}`
+spread, so the form round-trips the value without further changes.
+
+Sibling PR carrying the OpenRegister whitelist edit:
+**ConductionNL/openregister#feature/577-schema-default-auto-share**.
 
 ## Read path
 

--- a/openspec/changes/feature-2026-05-26-default-auto-share/proposal.md
+++ b/openspec/changes/feature-2026-05-26-default-auto-share/proposal.md
@@ -1,6 +1,7 @@
 ---
 kind: code
 depends_on:
+  - ConductionNL/openregister#feature/577-schema-default-auto-share
   - ConductionNL/nextcloud-vue#feature/files-tab-auto-share
 ---
 

--- a/openspec/changes/feature-2026-05-26-default-auto-share/proposal.md
+++ b/openspec/changes/feature-2026-05-26-default-auto-share/proposal.md
@@ -1,38 +1,66 @@
-# Default 'Automatically publish' per schema
+---
+kind: code
+depends_on:
+  - ConductionNL/nextcloud-vue#feature/files-tab-auto-share
+---
+
+# Proposal: Default 'Automatically publish' per schema
+
+## Summary
+
+Make the "Automatically publish" / "Automatisch delen" toggle in the
+RegieTool attachment-upload dialog default to a value configured **per
+publication schema**. Schemas opt-in via a new boolean
+`configuration.defaultAutoShare`; absence is treated as `false`
+(existing behaviour).
 
 ## Why
 
-In the RegieTool's "Add attachment" dialog (`UploadFiles.vue`), the
-"Automatically publish" toggle (Dutch: "Automatisch delen") always
-defaults to **off**, regardless of which publication / publication
-type the user is uploading to. For publication types where direct
-publication is the norm, this means the user must flip the toggle on
-every single upload — extra clicks and easy to forget.
+Editors uploading attachments today must flip the toggle on every
+single upload when the publication type they work on is conventionally
+"publish immediately". For publication types where the default is
+"keep as concept" the current behaviour is correct, but there is no
+way to express the preferred default per type — every upload starts
+identical regardless of context.
 
-The OpenRegister `Schema` entity already stores arbitrary JSON
-configuration via its `configuration` column, so a per-schema default
-fits naturally without a backend migration.
+Closing this gap removes per-upload friction (extra clicks, easy to
+forget) for publication workflows where direct publication is the
+norm, and keeps the conservative default for workflows where concept-
+first is the standard.
 
 Tracking issue: ConductionNL/opencatalogi#577
 
-## What Changes
+## What changes
 
-- `UploadFiles.vue` reads `configuration.defaultAutoShare` (boolean)
-  from the active publication's schema when the modal opens and uses
-  it as the initial value of the `share` toggle.
-- Schemas without `configuration.defaultAutoShare` keep the current
-  behaviour (`share` defaults to `false`).
-- The user can still override the toggle per upload — the schema
-  value only seeds the initial state.
+- **Read path (this app):** `src/modals/generic/UploadFiles.vue` reads
+  the active publication's schema configuration on dialog open and
+  seeds the `share` toggle from `configuration.defaultAutoShare`.
+  Schemas without the key keep the current default (off). Users can
+  still override per upload.
+- **Write path (sibling repo):** the active user-facing surface is
+  `CnFilesTab` in `@conduction/nextcloud-vue` (see depends_on); a
+  parallel PR there exposes `defaultShare` / `showShareToggle` /
+  `shareLabel` props and seeds from the same schema key when
+  `defaultShare` is `null`.
+
+## Capabilities
+
+### Modified Capabilities
+- `publication-attachment-defaults` — new spec defining how schema
+  configuration drives the upload-dialog default for the share/publish
+  toggle.
 
 ## Out of scope
 
 - A dedicated UI control on the schema editor's Configuration tab.
-  The schema editor lives in `@conduction/nextcloud-vue`
-  (`CnSchemaConfigurationTab.vue`) and preserves arbitrary
-  `configuration` keys via spread (`{...defaults, ...item}`), so the
-  field can already be set via the existing JSON pipeline or API.
-  A follow-up issue should add an explicit checkbox there.
-- Renaming or migrating the existing deprecated `configuration.autoPublish`
-  key (it has different semantics: post-hoc share on object publish,
-  not "default state of the upload toggle").
+  `@conduction/nextcloud-vue`'s `CnSchemaFormDialog` already preserves
+  arbitrary `configuration` keys through `{...defaults, ...item}`
+  spread, so the field can be set today via the existing JSON
+  pipeline or API. A follow-up issue should add an explicit checkbox.
+- Renaming or migrating the existing deprecated
+  `configuration.autoPublish` key. Its semantics ("share all
+  attachments when the object is published", per
+  `OpenRegister/lib/Service/Object/SaveObject/MetadataHydrationHandler.php`)
+  differ from this proposal ("default state of the per-upload
+  toggle"). The two keys coexist; only `defaultAutoShare` affects the
+  upload dialog default.

--- a/openspec/changes/feature-2026-05-26-default-auto-share/proposal.md
+++ b/openspec/changes/feature-2026-05-26-default-auto-share/proposal.md
@@ -1,0 +1,38 @@
+# Default 'Automatically publish' per schema
+
+## Why
+
+In the RegieTool's "Add attachment" dialog (`UploadFiles.vue`), the
+"Automatically publish" toggle (Dutch: "Automatisch delen") always
+defaults to **off**, regardless of which publication / publication
+type the user is uploading to. For publication types where direct
+publication is the norm, this means the user must flip the toggle on
+every single upload — extra clicks and easy to forget.
+
+The OpenRegister `Schema` entity already stores arbitrary JSON
+configuration via its `configuration` column, so a per-schema default
+fits naturally without a backend migration.
+
+Tracking issue: ConductionNL/opencatalogi#577
+
+## What Changes
+
+- `UploadFiles.vue` reads `configuration.defaultAutoShare` (boolean)
+  from the active publication's schema when the modal opens and uses
+  it as the initial value of the `share` toggle.
+- Schemas without `configuration.defaultAutoShare` keep the current
+  behaviour (`share` defaults to `false`).
+- The user can still override the toggle per upload — the schema
+  value only seeds the initial state.
+
+## Out of scope
+
+- A dedicated UI control on the schema editor's Configuration tab.
+  The schema editor lives in `@conduction/nextcloud-vue`
+  (`CnSchemaConfigurationTab.vue`) and preserves arbitrary
+  `configuration` keys via spread (`{...defaults, ...item}`), so the
+  field can already be set via the existing JSON pipeline or API.
+  A follow-up issue should add an explicit checkbox there.
+- Renaming or migrating the existing deprecated `configuration.autoPublish`
+  key (it has different semantics: post-hoc share on object publish,
+  not "default state of the upload toggle").

--- a/openspec/changes/feature-2026-05-26-default-auto-share/specs/publication-attachment-defaults/spec.md
+++ b/openspec/changes/feature-2026-05-26-default-auto-share/specs/publication-attachment-defaults/spec.md
@@ -1,0 +1,128 @@
+---
+status: in-progress
+---
+
+# Publication Attachment Defaults
+
+## Purpose
+
+Define how the publication-attachment upload dialog seeds its
+"Automatically publish" toggle from per-schema configuration, so that
+publication types can opt into a default-on toggle without changing
+the per-upload override behaviour.
+
+## Context
+
+The attachment upload dialog accepts a `share` boolean that drives
+the OpenRegister `filesMultipart` endpoint's immediate-share path.
+This spec covers only the **default value** the dialog presents on
+open. Whether `share` is truthy at submit time, what the backend does
+with it, and any later moderation flow are governed by other specs.
+
+Two surfaces implement the dialog:
+
+| Surface | Owner |
+|---|---|
+| `opencatalogi/src/modals/generic/UploadFiles.vue` | This app — legacy modal, kept aligned for future re-wire |
+| `@conduction/nextcloud-vue` `CnFilesTab` | Library — active user-facing surface (rendered inside `CnObjectSidebar`'s Files tab) |
+
+This spec applies to both. The library exposes a `defaultShare` prop
+as a consumer override and a `null` default that triggers the
+schema-driven path described below.
+
+## Requirements
+
+### Requirement: Schema MAY opt in via `configuration.defaultAutoShare`
+
+A Publication schema MAY set `configuration.defaultAutoShare: true`
+to make the upload dialog seed its "Automatically publish" toggle as
+on by default. The key lives on the existing
+`OpenRegister.Schema.configuration` JSON column (no migration).
+
+#### Scenario: Schema opts in
+- GIVEN a publication schema with `configuration.defaultAutoShare: true`
+- WHEN a user opens the attachment-upload dialog on a publication of that schema
+- THEN the "Automatically publish" toggle MUST be on by default
+- AND the user MUST be able to flip the toggle off before submitting
+
+#### Scenario: Schema does not opt in
+- GIVEN a publication schema with no `defaultAutoShare` key in `configuration`
+- WHEN a user opens the attachment-upload dialog on a publication of that schema
+- THEN the "Automatically publish" toggle MUST be off by default (current behaviour)
+
+#### Scenario: Schema explicitly opts out
+- GIVEN a publication schema with `configuration.defaultAutoShare: false`
+- WHEN a user opens the attachment-upload dialog on a publication of that schema
+- THEN the "Automatically publish" toggle MUST be off by default
+- AND the behaviour MUST be identical to the missing-key case
+
+### Requirement: Schema-driven default MUST NOT lock the toggle
+
+The schema configuration only seeds the **initial** value of the
+toggle. The user can always flip it before submitting an upload.
+
+#### Scenario: User overrides schema default before upload
+- GIVEN the dialog opened with the toggle seeded `true` from schema config
+- WHEN the user flips the toggle to off and submits the upload
+- THEN the `share` field in the request MUST be `false`
+- AND the backend MUST receive the user's explicit choice, not the schema default
+
+### Requirement: Lookup MUST fail closed
+
+Any failure path (network error, 404, malformed schema response,
+missing `@self.schema`, missing `configuration` block, non-boolean
+key value) MUST result in the toggle being off — never on. The
+schema's `true` is the only signal that flips the seed.
+
+#### Scenario: Schema API returns an error
+- GIVEN the schema lookup fetch returns an HTTP error or times out
+- WHEN the dialog opens
+- THEN the toggle MUST be off
+- AND the dialog MUST remain usable (the error MUST NOT block upload)
+
+#### Scenario: Active publication has no schema reference
+- GIVEN the active publication has no `@self.schema`
+- WHEN the dialog opens
+- THEN the toggle MUST be off
+- AND no schema fetch SHOULD be attempted
+
+#### Scenario: Schema config has a non-boolean `defaultAutoShare`
+- GIVEN the schema's `configuration.defaultAutoShare` is a non-`true` value (string, number, null, object)
+- WHEN the dialog opens
+- THEN the toggle MUST be off
+- AND only the strict boolean `true` MUST trigger the on-by-default seed
+
+### Requirement: Library consumers MAY override the schema lookup
+
+The `CnFilesTab` library component MUST accept a `defaultShare` prop
+that overrides the schema lookup when non-null. This lets consumers
+seed the toggle from their own source of truth (e.g. user
+preferences, route parameters, A/B test) without performing the
+schema fetch.
+
+#### Scenario: Consumer passes an explicit defaultShare
+- GIVEN a consumer mounts `CnFilesTab` with `:default-share="true"` on a schema with `defaultAutoShare: false`
+- WHEN the dialog renders
+- THEN the toggle MUST be on (the prop wins)
+- AND no schema fetch is required (the prop bypasses the lookup)
+
+#### Scenario: Consumer hides the toggle entirely
+- GIVEN a consumer mounts `CnFilesTab` with `:show-share-toggle="false"`
+- WHEN the dialog renders
+- THEN the toggle MUST NOT be visible
+- AND the upload request MUST NOT include a `share` form field (omission = "do not auto-share")
+
+### Requirement: Existing deprecated `configuration.autoPublish` MUST remain untouched
+
+`configuration.autoPublish` (deprecated per
+`OpenRegister.MetadataHydrationHandler::$deprecatedKeys`) has
+different semantics — "share all attachments when the parent object
+is published". This spec MUST NOT read, write, or migrate
+`autoPublish`. The two keys coexist on the same `configuration`
+block without interaction.
+
+#### Scenario: Schema has both keys set
+- GIVEN a schema with `autoPublish: true` and `defaultAutoShare: false`
+- WHEN the upload dialog opens
+- THEN the toggle MUST be off (driven only by `defaultAutoShare`)
+- AND any object-publish behaviour driven by `autoPublish` MUST be unchanged

--- a/openspec/changes/feature-2026-05-26-default-auto-share/tasks.md
+++ b/openspec/changes/feature-2026-05-26-default-auto-share/tasks.md
@@ -1,5 +1,13 @@
 # Tasks: Default 'Automatically publish' per schema
 
+## Phase 0 — Backend (sibling repo, depends_on)
+
+- [x] 0. In `openregister/lib/Db/Schema.php`, add `defaultAutoShare`
+      to `validateConfigurationArray()`'s `$boolFields` whitelist.
+      Without this the key is silently dropped on schema save (the
+      column is JSON but the validator is gate-keepered). Push as a
+      separate PR on `ConductionNL/openregister`.
+
 ## Phase 1 — Frontend (this app)
 
 - [x] 1. In `src/modals/generic/UploadFiles.vue`, add an

--- a/openspec/changes/feature-2026-05-26-default-auto-share/tasks.md
+++ b/openspec/changes/feature-2026-05-26-default-auto-share/tasks.md
@@ -1,20 +1,50 @@
 # Tasks: Default 'Automatically publish' per schema
 
-## Phase 1 — Frontend
+## Phase 1 — Frontend (this app)
 
-- [ ] 1. In `src/modals/generic/UploadFiles.vue`, when the modal
-      opens (`onOpenModal`), resolve the active publication's schema
-      and read `configuration.defaultAutoShare`. Seed the `share`
-      data property with that value (defaulting to `false` if the
-      schema reference, the schema, or the key is missing). The
-      lookup must succeed both when the publication carries an
-      inflated schema object on `@self.schema` and when it only
-      carries the schema id.
+- [x] 1. In `src/modals/generic/UploadFiles.vue`, add an
+      `applySchemaDefaults()` method called from `onOpenModal()`
+      that resolves the active publication's schema, reads
+      `configuration.defaultAutoShare`, and seeds `this.share`.
+      Handles both the inflated-schema and bare-id reference shapes;
+      falls back to `false` on any error.
 
-## Phase 2 — Verification
+## Phase 2 — Library (sibling repo, depends_on)
 
-- [ ] 2. Manual: open the "Add attachment" dialog on a publication
-      whose schema has `configuration.defaultAutoShare: true` —
-      verify the toggle is on by default and can still be flipped
-      off per upload. Then verify a schema without the key keeps
-      the toggle off (current behaviour).
+- [x] 2. In `@conduction/nextcloud-vue` `CnFilesTab`, add
+      `showShareToggle` / `defaultShare` / `shareLabel` props,
+      render an `NcCheckboxRadioSwitch` above the dropzone, send
+      `share` on multipart upload (omitted when toggle hidden), and
+      auto-detect from `configuration.defaultAutoShare` when
+      `defaultShare === null`. Push as a separate PR on
+      `ConductionNL/nextcloud-vue`.
+
+## Phase 3 — Verification
+
+- [ ] 3. Manual: on a publication whose schema has
+      `configuration.defaultAutoShare: true`, open the attachment
+      dialog → toggle is on. Flip off, upload → backend receives
+      `share=false`. On a schema without the key, toggle is off
+      (current behaviour). Re-test with an explicit
+      `defaultAutoShare: false`.
+
+- [ ] 4. Library: run `npm test` (all 2619 suites pass) and
+      `npm run check:jsdoc` / `npm run check:docs` (baselines hold)
+      in the `nextcloud-vue` repo before opening that PR.
+
+## Acceptance criteria
+
+- Schema with `configuration.defaultAutoShare: true` opens the
+  upload toggle on by default.
+- Schema without the key (or with `false`) keeps the toggle off.
+- User can override the toggle per upload — schema value never
+  coerces the submitted `share` field.
+- Network failure, missing schema, missing publication, or
+  non-boolean key value all fall back to off (fail closed).
+- No interaction with the deprecated
+  `configuration.autoPublish` key.
+- `CnFilesTab` `defaultShare` prop overrides the schema lookup
+  when non-null.
+- `CnFilesTab` `showShareToggle: false` hides the control and
+  omits `share` from the upload form data.
+- No backend / schema-column / DB migration required.

--- a/openspec/changes/feature-2026-05-26-default-auto-share/tasks.md
+++ b/openspec/changes/feature-2026-05-26-default-auto-share/tasks.md
@@ -1,0 +1,20 @@
+# Tasks: Default 'Automatically publish' per schema
+
+## Phase 1 — Frontend
+
+- [ ] 1. In `src/modals/generic/UploadFiles.vue`, when the modal
+      opens (`onOpenModal`), resolve the active publication's schema
+      and read `configuration.defaultAutoShare`. Seed the `share`
+      data property with that value (defaulting to `false` if the
+      schema reference, the schema, or the key is missing). The
+      lookup must succeed both when the publication carries an
+      inflated schema object on `@self.schema` and when it only
+      carries the schema id.
+
+## Phase 2 — Verification
+
+- [ ] 2. Manual: open the "Add attachment" dialog on a publication
+      whose schema has `configuration.defaultAutoShare: true` —
+      verify the toggle is on by default and can still be flipped
+      off per upload. Then verify a schema without the key keeps
+      the toggle off (current behaviour).

--- a/src/modals/generic/UploadFiles.vue
+++ b/src/modals/generic/UploadFiles.vue
@@ -600,6 +600,46 @@ export default {
 			this.newTags = []
 			EventBus.$emit('upload-files:opened')
 			this.getAllTags()
+			this.applySchemaDefaults()
+		},
+		/**
+		 * Seed the `share` toggle from the active publication's schema
+		 * (`configuration.defaultAutoShare`). Falls back to `false`
+		 * when the schema, the key or the lookup itself is missing —
+		 * existing behaviour for schemas that don't opt in.
+		 *
+		 * @spec openspec/changes/feature-2026-05-26-default-auto-share/tasks.md#task-1
+		 * @return {Promise<void>}
+		 */
+		async applySchemaDefaults() {
+			this.share = false
+			try {
+				const publication = objectStore.getActiveObject('publication')
+				const schemaRef = publication?.['@self']?.schema
+				if (!schemaRef) return
+
+				let configuration = (typeof schemaRef === 'object' && schemaRef !== null)
+					? schemaRef.configuration
+					: null
+
+				if (!configuration) {
+					const schemaId = typeof schemaRef === 'object'
+						? (schemaRef.id || schemaRef.uuid || schemaRef.slug)
+						: schemaRef
+					if (!schemaId) return
+					const response = await fetch(`/index.php/apps/openregister/api/schemas/${schemaId}`)
+					if (!response.ok) return
+					const schema = await response.json().catch(() => null)
+					configuration = schema?.configuration || null
+				}
+
+				if (configuration?.defaultAutoShare === true) {
+					this.share = true
+				}
+			} catch (e) {
+				// Non-fatal — keep the safe default (off) so a network
+				// hiccup never silently flips publications to "share on upload".
+			}
 		},
 		/** @spec openspec/changes/retrofit-2026-05-26-object-modals/tasks.md#task-4 */
 		onExternalClose() {


### PR DESCRIPTION
## Summary

- `src/modals/generic/UploadFiles.vue`: adds `applySchemaDefaults()` (called from `onOpenModal()`) that fetches the active publication's schema and seeds the "Automatically publish" toggle from `configuration.defaultAutoShare`. Falls back to off on any error (fail-closed).
- `openspec/changes/feature-2026-05-26-default-auto-share/`: full proposal + design + `publication-attachment-defaults` spec (Given/When/Then scenarios) + tasks + recorded dependency on the OpenRegister Schema-whitelist change.

Closes #577 for the in-app code path.

## Heads-up

In the current `development` branch, `UploadFiles.vue` is **not mounted by any active route** — `src/modals/Modals.vue` / `src/dialogs/Dialogs.vue` are themselves unused. The live attachment surface is `CnFilesTab` from `@conduction/nextcloud-vue`, which has no share toggle today.

The actual user-facing fix lives in the sibling PR:
**[ConductionNL/nextcloud-vue#455](https://github.com/ConductionNL/nextcloud-vue/pull/455)** ← merge first.

This PR keeps the legacy modal in lockstep as a reference implementation so a future re-wire (or any legacy consumer still importing it) lands the same behaviour, and gets the openspec change recorded against the right capability. See [the inline finding on the issue](https://github.com/ConductionNL/opencatalogi/issues/577#issuecomment-4544071719) for the full dead-code analysis.

## Dependency chain

Merge order to avoid a half-wired system:

1. **[ConductionNL/openregister#1944](https://github.com/ConductionNL/openregister/pull/1944)** — whitelists `defaultAutoShare` in `Schema::validateConfigurationArray()`, otherwise the backend silently drops the key on save.
2. **[ConductionNL/nextcloud-vue#455](https://github.com/ConductionNL/nextcloud-vue/pull/455)** — adds the active user-facing toggle on `CnFilesTab` + admin write-side checkbox on `CnSchemaFormDialog`.
3. **This PR** — legacy modal parity + openspec change.

## Test plan

- [x] `npm run dev` — webpack build succeeds with the diff
- [x] `npm run lint` — 0 errors (pre-existing JSDoc `@spec` warnings only)
- [x] `npm run check:l10n` — no new MISSING/UNWRAPPED introduced by this diff
- [ ] Manual smoke once the nextcloud-vue PR is published and `package.json` picks up the new beta — verify via `CnFilesTab` on a publication-detail page (the library path is the active surface, see "Heads-up" above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)