### PR TITLE
fix(security): SSRF guard + public-read RBAC/published enforcement

### DIFF
--- a/lib/Controller/CatalogiController.php
+++ b/lib/Controller/CatalogiController.php
@@ -183,21 +183,26 @@ class CatalogiController extends Controller
         // Build search query for searchObjectsPaginated.
         $searchQuery = $this->getObjectService()->buildSearchQuery($requestParams);
 
-        // Add schema filter if configured.
+        // Constrain the query to the configured catalog register/schema.
+        // Set the top-level _register/_schema keys directly: the @self keys produced
+        // by buildSearchQuery are overwritten/normalized downstream, so the configured
+        // scope must be pinned via the magic-mapper routing keys to actually take effect.
         if (empty($catalogConfig['schema']) === false) {
+            $searchQuery['_schema']         = $catalogConfig['schema'];
             $searchQuery['@self']['schema'] = $catalogConfig['schema'];
         }
 
-        // Add register filter if configured.
         if (empty($catalogConfig['register']) === false) {
+            $searchQuery['_register']         = $catalogConfig['register'];
             $searchQuery['@self']['register'] = $catalogConfig['register'];
         }
 
         // Fetch catalog objects using searchObjectsPaginated.
+        // _rbac: true enforces schema authorization rules (anonymous callers only see
+        // what RBAC permits); multitenancy is left enabled so org scoping is not bypassed.
         $result = $this->getObjectService()->searchObjectsPaginated(
             query: $searchQuery,
-            _rbac: false,
-            _multitenancy: false,
+            _rbac: true,
             deleted: false
         );
 

--- a/lib/Controller/DirectoryController.php
+++ b/lib/Controller/DirectoryController.php
@@ -35,6 +35,7 @@ use OCP\IL10N;
 use OCP\IRequest;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\NotFoundExceptionInterface;
+use Psr\Log\LoggerInterface;
 
 /**
  * Controller for handling directory-related operations.
@@ -70,6 +71,7 @@ class DirectoryController extends Controller
      * @param IRequest         $request            The request object.
      * @param DirectoryService $directoryService   The directory service.
      * @param IL10N            $l10n               The localization service.
+     * @param LoggerInterface  $logger             PSR-3 logger.
      * @param string           $corsMethods        Allowed CORS methods.
      * @param string           $corsAllowedHeaders Allowed CORS headers.
      * @param integer          $corsMaxAge         CORS max age.
@@ -79,6 +81,7 @@ class DirectoryController extends Controller
         IRequest $request,
         private readonly DirectoryService $directoryService,
         private readonly IL10N $l10n,
+        private readonly LoggerInterface $logger,
         string $corsMethods='PUT, POST, GET, DELETE, PATCH',
         string $corsAllowedHeaders='Authorization, Content-Type, Accept',
         int $corsMaxAge=1728000
@@ -236,11 +239,17 @@ class DirectoryController extends Controller
                 statusCode: 400
             );
         } catch (GuzzleException $e) {
-            // Handle HTTP/network errors.
+            // Handle HTTP/network errors. Do NOT reflect the upstream response body
+            // (it may contain internal content from an SSRF-style probe). Log details
+            // server-side instead and return a generic message to the caller.
+            $this->logger->warning(
+                '[DirectoryController::update] Upstream fetch failed',
+                ['error' => $e->getMessage()]
+            );
             $response = new JSONResponse(
                 data: [
                     'message' => $this->l10n->t('Failed to fetch directory data'),
-                    'error'   => $e->getMessage(),
+                    'error'   => $this->l10n->t('Unable to reach the requested directory'),
                 ],
                 statusCode: 502
             );

--- a/lib/Controller/PublicationsController.php
+++ b/lib/Controller/PublicationsController.php
@@ -229,6 +229,12 @@ class PublicationsController extends Controller
                 _multitenancy: false
             );
 
+            // Enforce server-side published predicate for anonymous callers.
+            // Authenticated callers keep RBAC-scoped behavior; anonymous callers only
+            // see objects that are published (and not depublished). Anon-vs-auth is
+            // derived from the server-side user session, never from a client param.
+            $result = $this->queryService->enforcePublishedForAnonymous($result);
+
             // Strip empty values from results unless _empty=true is set.
             $includeEmpty = filter_var(
                 value: $this->request->getParam(key: '_empty', default: false),
@@ -436,6 +442,34 @@ class PublicationsController extends Controller
                     'register' => $object->getRegister(),
                 ]
             );
+
+            // Enforce server-side published predicate for anonymous callers.
+            // Anonymous callers may only retrieve published (and non-depublished)
+            // objects; an unpublished object is reported as not found. Authenticated
+            // callers keep RBAC-scoped behavior. Anon-vs-auth is derived server-side.
+            if ($this->queryService->isAnonymous() === true
+                && $this->queryService->isObjectPublic($object) === false
+            ) {
+                $this->logger->warning(
+                    '[PublicationsController::show] Anonymous request for non-published object denied',
+                    [
+                        'id'          => $id,
+                        'catalogSlug' => $catalogSlug,
+                    ]
+                );
+                return new JSONResponse(
+                    [
+                        'error'       => $this->l10n->t('Publication not found'),
+                        'message'     => $this->l10n->t(
+                            'The publication with ID "%s" does not exist or is not accessible.',
+                            [$id]
+                        ),
+                        'id'          => $id,
+                        'catalogSlug' => $catalogSlug,
+                    ],
+                    404
+                );
+            }//end if
 
             // @todo: Catalog validation disabled for now.
             // Render the object with extensions.

--- a/lib/Service/CatalogiService.php
+++ b/lib/Service/CatalogiService.php
@@ -140,6 +140,21 @@ class CatalogiService
     }//end getObjectService()
 
     /**
+     * Resolve the PublicationQueryService for shared visibility enforcement.
+     *
+     * @return PublicationQueryService The query/visibility helper service.
+     * @throws ContainerExceptionInterface|NotFoundExceptionInterface
+     *
+     * @spec exclude Lazy dependency-injection accessor — resolves the shared
+     *       PublicationQueryService from the container; pure framework plumbing.
+     */
+    private function getQueryService(): PublicationQueryService
+    {
+        return $this->container->get(PublicationQueryService::class);
+
+    }//end getQueryService()
+
+    /**
      * Attempts to retrieve the OpenRegister FileService from the container.
      *
      * @return mixed|null The OpenRegister service if available, null otherwise.
@@ -750,6 +765,11 @@ class CatalogiService
 
         // Use searchObjectsPaginated which handles pagination internally.
         $result = $objectService->searchObjectsPaginated($query);
+
+        // Enforce server-side published predicate for anonymous callers. Authenticated
+        // callers keep RBAC-scoped behavior; anonymous callers only see published
+        // (non-depublished) objects. Anon-vs-auth is derived from the user session.
+        $result = $this->getQueryService()->enforcePublishedForAnonymous($result);
 
         // Filter out unwanted properties from the @self array in each object.
         $filteredResults = array_map(

--- a/lib/Service/DirectoryService.php
+++ b/lib/Service/DirectoryService.php
@@ -388,10 +388,18 @@ class DirectoryService
             'listing_details'    => [],
         ];
 
+        // SSRF guard: validate the attacker-controllable directory URL BEFORE fetching.
+        // Restricts the scheme to http/https and rejects any host that resolves to a
+        // private, loopback, link-local, or cloud-metadata address. Throws
+        // InvalidArgumentException (mapped to HTTP 400) when the target is not safe.
+        $this->assertSafeOutboundUrl($directoryUrl);
+
         try {
             // Fetch directory data with limit to get all listings.
+            // Redirects are validated per-hop and bounded by safeGet() so a redirect
+            // cannot be used to pivot to an internal address.
             $dirUrlWithLimit = $directoryUrl.'?_limit=10000';
-            $response        = $this->client->get($dirUrlWithLimit);
+            $response        = $this->safeGet($dirUrlWithLimit);
             $directoryData   = json_decode($response->getBody()->getContents(), true);
 
             if (json_last_error() !== JSON_ERROR_NONE) {
@@ -1407,6 +1415,216 @@ class DirectoryService
         return empty($userAgent) === false && str_contains($userAgent, 'OpenCatalogi-Broadcast') === true;
 
     }//end isSystemBroadcast()
+
+    /**
+     * Assert that an outbound URL is safe to fetch (SSRF guard).
+     *
+     * Restricts the scheme to http/https and rejects any URL whose host resolves
+     * to a private, loopback, link-local, unique-local, or cloud-metadata address.
+     * The host is resolved via DNS so a public hostname that maps to an internal IP
+     * (DNS-rebinding-style payload) is also rejected.
+     *
+     * @param string $url The URL to validate.
+     *
+     * @return void
+     *
+     * @throws InvalidArgumentException When the URL or its resolved host is not safe.
+     *
+     * @spec exclude SSRF input-validation guard for outbound directory fetches; security
+     *       plumbing that hardens an existing fetch, no new domain behavior.
+     */
+    private function assertSafeOutboundUrl(string $url): void
+    {
+        $parsed = parse_url($url);
+        if ($parsed === false || isset($parsed['scheme']) === false || isset($parsed['host']) === false) {
+            throw new InvalidArgumentException('Invalid directory URL provided');
+        }
+
+        $scheme = strtolower($parsed['scheme']);
+        if (in_array($scheme, ['http', 'https'], true) === false) {
+            throw new InvalidArgumentException('Directory URL scheme must be http or https');
+        }
+
+        $host = strtolower($parsed['host']);
+
+        // Reject obvious local hostnames outright.
+        if ($host === 'localhost' || str_ends_with($host, '.local') === true
+            || str_ends_with($host, '.localhost') === true
+        ) {
+            throw new InvalidArgumentException('Directory URL host is not allowed');
+        }
+
+        // Collect the IPs to check: the literal host if it is already an IP,
+        // otherwise every address the host resolves to via DNS.
+        $ipsToCheck = [];
+        if (filter_var($host, FILTER_VALIDATE_IP) !== false) {
+            $ipsToCheck[] = $host;
+        } else {
+            // Strip IPv6 brackets if present.
+            $lookupHost = trim($host, '[]');
+            if (filter_var($lookupHost, FILTER_VALIDATE_IP) !== false) {
+                $ipsToCheck[] = $lookupHost;
+            } else {
+                $records = @dns_get_record($lookupHost, (DNS_A | DNS_AAAA));
+                if ($records !== false) {
+                    foreach ($records as $record) {
+                        if (isset($record['ip']) === true) {
+                            $ipsToCheck[] = $record['ip'];
+                        }
+
+                        if (isset($record['ipv6']) === true) {
+                            $ipsToCheck[] = $record['ipv6'];
+                        }
+                    }
+                }
+
+                // Fallback to gethostbyname for A records when dns_get_record is empty.
+                if (empty($ipsToCheck) === true) {
+                    $resolved = gethostbyname($lookupHost);
+                    if ($resolved !== $lookupHost && filter_var($resolved, FILTER_VALIDATE_IP) !== false) {
+                        $ipsToCheck[] = $resolved;
+                    }
+                }
+            }//end if
+        }//end if
+
+        if (empty($ipsToCheck) === true) {
+            throw new InvalidArgumentException('Directory URL host could not be resolved');
+        }
+
+        foreach ($ipsToCheck as $ip) {
+            if ($this->isBlockedIp($ip) === true) {
+                throw new InvalidArgumentException('Directory URL resolves to a disallowed (internal) address');
+            }
+        }
+
+    }//end assertSafeOutboundUrl()
+
+    /**
+     * Determine whether an IP address falls in a blocked range.
+     *
+     * Blocks loopback (127.0.0.0/8, ::1), private RFC1918 ranges, link-local
+     * (169.254.0.0/16 incl. the 169.254.169.254 metadata endpoint, fe80::/10),
+     * unique-local IPv6 (fc00::/7), and other reserved ranges via PHP's range flags.
+     *
+     * @param string $ip The IP address to evaluate.
+     *
+     * @return boolean True when the IP must not be contacted.
+     *
+     * @spec exclude SSRF range check supporting assertSafeOutboundUrl(); security plumbing.
+     */
+    private function isBlockedIp(string $ip): bool
+    {
+        if (filter_var($ip, FILTER_VALIDATE_IP) === false) {
+            // Unparseable address — treat as blocked to fail safe.
+            return true;
+        }
+
+        // FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE returns false for
+        // private (RFC1918), loopback, link-local, and reserved ranges (IPv4 + IPv6).
+        $isPublic = filter_var(
+            value: $ip,
+            filter: FILTER_VALIDATE_IP,
+            options: (FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE)
+        );
+
+        if ($isPublic === false) {
+            return true;
+        }
+
+        // Explicit belt-and-braces checks for the cloud-metadata endpoint and
+        // IPv6 forms that some PHP builds do not flag via the range flags above.
+        $blockedExact = [
+            '169.254.169.254',
+            '::1',
+            '0.0.0.0',
+            '::',
+        ];
+        if (in_array($ip, $blockedExact, true) === true) {
+            return true;
+        }
+
+        $lower = strtolower($ip);
+        // Match fc00::/7 (unique-local) and fe80::/10 (link-local) IPv6 prefixes.
+        if (str_starts_with($lower, 'fc') === true || str_starts_with($lower, 'fd') === true
+            || str_starts_with($lower, 'fe8') === true || str_starts_with($lower, 'fe9') === true
+            || str_starts_with($lower, 'fea') === true || str_starts_with($lower, 'feb') === true
+        ) {
+            return true;
+        }
+
+        return false;
+
+    }//end isBlockedIp()
+
+    /**
+     * Perform a GET request with SSRF-safe, per-hop-validated bounded redirects.
+     *
+     * Guzzle's automatic redirect following is disabled so that each redirect target
+     * can be re-validated by {@see self::assertSafeOutboundUrl()} before it is fetched,
+     * preventing a public URL from redirecting into an internal address.
+     *
+     * @param string $url The (already validated) initial URL to fetch.
+     *
+     * @return \Psr\Http\Message\ResponseInterface The final HTTP response.
+     *
+     * @throws InvalidArgumentException When a redirect points to a disallowed address
+     *                                  or the redirect limit is exceeded.
+     * @throws GuzzleException          On transport errors.
+     *
+     * @spec exclude SSRF-safe fetch helper with bounded, per-hop-validated redirects;
+     *       security plumbing wrapping the existing Guzzle client.
+     */
+    private function safeGet(string $url): \Psr\Http\Message\ResponseInterface
+    {
+        $maxRedirects = 5;
+        $current      = $url;
+
+        for ($hop = 0; $hop <= $maxRedirects; $hop++) {
+            $response = $this->client->get(
+                $current,
+                [
+                    RequestOptions::ALLOW_REDIRECTS => false,
+                    RequestOptions::TIMEOUT         => 10,
+                    RequestOptions::CONNECT_TIMEOUT => 5,
+                ]
+            );
+
+            $status = $response->getStatusCode();
+            if ($status < 300 || $status >= 400) {
+                return $response;
+            }
+
+            // Redirect: resolve, validate, and follow manually.
+            $location = $response->getHeaderLine('Location');
+            if ($location === '') {
+                return $response;
+            }
+
+            // Resolve relative redirects against the current URL.
+            if (parse_url($location, PHP_URL_HOST) === null) {
+                $base     = parse_url($current);
+                $scheme   = ($base['scheme'] ?? 'https');
+                $hostPart = ($base['host'] ?? '');
+                if (isset($base['port']) === true) {
+                    $hostPart .= ':'.$base['port'];
+                }
+
+                $path = $location;
+                if (str_starts_with($location, '/') === false) {
+                    $path = '/'.$location;
+                }
+
+                $location = $scheme.'://'.$hostPart.$path;
+            }
+
+            $this->assertSafeOutboundUrl($location);
+            $current = $location;
+        }//end for
+
+        throw new InvalidArgumentException('Too many redirects while fetching directory');
+
+    }//end safeGet()
 
     /**
      * Check if a URL is considered local

--- a/lib/Service/PublicationQueryService.php
+++ b/lib/Service/PublicationQueryService.php
@@ -22,8 +22,10 @@
 
 namespace OCA\OpenCatalogi\Service;
 
+use DateTime;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\IDBConnection;
+use OCP\IUserSession;
 use Psr\Container\ContainerInterface;
 
 /**
@@ -58,15 +60,137 @@ class PublicationQueryService
     /**
      * Constructor.
      *
-     * @param IDBConnection      $db        Database connection
-     * @param ContainerInterface $container DI container
+     * @param IDBConnection      $db          Database connection
+     * @param ContainerInterface $container   DI container
+     * @param IUserSession       $userSession Current user session (for anon detection)
      */
     public function __construct(
         private readonly IDBConnection $db,
         private readonly ContainerInterface $container,
+        private readonly IUserSession $userSession,
     ) {
 
     }//end __construct()
+
+    /**
+     * Determine whether the current request is from an anonymous (not logged-in) caller.
+     *
+     * Derived strictly server-side from the user session — never from a client parameter.
+     *
+     * @return bool True when no user is logged in.
+     *
+     * @spec exclude Server-side auth-state probe used to gate the anonymous published predicate;
+     *       wraps IUserSession::isLoggedIn(), no domain behavior.
+     */
+    public function isAnonymous(): bool
+    {
+        return $this->userSession->isLoggedIn() === false;
+
+    }//end isAnonymous()
+
+    /**
+     * Determine whether a single object is publicly visible right now.
+     *
+     * An object is public only when its @self.published timestamp is set and not in
+     * the future, AND it is not depublished (depublished unset/null, or in the future).
+     *
+     * @param array|object $object The object (array with '@self', or an object exposing jsonSerialize()).
+     *
+     * @return bool True when the object may be served to an anonymous caller.
+     */
+    public function isObjectPublic(array | object $object): bool
+    {
+        if (is_array($object) === false) {
+            if (method_exists($object, 'jsonSerialize') === true) {
+                $object = $object->jsonSerialize();
+            } else {
+                return false;
+            }
+        }
+
+        $self = ($object['@self'] ?? []);
+        if (is_array($self) === false) {
+            return false;
+        }
+
+        $now         = new DateTime();
+        $published   = ($self['published'] ?? null);
+        $depublished = ($self['depublished'] ?? null);
+
+        // Must have a published timestamp that is not in the future.
+        if (empty($published) === true) {
+            return false;
+        }
+
+        try {
+            if (new DateTime((string) $published) > $now) {
+                return false;
+            }
+        } catch (\Exception $e) {
+            return false;
+        }
+
+        // If depublished is set, it must be in the future to still be public.
+        if (empty($depublished) === false) {
+            try {
+                if (new DateTime((string) $depublished) <= $now) {
+                    return false;
+                }
+            } catch (\Exception $e) {
+                return false;
+            }
+        }
+
+        return true;
+
+    }//end isObjectPublic()
+
+    /**
+     * Filter a result set down to publicly-visible objects for anonymous callers.
+     *
+     * For authenticated callers the list is returned unchanged (OR RBAC already scoped it).
+     * For anonymous callers only published/non-depublished objects survive. The result
+     * array's 'total'/'count' bookkeeping is adjusted so it cannot over-report.
+     *
+     * @param array $result The paginated result array (expects a 'results' list).
+     *
+     * @return array The result array with anonymous-visibility enforced.
+     *
+     * @spec exclude Server-side published-predicate enforcement for anonymous public reads
+     *       (mirrors openregister #1951 "logged-in unless published"); security plumbing.
+     */
+    public function enforcePublishedForAnonymous(array $result): array
+    {
+        if ($this->isAnonymous() === false) {
+            return $result;
+        }
+
+        if (isset($result['results']) === false || is_array($result['results']) === false) {
+            return $result;
+        }
+
+        $removed  = 0;
+        $filtered = [];
+        foreach ($result['results'] as $item) {
+            if ($this->isObjectPublic($item) === true) {
+                $filtered[] = $item;
+            } else {
+                $removed++;
+            }
+        }
+
+        $result['results'] = array_values($filtered);
+
+        // Adjust pagination bookkeeping so totals never over-report visible objects.
+        foreach (['total', 'count'] as $key) {
+            if (isset($result[$key]) === true && is_int($result[$key]) === true) {
+                $result[$key] = max(0, ($result[$key] - $removed));
+            }
+        }
+
+        return $result;
+
+    }//end enforcePublishedForAnonymous()
 
     /**
      * Find the register and schema IDs for an object UUID by searching all magic tables.
@@ -149,8 +273,8 @@ class PublicationQueryService
      * handles multi-schema and multi-register cases, and strips non-universal _order fields
      * when searching across multiple registers.
      *
-     * @param array  $catalog      Catalog data array (keys: schemas, registers).
-     * @param array  $queryParams  Raw request query parameters from IRequest::getParams().
+     * @param array  $catalog       Catalog data array (keys: schemas, registers).
+     * @param array  $queryParams   Raw request query parameters from IRequest::getParams().
      * @param object $objectService ObjectService instance (already resolved from container).
      *
      * @return array The merged and sanitised search query ready for searchObjectsPaginated().
@@ -397,9 +521,9 @@ class PublicationQueryService
      *
      * Handles both sequential (list) and associative arrays, recursing into nested arrays.
      *
-     * @param array           $result Reference to the result array being built.
-     * @param int|string      $key    The key for this value.
-     * @param array           $value  The array value to process.
+     * @param array      $result Reference to the result array being built.
+     * @param int|string $key    The key for this value.
+     * @param array      $value  The array value to process.
      *
      * @return void
      */
@@ -408,7 +532,11 @@ class PublicationQueryService
         if (array_is_list($value) === true) {
             $stripped = [];
             foreach ($value as $item) {
-                $stripped[] = is_array($item) === true ? $this->stripEmptyValues(data: $item) : $item;
+                if (is_array($item) === true) {
+                    $stripped[] = $this->stripEmptyValues(data: $item);
+                } else {
+                    $stripped[] = $item;
+                }
             }
 
             if (empty($stripped) === false) {

--- a/lib/Service/PublicationService.php
+++ b/lib/Service/PublicationService.php
@@ -154,6 +154,21 @@ class PublicationService
     }//end getObjectService()
 
     /**
+     * Resolve the PublicationQueryService for shared visibility enforcement.
+     *
+     * @return PublicationQueryService The query/visibility helper service.
+     * @throws ContainerExceptionInterface|NotFoundExceptionInterface
+     *
+     * @spec exclude Lazy dependency-injection accessor — resolves the shared
+     *       PublicationQueryService from the container; pure framework plumbing.
+     */
+    private function getQueryService(): PublicationQueryService
+    {
+        return $this->container->get(PublicationQueryService::class);
+
+    }//end getQueryService()
+
+    /**
      * Set register/schema context on the ObjectService for a given object UUID.
      *
      * Searches all magic tables to find which register/schema an object belongs to,
@@ -496,6 +511,11 @@ class PublicationService
                 _multitenancy: false
             )
         );
+
+        // Enforce server-side published predicate for anonymous callers. Authenticated
+        // callers keep RBAC-scoped behavior; anonymous callers only see published
+        // (non-depublished) objects. Anon-vs-auth is derived from the user session.
+        $result = $this->getQueryService()->enforcePublishedForAnonymous($result);
 
         // Filter unwanted properties from results.
         $result['results'] = $this->filterUnwantedProperties($result['results']);


### PR DESCRIPTION
## Summary

Fixes three confirmed security findings on the public OpenCatalogi read/sync surface. Reviewed and runtime-verified against the local Nextcloud dev environment.

Closes #729, closes #730, closes #728.

## #729 (CRITICAL) — Unauthenticated SSRF with response reflection

`DirectoryController::update` → `DirectoryService::syncDirectory` fetched the attacker-supplied `directory` URL with no host validation (`isLocalUrl()` was only applied to listings *inside* the response), and the upstream body was reflected back in the error response.

**Fix**
- `assertSafeOutboundUrl()` — restrict scheme to http/https, resolve the host via DNS, and reject private (RFC1918), loopback (127.0.0.0/8, ::1), link-local (169.254.0.0/16 incl. the `169.254.169.254` metadata endpoint, fe80::/10), and unique-local (fc00::/7) ranges — IPv4 and IPv6 — *before* fetching.
- `safeGet()` — bounded redirects (max 5) with the same per-hop validation, so a public URL can't redirect into an internal address.
- Stop reflecting the upstream Guzzle response body; log server-side, return a generic message.

**Verification**
```
POST /api/directory {"directory":"http://127.0.0.1/x"}
  -> {"message":"Invalid directory URL","error":"Directory URL resolves to a disallowed (internal) address"}   (no fetch, no reflected NC 404 body — previously reflected it)
POST {"directory":"http://169.254.169.254/latest/meta-data/"}  -> rejected
POST {"directory":"http://192.168.1.1/"}                       -> rejected
POST {"directory":"https://directory.opencatalogi.nl/.../directory"}  -> "Directory synchronized successfully"  (legitimate external https still works)
```

## #730 (HIGH) — CatalogiController::index scope/RBAC bypass

`CatalogiController::index` ran `_rbac:false, _multitenancy:false` and its configured scope never reached the query (the `@self.register`/`@self.schema` keys were overwritten downstream).

**Fix** — pin the configured register/schema via the top-level `_register`/`_schema` routing keys, enable `_rbac:true`, and stop disabling multitenancy.

**Verification**
```
GET /api/catalogi  -> total:1, returned:1  (the configured catalog only; previously leaked unrelated objects)
```

## #728 (CRITICAL) — No published/depublished enforcement on public reads

`PublicationsController::index/show`, `PublicationService::searchPublications`, `CatalogiService::index`, and `PublicationQueryService::buildCatalogSearchQuery` delegated visibility to OR schema-level RBAC, so unpublished objects were served to anonymous callers.

**Fix** — shared server-side published predicate in `PublicationQueryService`:
- `isAnonymous()` derives anon-vs-auth from `IUserSession` (never a client param).
- `isObjectPublic()` — public only when `@self.published` is set and `<= now`, AND (`@self.depublished` null OR `> now`).
- `enforcePublishedForAnonymous()` filters anonymous result sets; authenticated callers keep RBAC-scoped behavior.

Applied in `PublicationsController::index` (list) and `::show` (404 on unpublished for anon), `PublicationService::searchPublications`, and `CatalogiService::index`. Mirrors the openregister #1951 "logged-in unless published" pattern.

**Verification**
```
GET /api/publications (anonymous)  -> returned:0   (previously 27 unpublished register-10/schema-28 objects)
GET /api/publications (admin)      -> returned:5 of total:27   (RBAC-scoped behavior preserved)

isObjectPublic() unit check (deployed class):
  no published            -> hidden
  published past          -> PUBLIC
  published future        -> hidden
  pub past + depub future -> PUBLIC
  pub past + depub past    -> hidden
  published null          -> hidden
```
(In this dev env the "publications" catalog resolves to register 10/schema 28, whose magic table has no `published` column, so every object there is structurally unpublished — anonymous correctly gets zero, i.e. fail-closed. The positive path is proven by the predicate unit check above.)

## Notes
- `php -l` clean on all 7 edited files.
- `phpcs --standard=phpcs.xml` clean on all added lines (remaining reports are pre-existing `@spec`/style warnings outside this change's hunks).