### PR TITLE
fix: extend allowlist + catalog-membership + DoS guard + CORS + SOLR array-result (#732-#736)

### DIFF
--- a/lib/Controller/CatalogiController.php
+++ b/lib/Controller/CatalogiController.php
@@ -130,6 +130,42 @@ class CatalogiController extends Controller
     }//end getCatalogConfiguration()
 
     /**
+     * Resolve the Access-Control-Allow-Origin header value for the current request.
+     *
+     * Reads the configured allowlist from IAppConfig key 'cors_allowed_origins' (CSV).
+     * Special value '*' (the default) means "any origin allowed" and emits a literal '*'
+     * — the caller's Origin is NEVER echoed back unless it appears on the allowlist (#735).
+     *
+     * @return string The header value to use for Access-Control-Allow-Origin.
+     *
+     * @spec exclude CORS-policy plumbing; reads IAppConfig allowlist, no Origin reflection.
+     */
+    private function resolveAllowedOrigin(): string
+    {
+        $configured = trim($this->config->getValueString($this->appName, 'cors_allowed_origins', '*'));
+        if ($configured === '' || $configured === '*') {
+            return '*';
+        }
+
+        $allowlist = array_filter(
+            array_map('trim', explode(',', $configured)),
+            static fn(string $entry): bool => $entry !== ''
+        );
+
+        $callerOrigin = $this->request->getHeader('Origin');
+        if ($callerOrigin === '') {
+            $callerOrigin = ($this->request->server['HTTP_ORIGIN'] ?? '');
+        }
+
+        if ($callerOrigin !== '' && in_array($callerOrigin, $allowlist, true) === true) {
+            return $callerOrigin;
+        }
+
+        return ($allowlist[0] ?? '*');
+
+    }//end resolveAllowedOrigin()
+
+    /**
      * Implements a preflighted CORS response for OPTIONS requests.
      *
      * @return Response The CORS response.
@@ -142,15 +178,8 @@ class CatalogiController extends Controller
      */
     public function preflightedCors(): Response
     {
-        // Determine the origin.
-        $origin = $this->request->getHeader('Origin');
-        if ($origin === '') {
-            $origin = '*';
-        }
-
-        // Create and configure the response.
         $response = new Response();
-        $response->addHeader('Access-Control-Allow-Origin', $origin);
+        $response->addHeader('Access-Control-Allow-Origin', $this->resolveAllowedOrigin());
         $response->addHeader('Access-Control-Allow-Methods', $this->corsMethods);
         $response->addHeader('Access-Control-Max-Age', (string) $this->corsMaxAge);
         $response->addHeader('Access-Control-Allow-Headers', $this->corsAllowedHeaders);
@@ -206,11 +235,9 @@ class CatalogiController extends Controller
             deleted: false
         );
 
-        // Add CORS headers for public API access.
+        // Add CORS headers for public API access (#735 — never reflect arbitrary Origin).
         $response = new JSONResponse($result);
-        $origin   = $this->request->server['HTTP_ORIGIN'] ?? '*';
-
-        $response->addHeader('Access-Control-Allow-Origin', $origin);
+        $response->addHeader('Access-Control-Allow-Origin', $this->resolveAllowedOrigin());
         $response->addHeader('Access-Control-Allow-Methods', $this->corsMethods);
         $response->addHeader('Access-Control-Allow-Headers', $this->corsAllowedHeaders);
 
@@ -237,13 +264,8 @@ class CatalogiController extends Controller
         // Get all objects using the catalog's registers and schemas as filters.
         $response = $this->catalogiService->index($id);
 
-        // Add CORS headers for public API access.
-        $origin = $this->request->getHeader('Origin');
-        if ($origin === '') {
-            $origin = '*';
-        }
-
-        $response->addHeader('Access-Control-Allow-Origin', $origin);
+        // Add CORS headers for public API access (#735 — never reflect arbitrary Origin).
+        $response->addHeader('Access-Control-Allow-Origin', $this->resolveAllowedOrigin());
         $response->addHeader('Access-Control-Allow-Methods', $this->corsMethods);
         $response->addHeader('Access-Control-Allow-Headers', $this->corsAllowedHeaders);
 

--- a/lib/Controller/DirectoryController.php
+++ b/lib/Controller/DirectoryController.php
@@ -31,6 +31,7 @@ use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Db\MultipleObjectsReturnedException;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\Http\Response;
+use OCP\IAppConfig;
 use OCP\IL10N;
 use OCP\IRequest;
 use Psr\Container\ContainerExceptionInterface;
@@ -72,6 +73,7 @@ class DirectoryController extends Controller
      * @param DirectoryService $directoryService   The directory service.
      * @param IL10N            $l10n               The localization service.
      * @param LoggerInterface  $logger             PSR-3 logger.
+     * @param IAppConfig|null  $config             App config for CORS allowlist (optional).
      * @param string           $corsMethods        Allowed CORS methods.
      * @param string           $corsAllowedHeaders Allowed CORS headers.
      * @param integer          $corsMaxAge         CORS max age.
@@ -81,7 +83,8 @@ class DirectoryController extends Controller
         IRequest $request,
         private readonly DirectoryService $directoryService,
         private readonly IL10N $l10n,
-        private readonly LoggerInterface $logger,
+        private readonly ?LoggerInterface $logger=null,
+        private readonly ?IAppConfig $config=null,
         string $corsMethods='PUT, POST, GET, DELETE, PATCH',
         string $corsAllowedHeaders='Authorization, Content-Type, Accept',
         int $corsMaxAge=1728000
@@ -92,6 +95,46 @@ class DirectoryController extends Controller
         $this->corsMaxAge         = $corsMaxAge;
 
     }//end __construct()
+
+    /**
+     * Resolve the Access-Control-Allow-Origin header value for the current request.
+     *
+     * Reads the configured allowlist from IAppConfig key 'cors_allowed_origins' (CSV).
+     * Special value '*' (the default) means "any origin allowed" and emits a literal '*'
+     * — the caller's Origin is NEVER echoed back unless it appears on the allowlist (#735).
+     *
+     * @return string The header value to use for Access-Control-Allow-Origin.
+     *
+     * @spec exclude CORS-policy plumbing; reads IAppConfig allowlist, no Origin reflection.
+     */
+    private function resolveAllowedOrigin(): string
+    {
+        $configured = '*';
+        if ($this->config !== null) {
+            $configured = trim($this->config->getValueString($this->appName, 'cors_allowed_origins', '*'));
+        }
+
+        if ($configured === '' || $configured === '*') {
+            return '*';
+        }
+
+        $allowlist = array_filter(
+            array_map('trim', explode(',', $configured)),
+            static fn(string $entry): bool => $entry !== ''
+        );
+
+        $callerOrigin = $this->request->getHeader('Origin');
+        if ($callerOrigin === '') {
+            $callerOrigin = ($this->request->server['HTTP_ORIGIN'] ?? '');
+        }
+
+        if ($callerOrigin !== '' && in_array($callerOrigin, $allowlist, true) === true) {
+            return $callerOrigin;
+        }
+
+        return ($allowlist[0] ?? '*');
+
+    }//end resolveAllowedOrigin()
 
     /**
      * Implements a preflighted CORS response for OPTIONS requests.
@@ -106,15 +149,8 @@ class DirectoryController extends Controller
      */
     public function preflightedCors(): Response
     {
-        // Determine the origin.
-        $origin = $this->request->getHeader('Origin');
-        if ($origin === '') {
-            $origin = '*';
-        }
-
-        // Create and configure the response.
         $response = new Response();
-        $response->addHeader('Access-Control-Allow-Origin', $origin);
+        $response->addHeader('Access-Control-Allow-Origin', $this->resolveAllowedOrigin());
         $response->addHeader('Access-Control-Allow-Methods', $this->corsMethods);
         $response->addHeader('Access-Control-Max-Age', (string) $this->corsMaxAge);
         $response->addHeader('Access-Control-Allow-Headers', $this->corsAllowedHeaders);
@@ -145,27 +181,27 @@ class DirectoryController extends Controller
             // Use the directory service to get combined directory data.
             $data = $this->directoryService->getDirectory($requestParams);
 
-            // Create JSON response with CORS headers.
+            // Create JSON response with CORS headers (#735 — never reflect Origin).
             $response = new JSONResponse($data);
-            $origin   = $this->request->server['HTTP_ORIGIN'] ?? '*';
-
-            $response->addHeader('Access-Control-Allow-Origin', $origin);
+            $response->addHeader('Access-Control-Allow-Origin', $this->resolveAllowedOrigin());
             $response->addHeader('Access-Control-Allow-Methods', $this->corsMethods);
             $response->addHeader('Access-Control-Allow-Headers', $this->corsAllowedHeaders);
 
             return $response;
         } catch (\Exception $e) {
-            // Handle errors gracefully with CORS headers.
+            // Public endpoint — log details server-side, return generic body (#735).
+            $this->logger?->error(
+                '[DirectoryController::index] Failed to retrieve directory data',
+                [
+                    'error' => $e->getMessage(),
+                    'trace' => $e->getTraceAsString(),
+                ]
+            );
             $response = new JSONResponse(
-                data: [
-                    'message' => $this->l10n->t('Failed to retrieve directory data'),
-                    'error'   => $e->getMessage(),
-                ],
+                data: ['error' => $this->l10n->t('Internal server error')],
                 statusCode: 500
             );
-            $origin   = $this->request->server['HTTP_ORIGIN'] ?? '*';
-
-            $response->addHeader('Access-Control-Allow-Origin', $origin);
+            $response->addHeader('Access-Control-Allow-Origin', $this->resolveAllowedOrigin());
             $response->addHeader('Access-Control-Allow-Methods', $this->corsMethods);
             $response->addHeader('Access-Control-Allow-Headers', $this->corsAllowedHeaders);
 
@@ -205,13 +241,8 @@ class DirectoryController extends Controller
                 statusCode: 400
             );
 
-            // Add CORS headers for public API access.
-            $origin = $this->request->getHeader('Origin');
-            if ($origin === '') {
-                $origin = '*';
-            }
-
-            $response->addHeader('Access-Control-Allow-Origin', $origin);
+            // Add CORS headers for public API access (#735 — never reflect Origin).
+            $response->addHeader('Access-Control-Allow-Origin', $this->resolveAllowedOrigin());
             $response->addHeader('Access-Control-Allow-Methods', $this->corsMethods);
             $response->addHeader('Access-Control-Allow-Headers', $this->corsAllowedHeaders);
 
@@ -230,7 +261,8 @@ class DirectoryController extends Controller
                 ]
             );
         } catch (\InvalidArgumentException $e) {
-            // Handle validation errors (invalid URL, etc.).
+            // Handle validation errors (invalid URL, etc.). The raw message here is
+            // safe because it's the caller's own input being echoed back.
             $response = new JSONResponse(
                 data: [
                     'message' => $this->l10n->t('Invalid directory URL'),
@@ -242,7 +274,7 @@ class DirectoryController extends Controller
             // Handle HTTP/network errors. Do NOT reflect the upstream response body
             // (it may contain internal content from an SSRF-style probe). Log details
             // server-side instead and return a generic message to the caller.
-            $this->logger->warning(
+            $this->logger?->warning(
                 '[DirectoryController::update] Upstream fetch failed',
                 ['error' => $e->getMessage()]
             );
@@ -254,23 +286,23 @@ class DirectoryController extends Controller
                 statusCode: 502
             );
         } catch (\Exception $e) {
-            // Handle other unexpected errors.
+            // Handle other unexpected errors. Public endpoint — log server-side, return
+            // a generic body so internal details (paths, SQL fragments) do not leak (#735).
+            $this->logger?->error(
+                '[DirectoryController::update] Directory synchronization failed',
+                [
+                    'error' => $e->getMessage(),
+                    'trace' => $e->getTraceAsString(),
+                ]
+            );
             $response = new JSONResponse(
-                data: [
-                    'message' => $this->l10n->t('Directory synchronization failed'),
-                    'error'   => $e->getMessage(),
-                ],
+                data: ['error' => $this->l10n->t('Internal server error')],
                 statusCode: 500
             );
         }//end try
 
-        // Add CORS headers for public API access.
-        $origin = $this->request->getHeader('Origin');
-        if ($origin === '') {
-            $origin = '*';
-        }
-
-        $response->addHeader('Access-Control-Allow-Origin', $origin);
+        // Add CORS headers for public API access (#735 — never reflect Origin).
+        $response->addHeader('Access-Control-Allow-Origin', $this->resolveAllowedOrigin());
         $response->addHeader('Access-Control-Allow-Methods', $this->corsMethods);
         $response->addHeader('Access-Control-Allow-Headers', $this->corsAllowedHeaders);
 

--- a/lib/Controller/PublicationsController.php
+++ b/lib/Controller/PublicationsController.php
@@ -37,6 +37,7 @@ use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\DataDownloadResponse;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\IAppConfig;
 use OCP\IL10N;
 use OCP\IRequest;
 use OCP\App\IAppManager;
@@ -57,6 +58,17 @@ use RuntimeException;
  */
 class PublicationsController extends Controller
 {
+
+    /**
+     * Maximum number of extend entries accepted on public read endpoints.
+     *
+     * Caps the breadth of relation traversal triggered by a single anonymous request
+     * to prevent N+1 amplification (#732). Five is generous for legitimate '@self.'
+     * extends while keeping per-request OR query count bounded.
+     *
+     * @var integer
+     */
+    private const MAX_PUBLIC_EXTEND = 5;
 
     /**
      * Allowed CORS methods.
@@ -91,6 +103,7 @@ class PublicationsController extends Controller
      * @param IAppManager             $appManager         The app manager
      * @param LoggerInterface         $logger             PSR-3 logger
      * @param IL10N                   $l10n               Localization service
+     * @param IAppConfig|null         $appConfig          App config for CORS allowlist (optional)
      * @param string                  $corsMethods        Allowed CORS methods
      * @param string                  $corsAllowedHeaders Allowed CORS headers
      * @param integer                 $corsMaxAge         CORS max age
@@ -107,6 +120,7 @@ class PublicationsController extends Controller
         private readonly IAppManager $appManager,
         private readonly LoggerInterface $logger,
         private readonly IL10N $l10n,
+        private readonly ?IAppConfig $appConfig=null,
         string $corsMethods='PUT, POST, GET, DELETE, PATCH',
         string $corsAllowedHeaders='Authorization, Content-Type, Accept',
         int $corsMaxAge=1728000
@@ -135,6 +149,55 @@ class PublicationsController extends Controller
     }//end getObjectService()
 
     /**
+     * Resolve the Access-Control-Allow-Origin header value for the current request.
+     *
+     * Reads the configured allowlist from IAppConfig key 'cors_allowed_origins' (CSV).
+     * Special value '*' (the default) means "any origin allowed" and emits a literal '*'
+     * — the caller's Origin is NEVER echoed back unless it is explicitly listed in the
+     * configured allowlist. This prevents arbitrary-origin reflection on public endpoints
+     * (#735). When credentials are not allowed (as on these public read endpoints) a
+     * static '*' is the safest default; only operators that need credentialed CORS
+     * should configure a strict allowlist.
+     *
+     * @return string The header value to use for Access-Control-Allow-Origin.
+     *
+     * @spec exclude CORS-policy plumbing extracted to fail-closed on Origin reflection;
+     *       reads an IAppConfig allowlist and never echoes an unvetted caller Origin.
+     */
+    private function resolveAllowedOrigin(): string
+    {
+        $configured = '*';
+        if ($this->appConfig !== null) {
+            $configured = $this->appConfig->getValueString($this->appName, 'cors_allowed_origins', '*');
+        }
+
+        $configured = trim($configured);
+        if ($configured === '' || $configured === '*') {
+            return '*';
+        }
+
+        $allowlist = array_filter(
+            array_map('trim', explode(',', $configured)),
+            static fn(string $entry): bool => $entry !== ''
+        );
+
+        $callerOrigin = $this->request->getHeader('Origin');
+        if ($callerOrigin === '') {
+            $callerOrigin = ($this->request->server['HTTP_ORIGIN'] ?? '');
+        }
+
+        if ($callerOrigin !== '' && in_array($callerOrigin, $allowlist, true) === true) {
+            return $callerOrigin;
+        }
+
+        // Caller Origin not on the allowlist — fall back to the first configured entry
+        // (or '*' if the allowlist became empty after trimming). Crucially, we do NOT
+        // echo back the caller's unvetted Origin.
+        return ($allowlist[0] ?? '*');
+
+    }//end resolveAllowedOrigin()
+
+    /**
      * Add standard CORS headers to a response.
      *
      * @param JSONResponse $response The response to add headers to.
@@ -143,12 +206,120 @@ class PublicationsController extends Controller
      */
     private function addCorsHeaders(JSONResponse $response): void
     {
-        $origin = $this->request->server['HTTP_ORIGIN'] ?? '*';
-        $response->addHeader('Access-Control-Allow-Origin', $origin);
+        $response->addHeader('Access-Control-Allow-Origin', $this->resolveAllowedOrigin());
         $response->addHeader('Access-Control-Allow-Methods', $this->corsMethods);
         $response->addHeader('Access-Control-Allow-Headers', $this->corsAllowedHeaders);
 
     }//end addCorsHeaders()
+
+    /**
+     * Sanitise a public extend list to the '@self.'-prefix allowlist with a max breadth.
+     *
+     * Public read endpoints accept extend/_extend, but allowing arbitrary extend targets
+     * lets an anonymous caller traverse to unrelated objects and amplify a single
+     * request into many OR queries (#732). This filter restricts entries to those
+     * beginning with '@self.' (mirroring PublicationService::show) and caps the list
+     * at MAX_PUBLIC_EXTEND entries.
+     *
+     * @param array $extend The raw extend list from the request.
+     *
+     * @return array<string> The sanitised extend list (deduplicated, capped).
+     *
+     * @spec exclude Input-shaping plumbing extracted from PublicationsController::show;
+     *       enforces the public extend allowlist and breadth cap, no domain behaviour.
+     */
+    private function sanitizePublicExtend(array $extend): array
+    {
+        $filtered = [];
+        foreach ($extend as $entry) {
+            if (is_string($entry) === false) {
+                continue;
+            }
+
+            $trimmed = trim($entry);
+            if ($trimmed === '' || str_starts_with($trimmed, '@self.') === false) {
+                continue;
+            }
+
+            $filtered[$trimmed] = true;
+        }
+
+        $sanitised = array_keys($filtered);
+        if (count($sanitised) > self::MAX_PUBLIC_EXTEND) {
+            $sanitised = array_slice($sanitised, 0, self::MAX_PUBLIC_EXTEND);
+        }
+
+        return $sanitised;
+
+    }//end sanitizePublicExtend()
+
+    /**
+     * Normalise a register/schema identifier list from a catalog field.
+     *
+     * Catalog 'registers' and 'schemas' may arrive as a native array or as a JSON
+     * string. This helper resolves either shape to a list of integer IDs.
+     *
+     * @param array|string|null $raw The catalog field value.
+     *
+     * @return array<int> Integer ID list (empty when nothing usable).
+     *
+     * @spec exclude Catalog-shape normalisation plumbing used by the show fast path,
+     *       fallback, and membership validation; no domain behaviour.
+     */
+    private function normaliseIdList(array | string | null $raw): array
+    {
+        if ($raw === null) {
+            return [];
+        }
+
+        if (is_string($raw) === true) {
+            $decoded = json_decode($raw, true);
+            if (is_array($decoded) === true) {
+                $raw = $decoded;
+            } else {
+                $raw = [];
+            }
+        }
+
+        $ids = [];
+        foreach ($raw as $value) {
+            if (is_numeric($value) === true) {
+                $ids[] = (int) $value;
+            }
+        }
+
+        return $ids;
+
+    }//end normaliseIdList()
+
+    /**
+     * Determine whether an object's register/schema belongs to the catalog scope.
+     *
+     * When either scope list is empty the object is treated as outside scope —
+     * unscoped catalogs are not allowed to disclose individual objects (#733).
+     *
+     * @param object $object           ObjectEntity exposing getRegister()/getSchema().
+     * @param array  $allowedRegisters Allowed register IDs from the catalog.
+     * @param array  $allowedSchemas   Allowed schema IDs from the catalog.
+     *
+     * @return bool True when the object's register AND schema are both allowed.
+     *
+     * @spec exclude Catalog-membership predicate extracted from show; pure check, no
+     *       domain behaviour.
+     */
+    private function objectMatchesCatalogScope(object $object, array $allowedRegisters, array $allowedSchemas): bool
+    {
+        if (empty($allowedRegisters) === true || empty($allowedSchemas) === true) {
+            return false;
+        }
+
+        $objectRegister = (int) $object->getRegister();
+        $objectSchema   = (int) $object->getSchema();
+
+        return (in_array($objectRegister, $allowedRegisters, true) === true
+            && in_array($objectSchema, $allowedSchemas, true) === true);
+
+    }//end objectMatchesCatalogScope()
 
     /**
      * Implements a preflighted CORS response for OPTIONS requests.
@@ -163,15 +334,10 @@ class PublicationsController extends Controller
      */
     public function preflightedCors(): Response
     {
-        // Determine the origin.
-        $origin = $this->request->getHeader('Origin');
-        if ($origin === '') {
-            $origin = '*';
-        }
-
-        // Create and configure the response.
+        // Determine the origin via the same allowlist-aware resolver used elsewhere
+        // so we never reflect an arbitrary caller-supplied Origin (#735).
         $response = new Response();
-        $response->addHeader('Access-Control-Allow-Origin', $origin);
+        $response->addHeader('Access-Control-Allow-Origin', $this->resolveAllowedOrigin());
         $response->addHeader('Access-Control-Allow-Methods', $this->corsMethods);
         $response->addHeader('Access-Control-Max-Age', (string) $this->corsMaxAge);
         $response->addHeader('Access-Control-Allow-Headers', $this->corsAllowedHeaders);
@@ -269,7 +435,7 @@ class PublicationsController extends Controller
             ];
 
             // Enrich @self with resolved schema and register objects for frontend enrichment.
-            $resolved                      = $this->queryService->resolveSchemaAndRegisterObjects($catalog);
+            $resolved = $this->queryService->resolveSchemaAndRegisterObjects($catalog);
             $result['@self']['schemas']   = $resolved['schemas'];
             $result['@self']['registers'] = $resolved['registers'];
 
@@ -279,8 +445,18 @@ class PublicationsController extends Controller
 
             return $response;
         } catch (\Exception $e) {
+            // Public endpoint — log exception details server-side only and return a
+            // generic error body to the caller (#735); never leak raw $e->getMessage().
+            $this->logger->error(
+                '[PublicationsController::index] Failed to retrieve publications',
+                [
+                    'catalogSlug' => $catalogSlug,
+                    'error'       => $e->getMessage(),
+                    'trace'       => $e->getTraceAsString(),
+                ]
+            );
             return new JSONResponse(
-                ['error' => $this->l10n->t('Failed to retrieve publications').': '.$e->getMessage()],
+                ['error' => $this->l10n->t('Internal server error')],
                 500
             );
         }//end try
@@ -328,7 +504,10 @@ class PublicationsController extends Controller
             // Get ObjectService directly.
             $objectService = $this->getObjectService();
 
-            // Build extend parameters.
+            // Build extend parameters with controller-layer allowlist + bounds (#732).
+            // Public extends are restricted to '@self.'-prefixed paths (mirrors
+            // PublicationService::show()) AND a max of 5 entries to prevent N+1
+            // amplification through unbounded extends on anonymous endpoints.
             $requestParams = $this->request->getParams();
             $extend        = ($requestParams['extend'] ?? $requestParams['_extend'] ?? []);
             // Normalize to array and handle comma-separated strings.
@@ -337,6 +516,12 @@ class PublicationsController extends Controller
             } else if (is_array($extend) === false) {
                 $extend = [$extend];
             }
+
+            $extend = $this->sanitizePublicExtend($extend);
+
+            // Resolve catalog scope (parse JSON strings if needed).
+            $catalogRegisters = $this->normaliseIdList($catalog['registers'] ?? []);
+            $catalogSchemas   = $this->normaliseIdList($catalog['schemas'] ?? []);
 
             // Debug logging.
             $this->logger->debug(
@@ -358,9 +543,6 @@ class PublicationsController extends Controller
             $objects = [];
 
             // Fast path: try catalog register and schema combinations first.
-            $catalogRegisters = $catalog['registers'] ?? [];
-            $catalogSchemas   = $catalog['schemas'] ?? [];
-
             if (empty($catalogRegisters) === false && empty($catalogSchemas) === false) {
                 foreach ($catalogRegisters as $reg) {
                     foreach ($catalogSchemas as $sch) {
@@ -386,9 +568,21 @@ class PublicationsController extends Controller
                 }//end foreach
             }//end if
 
-            // Fallback: find the object register and schema across all magic tables.
-            if ($object === null) {
-                $location = $this->queryService->findObjectLocation($id);
+            // Fallback: locate the object's register/schema, but constrained to the
+            // catalog's configured registers/schemas only (#734). Without this scope
+            // findObjectLocation would scan every magic table on the platform and would
+            // return objects outside this catalog's namespace (#733). When the catalog
+            // has no configured scope (e.g. unscoped catalog), the fallback is skipped
+            // entirely — there is no safe namespace to search.
+            if ($object === null
+                && empty($catalogRegisters) === false
+                && empty($catalogSchemas) === false
+            ) {
+                $location = $this->queryService->findObjectLocation(
+                    uuid: $id,
+                    allowedRegisters: $catalogRegisters,
+                    allowedSchemas: $catalogSchemas
+                );
 
                 if ($location !== null) {
                     $searchQuery = [
@@ -471,8 +665,43 @@ class PublicationsController extends Controller
                 );
             }//end if
 
-            // @todo: Catalog validation disabled for now.
-            // Render the object with extensions.
+            // Catalog-membership validation (#733): the resolved object's
+            // register/schema MUST belong to this catalog's configured scope. Without
+            // this check `/api/{anyCatalogSlug}/{anyUuid}` would return objects from
+            // wholly unrelated catalogs, enabling cross-catalog enumeration. When the
+            // catalog has no configured scope we treat the object as not found —
+            // unscoped catalogs cannot disclose individual objects.
+            if ($this->objectMatchesCatalogScope(
+                object: $object,
+                allowedRegisters: $catalogRegisters,
+                allowedSchemas: $catalogSchemas
+            ) === false
+            ) {
+                $this->logger->warning(
+                    '[PublicationsController::show] Object outside catalog scope',
+                    [
+                        'id'             => $id,
+                        'catalogSlug'    => $catalogSlug,
+                        'objectRegister' => $object->getRegister(),
+                        'objectSchema'   => $object->getSchema(),
+                    ]
+                );
+                return new JSONResponse(
+                    [
+                        'error'       => $this->l10n->t('Publication not found'),
+                        'message'     => $this->l10n->t(
+                            'The publication with ID "%s" does not exist or is not accessible.',
+                            [$id]
+                        ),
+                        'id'          => $id,
+                        'catalogSlug' => $catalogSlug,
+                    ],
+                    404
+                );
+            }//end if
+
+            // Render the object with the sanitised extend list. The '@self.'-prefix
+            // allowlist plus max-entries cap has already been applied above (#732).
             $result = $objectService->renderEntity(
                 entity: $object,
                 _extend: $extend,
@@ -504,6 +733,8 @@ class PublicationsController extends Controller
                 404
             );
         } catch (\Exception $e) {
+            // Public endpoint — log exception details server-side only and return a
+            // generic error body to the caller (#735); never leak raw $e->getMessage().
             $this->logger->error(
                 '[PublicationsController::show] Failed to retrieve publication',
                 [
@@ -515,11 +746,8 @@ class PublicationsController extends Controller
             );
             return new JSONResponse(
                 [
-                    'error'       => $this->l10n->t('Failed to retrieve publication'),
-                    'message'     => $e->getMessage(),
-                    'id'          => $id,
-                    'catalogSlug' => $catalogSlug,
-                    'hint'        => $this->l10n->t('Check server logs for more details.'),
+                    'error' => $this->l10n->t('Internal server error'),
+                    'hint'  => $this->l10n->t('Check server logs for more details.'),
                 ],
                 500
             );
@@ -561,7 +789,11 @@ class PublicationsController extends Controller
 
             // First verify the object exists in this catalog register and schema.
             $objectService = $this->getObjectService();
-            $object        = $this->queryService->findObjectInCatalog($catalog, $id, $objectService);
+            $object        = $this->queryService->findObjectInCatalog(
+                catalog: $catalog,
+                id: $id,
+                objectService: $objectService
+            );
 
             if ($object === null) {
                 return new JSONResponse(
@@ -590,11 +822,18 @@ class PublicationsController extends Controller
                 404
             );
         } catch (\Exception $e) {
-            return new JSONResponse(
+            // Public endpoint — log details server-side, return generic body (#735).
+            $this->logger->error(
+                '[PublicationsController::attachments] Failed to retrieve attachments',
                 [
-                    'error'   => $this->l10n->t('Failed to retrieve attachments'),
-                    'message' => $e->getMessage(),
-                ],
+                    'id'          => $id,
+                    'catalogSlug' => $catalogSlug,
+                    'error'       => $e->getMessage(),
+                    'trace'       => $e->getTraceAsString(),
+                ]
+            );
+            return new JSONResponse(
+                ['error' => $this->l10n->t('Internal server error')],
                 500
             );
         }//end try
@@ -634,7 +873,11 @@ class PublicationsController extends Controller
 
             // First verify the object exists in this catalog register and schema.
             $objectService = $this->getObjectService();
-            $object        = $this->queryService->findObjectInCatalog($catalog, $id, $objectService);
+            $object        = $this->queryService->findObjectInCatalog(
+                catalog: $catalog,
+                id: $id,
+                objectService: $objectService
+            );
 
             if ($object === null) {
                 return new JSONResponse(
@@ -663,11 +906,18 @@ class PublicationsController extends Controller
                 404
             );
         } catch (\Exception $e) {
-            return new JSONResponse(
+            // Public endpoint — log details server-side, return generic body (#735).
+            $this->logger->error(
+                '[PublicationsController::download] Failed to download publication',
                 [
-                    'error'   => $this->l10n->t('Failed to download publication'),
-                    'message' => $e->getMessage(),
-                ],
+                    'id'          => $id,
+                    'catalogSlug' => $catalogSlug,
+                    'error'       => $e->getMessage(),
+                    'trace'       => $e->getTraceAsString(),
+                ]
+            );
+            return new JSONResponse(
+                ['error' => $this->l10n->t('Internal server error')],
                 500
             );
         }//end try
@@ -696,11 +946,24 @@ class PublicationsController extends Controller
         try {
             $objectService = $this->getObjectService();
 
-            // Set register/schema context so RelationHandler can find the object in magic tables.
-            $location = $this->queryService->findObjectLocation($id);
-            if ($location !== null) {
-                $objectService->setRegister(register: (string) $location['register']);
-                $objectService->setSchema(schema: (string) $location['schema']);
+            // Set register/schema context so RelationHandler can find the object in
+            // magic tables. Constrain the lookup to this catalog's configured scope
+            // (#734) — a platform-wide scan would reveal arbitrary cross-catalog
+            // objects (#733). When the catalog has no configured scope, skip the
+            // context hint entirely.
+            $catalog          = $this->catalogiService->getCatalogBySlug($catalogSlug);
+            $catalogRegisters = $this->normaliseIdList(($catalog['registers'] ?? []));
+            $catalogSchemas   = $this->normaliseIdList(($catalog['schemas'] ?? []));
+            if (empty($catalogRegisters) === false && empty($catalogSchemas) === false) {
+                $location = $this->queryService->findObjectLocation(
+                    uuid: $id,
+                    allowedRegisters: $catalogRegisters,
+                    allowedSchemas: $catalogSchemas
+                );
+                if ($location !== null) {
+                    $objectService->setRegister(register: (string) $location['register']);
+                    $objectService->setSchema(schema: (string) $location['schema']);
+                }
             }
 
             $queryParams = $this->request->getParams();
@@ -726,12 +989,9 @@ class PublicationsController extends Controller
                     'error' => $e->getMessage(),
                 ]
             );
+            // Public endpoint — return a generic error body to the caller (#735).
             return new JSONResponse(
-                [
-                    'error'   => $this->l10n->t('Failed to retrieve publication uses'),
-                    'message' => $e->getMessage(),
-                    'id'      => $id,
-                ],
+                ['error' => $this->l10n->t('Internal server error')],
                 500
             );
         }//end try
@@ -760,11 +1020,24 @@ class PublicationsController extends Controller
         try {
             $objectService = $this->getObjectService();
 
-            // Set register/schema context so RelationHandler can find the object in magic tables.
-            $location = $this->queryService->findObjectLocation($id);
-            if ($location !== null) {
-                $objectService->setRegister(register: (string) $location['register']);
-                $objectService->setSchema(schema: (string) $location['schema']);
+            // Set register/schema context so RelationHandler can find the object in
+            // magic tables. Constrain the lookup to this catalog's configured scope
+            // (#734) — a platform-wide scan would reveal arbitrary cross-catalog
+            // objects (#733). When the catalog has no configured scope, skip the
+            // context hint entirely.
+            $catalog          = $this->catalogiService->getCatalogBySlug($catalogSlug);
+            $catalogRegisters = $this->normaliseIdList(($catalog['registers'] ?? []));
+            $catalogSchemas   = $this->normaliseIdList(($catalog['schemas'] ?? []));
+            if (empty($catalogRegisters) === false && empty($catalogSchemas) === false) {
+                $location = $this->queryService->findObjectLocation(
+                    uuid: $id,
+                    allowedRegisters: $catalogRegisters,
+                    allowedSchemas: $catalogSchemas
+                );
+                if ($location !== null) {
+                    $objectService->setRegister(register: (string) $location['register']);
+                    $objectService->setSchema(schema: (string) $location['schema']);
+                }
             }
 
             $queryParams = $this->request->getParams();
@@ -790,16 +1063,12 @@ class PublicationsController extends Controller
                     'error' => $e->getMessage(),
                 ]
             );
+            // Public endpoint — return a generic error body to the caller (#735).
             return new JSONResponse(
-                [
-                    'error'   => $this->l10n->t('Failed to retrieve publication used'),
-                    'message' => $e->getMessage(),
-                    'id'      => $id,
-                ],
+                ['error' => $this->l10n->t('Internal server error')],
                 500
             );
         }//end try
 
     }//end used()
-
 }//end class

--- a/lib/Service/CatalogiService.php
+++ b/lib/Service/CatalogiService.php
@@ -774,7 +774,16 @@ class CatalogiService
         // Filter out unwanted properties from the @self array in each object.
         $filteredResults = array_map(
             function ($object) {
-                $objectArray = $object->jsonSerialize();
+                // The OR SOLR backend returns array shapes (not ObjectEntity instances)
+                // from searchObjectsPaginated; the magic-mapper backend returns entities.
+                // Guard so we do not fatal with "Call to a member function jsonSerialize()
+                // on array" under SOLR (#736), mirroring the dual-shape handling already
+                // present in CatalogiController/PublicationsController::index.
+                if (is_array($object) === true) {
+                    $objectArray = $object;
+                } else {
+                    $objectArray = $object->jsonSerialize();
+                }
 
                 // @todo: a logged-in user should be able to see the full object.
                 if (isset($objectArray['@self']) === true && is_array($objectArray['@self']) === true) {

--- a/lib/Service/PublicationQueryService.php
+++ b/lib/Service/PublicationQueryService.php
@@ -58,6 +58,17 @@ class PublicationQueryService
     ];
 
     /**
+     * Per-instance existence cache for magic-mapper tables.
+     *
+     * Avoids repeated information_schema lookups when a request touches the same
+     * (register × schema) pair multiple times. Cleared whenever the service is
+     * reconstructed (no long-lived state across requests).
+     *
+     * @var array<string, bool>
+     */
+    private array $magicTableCache = [];
+
+    /**
      * Constructor.
      *
      * @param IDBConnection      $db          Database connection
@@ -193,58 +204,66 @@ class PublicationQueryService
     }//end enforcePublishedForAnonymous()
 
     /**
-     * Find the register and schema IDs for an object UUID by searching all magic tables.
+     * Find the register and schema IDs for an object UUID within a constrained scope.
      *
      * OpenRegister stores objects in per-register-per-schema "magic tables" named
-     * oc_openregister_table_{register}_{schema}. Without knowing the register/schema,
-     * we need to search across all these tables to find where an object lives.
+     * oc_openregister_table_{register}_{schema}. This helper locates which table a
+     * UUID lives in, but it is ALWAYS scoped to the caller-supplied register/schema
+     * lists. The legacy platform-wide UNION-ALL across every magic table (with a
+     * per-request information_schema reflection) is gone (#734) — it was an
+     * anonymous-reachable DoS vector and also leaked cross-catalog objects (#733).
      *
-     * @param string $uuid The UUID of the object to find
+     * Callers MUST pass non-empty $allowedRegisters and $allowedSchemas; otherwise
+     * the method returns null without touching the database.
      *
-     * @return array{register: int, schema: int}|null The register/schema IDs, or null if not found.
+     * @param string                 $uuid             The UUID of the object to find.
+     * @param array<int|string>|null $allowedRegisters Register IDs the search may touch.
+     * @param array<int|string>|null $allowedSchemas   Schema IDs the search may touch.
      *
-     * @spec exclude DB-scan helper that searches magic mapper tables to locate an object's
-     *       register/schema IDs; pure framework plumbing, no domain behavior.
+     * @return array{register: int, schema: int}|null The register/schema IDs, or null.
+     *
+     * @spec exclude DB-scan helper that searches a constrained subset of magic mapper
+     *       tables to locate an object's register/schema IDs; pure framework plumbing.
      */
-    public function findObjectLocation(string $uuid): ?array
-    {
-        // Get all magic table names from the database schema.
-        $sql    = "SELECT table_name FROM information_schema.tables";
-        $sql   .= " WHERE table_name LIKE 'oc_openregister_table_%'";
-        $sql   .= " ORDER BY table_name";
-        $result = $this->db->executeQuery($sql);
-
-        $tables = [];
-        while (($row = $result->fetch()) !== false) {
-            $tables[] = $row['table_name'];
-        }
-
-        $result->closeCursor();
-
-        if (empty($tables) === true) {
+    public function findObjectLocation(
+        string $uuid,
+        ?array $allowedRegisters=null,
+        ?array $allowedSchemas=null
+    ): ?array {
+        if (empty($allowedRegisters) === true || empty($allowedSchemas) === true) {
+            // Fail closed — without an explicit constraint we will NOT do a
+            // platform-wide scan. This is the post-#734 behaviour.
             return null;
         }
 
-        // Build a UNION ALL query to search all magic tables for the UUID.
+        // Build a UNION ALL query across the catalog's (register × schema) magic
+        // tables. The table name pattern is deterministic so there is no need to
+        // reflect against information_schema on the hot path.
         $unionParts = [];
         $quotedUuid = $this->db->quote($uuid);
-        $matches    = [];
-        foreach ($tables as $table) {
-            // Extract register and schema from table name pattern.
-            if (preg_match(
-                pattern: '/^oc_openregister_table_(\d+)_(\d+)$/',
-                subject: $table,
-                matches: $matches
-            ) === 1
-            ) {
-                $register     = (int) $matches[1];
-                $schema       = (int) $matches[2];
-                $part         = "(SELECT {$register} AS register_id,";
-                $part        .= " {$schema} AS schema_id";
+        foreach ($allowedRegisters as $register) {
+            if (is_numeric($register) === false) {
+                continue;
+            }
+
+            $registerId = (int) $register;
+            foreach ($allowedSchemas as $schema) {
+                if (is_numeric($schema) === false) {
+                    continue;
+                }
+
+                $schemaId = (int) $schema;
+                $table    = "oc_openregister_table_{$registerId}_{$schemaId}";
+                if ($this->magicTableExists($table) === false) {
+                    continue;
+                }
+
+                $part         = "(SELECT {$registerId} AS register_id,";
+                $part        .= " {$schemaId} AS schema_id";
                 $part        .= " FROM {$table} WHERE _uuid = {$quotedUuid})";
                 $unionParts[] = $part;
             }
-        }
+        }//end foreach
 
         if (empty($unionParts) === true) {
             return null;
@@ -265,6 +284,48 @@ class PublicationQueryService
         ];
 
     }//end findObjectLocation()
+
+    /**
+     * Lightweight existence probe for a magic-mapper table.
+     *
+     * Cached for the lifetime of the service instance. Lets callers safely UNION
+     * across a catalog's (register × schema) combinations even when some pairs
+     * have no backing table — without falling back to a platform-wide
+     * information_schema scan (#734).
+     *
+     * @param string $table The magic-mapper table name.
+     *
+     * @return bool True when the table exists.
+     *
+     * @spec exclude DB-existence-probe plumbing for the constrained findObjectLocation;
+     *       pure framework helper.
+     */
+    private function magicTableExists(string $table): bool
+    {
+        if (isset($this->magicTableCache[$table]) === true) {
+            return $this->magicTableCache[$table];
+        }
+
+        // Use a parameterised information_schema lookup constrained to this single
+        // table name. Cheap (index lookup, single row), not a full table-pattern scan.
+        $qb = $this->db->getQueryBuilder();
+        $qb->select($qb->func()->count('*', 'cnt'))
+            ->from('information_schema.tables')
+            ->where($qb->expr()->eq('table_name', $qb->createNamedParameter($table)));
+
+        try {
+            $result = $qb->executeQuery();
+            $row    = $result->fetch();
+            $result->closeCursor();
+            $exists = ($row !== false && (int) ($row['cnt'] ?? 0) > 0);
+        } catch (\Exception $e) {
+            $exists = false;
+        }
+
+        $this->magicTableCache[$table] = $exists;
+        return $exists;
+
+    }//end magicTableExists()
 
     /**
      * Build the ObjectService search query for a catalog index request.
@@ -552,5 +613,4 @@ class PublicationQueryService
         }
 
     }//end processArrayValue()
-
 }//end class

--- a/lib/Service/PublicationService.php
+++ b/lib/Service/PublicationService.php
@@ -766,15 +766,26 @@ class PublicationService
         // Get request parameters for filtering and searching.
         $requestParams = $this->request->getParams();
 
-        // @todo validate if it in the calaogue etc etc (this is a bit dangerues now).
-        $extend = ($requestParams['extend'] ?? $requestParams['_extend'] ?? null);
+        // Catalog membership is enforced by the catalog-scoped show() in
+        // PublicationsController; this generic /api/objects/{id} entry point trusts OR
+        // RBAC + the '@self.'-prefix extend allowlist below. The previous "@todo this
+        // is a bit dangerous now" comment referred to the missing catalog check, which
+        // is now applied at the controller layer (#733).
+        $extend = ($requestParams['extend'] ?? $requestParams['_extend'] ?? []);
         // Normalize to array.
         if (is_array($extend) === false) {
             $extend = [$extend];
         }
 
-        // Filter only values that start with '@self.'.
-        $extend = array_filter($extend, fn($val) => is_string($val) === true && str_starts_with($val, '@self.') === true);
+        // Filter only values that start with '@self.' and cap breadth (#732).
+        $filtered = array_filter(
+            $extend,
+            static fn($val) => is_string($val) === true && str_starts_with($val, '@self.') === true
+        );
+        $extend   = array_values($filtered);
+        if (count($extend) > 5) {
+            $extend = array_slice($extend, 0, 5);
+        }
 
         try {
             // Render the object with requested extensions and filters.
@@ -923,8 +934,16 @@ class PublicationService
         // Filter each object.
         return array_map(
             function ($object) use ($unwantedProperties) {
-                // Use jsonSerialize to get an array representation of the object.
-                $objectArray = $object->jsonSerialize();
+                // The OR SOLR backend returns array shapes (not ObjectEntity instances)
+                // from searchObjectsPaginated; the magic-mapper backend returns entities.
+                // Guard so we do not fatal with "Call to a member function jsonSerialize()
+                // on array" under SOLR (#736), mirroring the dual-shape handling that
+                // already exists in PublicationsController::index.
+                if (is_array($object) === true) {
+                    $objectArray = $object;
+                } else {
+                    $objectArray = $object->jsonSerialize();
+                }
 
                 // Remove unwanted properties from the '@self' array.
                 if (isset($objectArray['@self']) === true && is_array($objectArray['@self']) === true) {

--- a/tests/Unit/Controller/CatalogiControllerTest.php
+++ b/tests/Unit/Controller/CatalogiControllerTest.php
@@ -87,8 +87,10 @@ class CatalogiControllerTest extends TestCase
             ->with('OCA\OpenRegister\Service\ObjectService')
             ->willReturn($mockObjService);
 
+        // Default-pass every config key (catalog config + CORS allowlist) to its
+        // documented default value so the controller falls back to '*' for CORS.
         $this->config->method('getValueString')
-            ->willReturn('');
+            ->willReturnCallback(fn(string $app, string $key, string $default = '') => $default);
 
         $this->request->method('getParams')
             ->willReturn([]);
@@ -116,11 +118,16 @@ class CatalogiControllerTest extends TestCase
         $this->container->method('get')
             ->willReturn($mockObjService);
 
+        // Configure catalog scope and leave CORS allowlist at its default '*'.
         $this->config->method('getValueString')
-            ->willReturnMap([
-                ['opencatalogi', 'catalog_schema', '', '5'],
-                ['opencatalogi', 'catalog_register', '', '3'],
-            ]);
+            ->willReturnCallback(function (string $app, string $key, string $default = '') {
+                return match ($key) {
+                    'catalog_schema'       => '5',
+                    'catalog_register'     => '3',
+                    'cors_allowed_origins' => $default,
+                    default                => $default,
+                };
+            });
 
         $this->request->method('getParams')
             ->willReturn([]);
@@ -138,7 +145,7 @@ class CatalogiControllerTest extends TestCase
             ->willReturn([]);
 
         $this->config->method('getValueString')
-            ->willReturn('');
+            ->willReturnCallback(fn(string $app, string $key, string $default = '') => $default);
 
         $this->request->method('getParams')
             ->willReturn([]);
@@ -200,5 +207,70 @@ class CatalogiControllerTest extends TestCase
         $response = $this->controller->show(42);
 
         $this->assertInstanceOf(JSONResponse::class, $response);
+    }
+
+    /**
+     * Security (#735): an attacker-controlled Origin header must NOT be reflected
+     * back in Access-Control-Allow-Origin when the allowlist is not '*'. The
+     * controller must fall back to the configured allowlist entry instead.
+     */
+    public function testShowDoesNotReflectArbitraryOriginWhenAllowlistConfigured(): void
+    {
+        $expectedResponse = new JSONResponse(['id' => '123']);
+
+        $this->catalogiService->method('index')
+            ->with('123')
+            ->willReturn($expectedResponse);
+
+        $this->config->method('getValueString')
+            ->willReturnCallback(function (string $app, string $key, string $default = '') {
+                return match ($key) {
+                    'cors_allowed_origins' => 'https://trusted.example',
+                    default                => $default,
+                };
+            });
+
+        $this->request->method('getHeader')
+            ->with('Origin')
+            ->willReturn('https://evil.attacker.test');
+
+        $response = $this->controller->show('123');
+
+        $this->assertSame(
+            'https://trusted.example',
+            $response->getHeaders()['Access-Control-Allow-Origin']
+        );
+    }
+
+    /**
+     * When the configured allowlist contains the caller's Origin, that exact value
+     * may be echoed back (CORS by-design); otherwise the first allowlist entry wins.
+     */
+    public function testShowEchoesOriginOnlyWhenOnAllowlist(): void
+    {
+        $expectedResponse = new JSONResponse(['id' => '123']);
+
+        $this->catalogiService->method('index')
+            ->with('123')
+            ->willReturn($expectedResponse);
+
+        $this->config->method('getValueString')
+            ->willReturnCallback(function (string $app, string $key, string $default = '') {
+                return match ($key) {
+                    'cors_allowed_origins' => 'https://trusted.example,https://other.example',
+                    default                => $default,
+                };
+            });
+
+        $this->request->method('getHeader')
+            ->with('Origin')
+            ->willReturn('https://other.example');
+
+        $response = $this->controller->show('123');
+
+        $this->assertSame(
+            'https://other.example',
+            $response->getHeaders()['Access-Control-Allow-Origin']
+        );
     }
 }

--- a/tests/Unit/Controller/DirectoryControllerTest.php
+++ b/tests/Unit/Controller/DirectoryControllerTest.php
@@ -8,10 +8,12 @@ use OCA\OpenCatalogi\Controller\DirectoryController;
 use OCA\OpenCatalogi\Service\DirectoryService;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\Http\Response;
+use OCP\IAppConfig;
 use OCP\IL10N;
 use OCP\IRequest;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 use GuzzleHttp\Exception\TransferException;
 
 /**
@@ -23,6 +25,8 @@ class DirectoryControllerTest extends TestCase
     private IRequest|MockObject $request;
     private DirectoryService|MockObject $directoryService;
     private IL10N|MockObject $l10n;
+    private LoggerInterface|MockObject $logger;
+    private IAppConfig|MockObject $config;
     private DirectoryController $controller;
 
     protected function setUp(): void
@@ -30,15 +34,23 @@ class DirectoryControllerTest extends TestCase
         $this->request          = $this->createMock(IRequest::class);
         $this->directoryService = $this->createMock(DirectoryService::class);
         $this->l10n             = $this->createMock(IL10N::class);
+        $this->logger           = $this->createMock(LoggerInterface::class);
+        $this->config           = $this->createMock(IAppConfig::class);
 
         $this->l10n->method('t')
-            ->willReturnCallback(fn(string $text) => $text);
+            ->willReturnCallback(fn(string $text, array $params = []) => $text);
+
+        // CORS allowlist defaults to '*' unless a test overrides it.
+        $this->config->method('getValueString')
+            ->willReturnCallback(fn(string $app, string $key, string $default = '') => $default);
 
         $this->controller = new DirectoryController(
             'opencatalogi',
             $this->request,
             $this->directoryService,
-            $this->l10n
+            $this->l10n,
+            $this->logger,
+            $this->config
         );
     }
 
@@ -88,7 +100,7 @@ class DirectoryControllerTest extends TestCase
             ->willReturn([]);
 
         $this->directoryService->method('getDirectory')
-            ->willThrowException(new \Exception('Database error'));
+            ->willThrowException(new \Exception('Database error: revealing SQL fragment'));
 
         $this->request->server = [];
 
@@ -96,6 +108,67 @@ class DirectoryControllerTest extends TestCase
 
         $this->assertInstanceOf(JSONResponse::class, $response);
         $this->assertEquals(500, $response->getStatus());
+    }
+
+    /**
+     * Security (#735): a public 500 response must NOT leak the raw exception message
+     * to the caller — internal SQL/file-path fragments accelerate reconnaissance.
+     */
+    public function testIndexReturns500WithoutLeakingExceptionMessage(): void
+    {
+        $this->request->method('getParams')
+            ->willReturn([]);
+
+        $secretMessage = 'PDOException: SQLSTATE[42S02] in /var/www/html/internal-path/foo.php:123';
+        $this->directoryService->method('getDirectory')
+            ->willThrowException(new \Exception($secretMessage));
+
+        $this->request->server = [];
+
+        $response = $this->controller->index();
+
+        $this->assertSame(500, $response->getStatus());
+        $body = json_encode($response->getData());
+        $this->assertStringNotContainsString($secretMessage, (string) $body);
+        $this->assertStringNotContainsString('PDOException', (string) $body);
+        $this->assertStringNotContainsString('/var/www/html', (string) $body);
+    }
+
+    /**
+     * Security (#735): an attacker-controlled Origin must NOT be reflected when a
+     * non-wildcard allowlist is configured.
+     */
+    public function testIndexDoesNotReflectArbitraryOriginWhenAllowlistConfigured(): void
+    {
+        // Re-create the config + controller with a non-wildcard allowlist.
+        $config = $this->createMock(IAppConfig::class);
+        $config->method('getValueString')
+            ->willReturnCallback(function (string $app, string $key, string $default = '') {
+                return match ($key) {
+                    'cors_allowed_origins' => 'https://trusted.example',
+                    default                => $default,
+                };
+            });
+
+        $controller = new DirectoryController(
+            'opencatalogi',
+            $this->request,
+            $this->directoryService,
+            $this->l10n,
+            $this->logger,
+            $config
+        );
+
+        $this->directoryService->method('getDirectory')->willReturn(['results' => []]);
+        $this->request->method('getParams')->willReturn([]);
+        $this->request->server = ['HTTP_ORIGIN' => 'https://evil.attacker.test'];
+
+        $response = $controller->index();
+
+        $this->assertSame(
+            'https://trusted.example',
+            $response->getHeaders()['Access-Control-Allow-Origin']
+        );
     }
 
     public function testUpdateReturnsBadRequestWhenNoDirectoryUrl(): void

--- a/tests/Unit/Controller/PublicationsControllerTest.php
+++ b/tests/Unit/Controller/PublicationsControllerTest.php
@@ -10,6 +10,7 @@ use OCA\OpenCatalogi\Service\PublicationQueryService;
 use OCA\OpenCatalogi\Service\PublicationService;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\Http\Response;
+use OCP\IAppConfig;
 use OCP\IDBConnection;
 use OCP\IL10N;
 use OCP\IRequest;
@@ -35,6 +36,7 @@ class PublicationsControllerTest extends TestCase
     private LoggerInterface|MockObject $logger;
     private IDBConnection|MockObject $db;
     private IL10N|MockObject $l10n;
+    private IAppConfig|MockObject $appConfig;
     private PublicationsController $controller;
 
     protected function setUp(): void
@@ -48,9 +50,14 @@ class PublicationsControllerTest extends TestCase
         $this->logger             = $this->createMock(LoggerInterface::class);
         $this->db                 = $this->createMock(IDBConnection::class);
         $this->l10n               = $this->createMock(IL10N::class);
+        $this->appConfig          = $this->createMock(IAppConfig::class);
 
         $this->l10n->method('t')
             ->willReturnCallback(fn(string $text, array $params = []) => $text);
+
+        // CORS allowlist defaults to '*' (wildcard) unless a test overrides it.
+        $this->appConfig->method('getValueString')
+            ->willReturnCallback(fn(string $app, string $key, string $default = '') => $default);
 
         // Default query-service behaviour: the search query and result shaping are
         // pass-throughs, schema/register resolution is empty, and the published
@@ -83,7 +90,8 @@ class PublicationsControllerTest extends TestCase
             $this->container,
             $this->appManager,
             $this->logger,
-            $this->l10n
+            $this->l10n,
+            $this->appConfig
         );
     }
 
@@ -132,7 +140,8 @@ class PublicationsControllerTest extends TestCase
             $this->container,
             $this->appManager,
             $this->logger,
-            $this->l10n
+            $this->l10n,
+            $this->appConfig
         );
     }
 
@@ -1347,6 +1356,7 @@ class PublicationsControllerTest extends TestCase
             $this->appManager,
             $this->logger,
             $this->l10n,
+            $this->appConfig,
             'GET, POST',
             'Authorization',
             3600
@@ -1359,5 +1369,317 @@ class PublicationsControllerTest extends TestCase
         $response = $controller->preflightedCors();
 
         $this->assertInstanceOf(Response::class, $response);
+    }
+
+    // =======================================================================
+    // #732 — extend allowlist + breadth cap on public show()
+    // =======================================================================
+
+    /**
+     * Security (#732): a non-'@self.'-prefixed extend entry must be stripped before
+     * reaching ObjectService::renderEntity. The public endpoint must only traverse
+     * relations under @self.* — never arbitrary properties.
+     */
+    public function testShowStripsNonSelfExtendOnPublicEndpoint(): void
+    {
+        $mockObjService = $this->mockObjectService();
+
+        $this->catalogiService->method('getCatalogBySlug')
+            ->willReturn(['title' => 'T', 'schemas' => [1], 'registers' => [1]]);
+
+        $mockObj = $this->createObjectEntityMock(register: 1, schema: 1);
+        $mockObjService->method('searchObjects')->willReturn([$mockObj]);
+
+        $captured = [];
+        $mockObjService->method('renderEntity')
+            ->willReturnCallback(function (...$args) use (&$captured) {
+                // Named args land as a single assoc array on PHP positional call.
+                $captured[] = func_get_args();
+                return ['id' => 'pub-123'];
+            });
+
+        $this->request->method('getParams')
+            ->willReturn(['_extend' => ['@self.files', 'parent', 'children', '@self.metadata']]);
+
+        $this->request->server = [];
+
+        $response = $this->controller->show('test-catalog', 'pub-123');
+
+        $this->assertEquals(200, $response->getStatus());
+        // Inspect the rendered-entity call: only '@self.'-prefixed entries should survive.
+        $this->assertGreaterThan(0, count($captured));
+        $renderArgs = $captured[0];
+        // The _extend arg is the 2nd positional one.
+        $extendArg = $renderArgs[1];
+        $this->assertContains('@self.files', $extendArg);
+        $this->assertContains('@self.metadata', $extendArg);
+        $this->assertNotContains('parent', $extendArg);
+        $this->assertNotContains('children', $extendArg);
+    }
+
+    /**
+     * Security (#732): extend breadth is capped to MAX_PUBLIC_EXTEND (5) to prevent
+     * N+1 amplification on the public endpoint.
+     */
+    public function testShowCapsExtendBreadthAtFive(): void
+    {
+        $mockObjService = $this->mockObjectService();
+
+        $this->catalogiService->method('getCatalogBySlug')
+            ->willReturn(['title' => 'T', 'schemas' => [1], 'registers' => [1]]);
+
+        $mockObj = $this->createObjectEntityMock(register: 1, schema: 1);
+        $mockObjService->method('searchObjects')->willReturn([$mockObj]);
+
+        $captured = [];
+        $mockObjService->method('renderEntity')
+            ->willReturnCallback(function (...$args) use (&$captured) {
+                $captured[] = $args;
+                return ['id' => 'pub-123'];
+            });
+
+        // Twelve valid '@self.' entries — only five should survive the cap.
+        $extend = [];
+        for ($i = 0; $i < 12; $i++) {
+            $extend[] = '@self.field'.$i;
+        }
+
+        $this->request->method('getParams')->willReturn(['_extend' => $extend]);
+        $this->request->server = [];
+
+        $response = $this->controller->show('test-catalog', 'pub-123');
+
+        $this->assertEquals(200, $response->getStatus());
+        $this->assertCount(5, $captured[0][1]);
+    }
+
+    // =======================================================================
+    // #733 — catalog-membership validation on show()
+    // =======================================================================
+
+    /**
+     * Security (#733): when the resolved object's register/schema is NOT in the
+     * requested catalog's scope, show() MUST return 404 — never disclose the object.
+     */
+    public function testShowReturns404WhenObjectOutsideCatalogScope(): void
+    {
+        $mockObjService = $this->mockObjectService();
+
+        $this->catalogiService->method('getCatalogBySlug')
+            ->willReturn([
+                'title'     => 'Catalog A',
+                'schemas'   => [10],
+                'registers' => [20],
+            ]);
+
+        // Object belongs to a DIFFERENT register/schema than the catalog's scope.
+        $foreignObject = $this->createObjectEntityMock(register: 99, schema: 99);
+
+        // Fast-path searchObjects returns nothing (since the catalog scope is 20/10).
+        // The fallback then finds the foreign object via findObjectLocation.
+        $callCount = 0;
+        $mockObjService->method('searchObjects')
+            ->willReturnCallback(function () use (&$callCount, $foreignObject) {
+                $callCount++;
+                // Fast path empty; fallback returns the foreign-scope object.
+                return ($callCount === 1 ? [] : [$foreignObject]);
+            });
+
+        // Stub findObjectLocation to claim the object is in the catalog's scope so we
+        // exercise the post-lookup membership check (not the upstream constraint).
+        $this->queryService = $this->createMock(PublicationQueryService::class);
+        $this->queryService->method('buildCatalogSearchQuery')->willReturn([]);
+        $this->queryService->method('enforcePublishedForAnonymous')
+            ->willReturnCallback(fn(array $r) => $r);
+        $this->queryService->method('stripEmptyValues')
+            ->willReturnCallback(fn(array $d) => $d);
+        $this->queryService->method('resolveSchemaAndRegisterObjects')
+            ->willReturn(['schemas' => [], 'registers' => []]);
+        $this->queryService->method('isAnonymous')->willReturn(false);
+        $this->queryService->method('isObjectPublic')->willReturn(true);
+        $this->queryService->method('findObjectLocation')
+            ->willReturn(['register' => 20, 'schema' => 10]);
+        $this->controller = $this->newControllerWithQueryService();
+
+        $this->request->method('getParams')->willReturn([]);
+        $this->request->server = [];
+
+        $response = $this->controller->show('catalog-a', 'foreign-uuid');
+
+        $this->assertEquals(404, $response->getStatus());
+    }
+
+    // =======================================================================
+    // #734 — findObjectLocation must NOT be called platform-wide on show()
+    // =======================================================================
+
+    /**
+     * Security (#734): findObjectLocation must be invoked WITH catalog-scope
+     * constraints, never as an unbounded platform-wide lookup.
+     */
+    public function testShowCallsFindObjectLocationWithCatalogScope(): void
+    {
+        $mockObjService = $this->mockObjectService();
+
+        $this->catalogiService->method('getCatalogBySlug')
+            ->willReturn([
+                'title'     => 'Catalog',
+                'schemas'   => [11, 12],
+                'registers' => [21],
+            ]);
+
+        $mockObjService->method('searchObjects')->willReturn([]);
+
+        $this->queryService = $this->createMock(PublicationQueryService::class);
+        $this->queryService->method('buildCatalogSearchQuery')->willReturn([]);
+        $this->queryService->method('enforcePublishedForAnonymous')
+            ->willReturnCallback(fn(array $r) => $r);
+        $this->queryService->method('stripEmptyValues')
+            ->willReturnCallback(fn(array $d) => $d);
+        $this->queryService->method('resolveSchemaAndRegisterObjects')
+            ->willReturn(['schemas' => [], 'registers' => []]);
+        $this->queryService->method('isAnonymous')->willReturn(false);
+        $this->queryService->method('isObjectPublic')->willReturn(true);
+
+        // The controller MUST call findObjectLocation with the catalog's scope
+        // (allowedRegisters + allowedSchemas), never with just $uuid alone.
+        $this->queryService->expects($this->atLeastOnce())
+            ->method('findObjectLocation')
+            ->with(
+                $this->equalTo('missing-id'),
+                $this->equalTo([21]),
+                $this->equalTo([11, 12])
+            )
+            ->willReturn(null);
+
+        $this->controller = $this->newControllerWithQueryService();
+
+        $this->request->method('getParams')->willReturn([]);
+        $this->request->server = [];
+
+        $response = $this->controller->show('any-slug', 'missing-id');
+
+        // Object not found — 404. The point is the call-shape assertion above.
+        $this->assertEquals(404, $response->getStatus());
+    }
+
+    /**
+     * Security (#734): show() must NOT invoke findObjectLocation at all when the
+     * catalog has no configured registers/schemas — an unscoped catalog cannot be
+     * used as a platform-wide namespace.
+     */
+    public function testShowSkipsFindObjectLocationForUnscopedCatalog(): void
+    {
+        $mockObjService = $this->mockObjectService();
+
+        $this->catalogiService->method('getCatalogBySlug')
+            ->willReturn([
+                'title'     => 'Empty',
+                'schemas'   => [],
+                'registers' => [],
+            ]);
+
+        $mockObjService->method('searchObjects')->willReturn([]);
+
+        $this->queryService = $this->createMock(PublicationQueryService::class);
+        $this->queryService->method('buildCatalogSearchQuery')->willReturn([]);
+        $this->queryService->method('enforcePublishedForAnonymous')
+            ->willReturnCallback(fn(array $r) => $r);
+        $this->queryService->method('stripEmptyValues')
+            ->willReturnCallback(fn(array $d) => $d);
+        $this->queryService->method('resolveSchemaAndRegisterObjects')
+            ->willReturn(['schemas' => [], 'registers' => []]);
+        $this->queryService->method('isAnonymous')->willReturn(false);
+        $this->queryService->method('isObjectPublic')->willReturn(true);
+
+        // findObjectLocation MUST NOT be called for an unscoped catalog.
+        $this->queryService->expects($this->never())
+            ->method('findObjectLocation');
+
+        $this->controller = $this->newControllerWithQueryService();
+
+        $this->request->method('getParams')->willReturn([]);
+        $this->request->server = [];
+
+        $response = $this->controller->show('unscoped-catalog', 'any-uuid');
+
+        $this->assertEquals(404, $response->getStatus());
+    }
+
+    // =======================================================================
+    // #735 — CORS Origin allowlist + generic error responses
+    // =======================================================================
+
+    /**
+     * Security (#735): when the allowlist is configured (non-'*'), an attacker-
+     * controlled Origin must NOT be reflected back in Access-Control-Allow-Origin.
+     */
+    public function testIndexDoesNotReflectArbitraryOriginWhenAllowlistConfigured(): void
+    {
+        $this->appConfig = $this->createMock(IAppConfig::class);
+        $this->appConfig->method('getValueString')
+            ->willReturnCallback(function (string $app, string $key, string $default = '') {
+                return match ($key) {
+                    'cors_allowed_origins' => 'https://trusted.example',
+                    default                => $default,
+                };
+            });
+        $this->controller = $this->newControllerWithQueryService();
+
+        $mockObjService = $this->mockObjectService();
+        $this->catalogiService->method('getCatalogBySlug')
+            ->willReturn(['title' => 'T', 'schemas' => [1], 'registers' => [1]]);
+        $mockObjService->method('buildSearchQuery')->willReturn([]);
+        $mockObjService->method('searchObjectsPaginated')
+            ->willReturn(['results' => [], 'total' => 0]);
+        $this->request->method('getParams')->willReturn([]);
+        $this->request->method('getHeader')
+            ->with('Origin')
+            ->willReturn('https://evil.attacker.test');
+        $this->request->server = ['HTTP_ORIGIN' => 'https://evil.attacker.test'];
+
+        $response = $this->controller->index('test');
+
+        $this->assertSame(
+            'https://trusted.example',
+            $response->getHeaders()['Access-Control-Allow-Origin']
+        );
+    }
+
+    /**
+     * Security (#735): a public 500 response must NOT leak the raw exception message.
+     */
+    public function testShowReturns500WithoutLeakingExceptionMessage(): void
+    {
+        $secretMessage = 'PDOException: SQLSTATE[42S22] internal_table.column at /var/www/secret.php:99';
+
+        $this->catalogiService->method('getCatalogBySlug')
+            ->willThrowException(new \Exception($secretMessage));
+
+        $response = $this->controller->show('test-catalog', 'pub-123');
+
+        $this->assertSame(500, $response->getStatus());
+        $body = json_encode($response->getData());
+        $this->assertStringNotContainsString($secretMessage, (string) $body);
+        $this->assertStringNotContainsString('PDOException', (string) $body);
+        $this->assertStringNotContainsString('/var/www', (string) $body);
+    }
+
+    /**
+     * Security (#735): a public 500 on index() must NOT leak the raw exception message.
+     */
+    public function testIndexReturns500WithoutLeakingExceptionMessage(): void
+    {
+        $secretMessage = 'PDOException: internal-server-hostname:1234 leaked';
+
+        $this->catalogiService->method('getCatalogBySlug')
+            ->willThrowException(new \Exception($secretMessage));
+
+        $response = $this->controller->index('test-catalog');
+
+        $this->assertSame(500, $response->getStatus());
+        $body = json_encode($response->getData());
+        $this->assertStringNotContainsString($secretMessage, (string) $body);
+        $this->assertStringNotContainsString('internal-server-hostname', (string) $body);
     }
 }

--- a/tests/Unit/Service/CatalogiServiceTest.php
+++ b/tests/Unit/Service/CatalogiServiceTest.php
@@ -1217,4 +1217,58 @@ class CatalogiServiceTest extends TestCase
 
         return $method;
     }//end getPrivateMethod()
+
+    /**
+     * Robustness (#736): under the SOLR backend, searchObjectsPaginated returns
+     * array shapes (not ObjectEntity instances). CatalogiService::index MUST
+     * accept both array AND entity shapes without fataling with
+     * "Call to a member function jsonSerialize() on array".
+     */
+    public function testIndexAcceptsArrayShapedResultsFromSolrBackend(): void
+    {
+        $this->request->method('getParams')->willReturn([]);
+        $this->config->method('getValueString')
+            ->willReturnMap([
+                ['opencatalogi', 'catalog_schema', '', 'schema-1'],
+                ['opencatalogi', 'catalog_register', '', 'register-1'],
+            ]);
+
+        $catalogObject = $this->createMockCatalogObject([
+            'registers' => ['reg-1'],
+            'schemas'   => ['sch-1'],
+        ]);
+
+        // SOLR-shape result: plain associative array, NOT an ObjectEntity.
+        $solrShapedResult = [
+            '@self' => [
+                'id'            => 'pub-solr-1',
+                'register'      => 'reg-1',
+                'schema'        => 'sch-1',
+                'owner'         => 'admin',
+                'schemaVersion' => '1.0',
+            ],
+        ];
+
+        $objectService = $this->createMock(ObjectService::class);
+        $objectService->method('searchObjects')->willReturn([$catalogObject]);
+        $objectService->method('searchObjectsPaginated')
+            ->willReturn([
+                'results' => [$solrShapedResult],
+                'total'   => 1,
+                'page'    => 1,
+                'pages'   => 1,
+            ]);
+
+        $this->injectObjectService($objectService);
+
+        $response = $this->service->index();
+
+        $this->assertInstanceOf(JSONResponse::class, $response);
+        $data = $response->getData();
+        $this->assertCount(1, $data['results']);
+        $first = $data['results'][0];
+        $this->assertArrayNotHasKey('owner', $first['@self']);
+        $this->assertArrayNotHasKey('schemaVersion', $first['@self']);
+        $this->assertSame('reg-1', $first['@self']['register']);
+    }
 }//end class

--- a/tests/Unit/Service/PublicationQueryServiceTest.php
+++ b/tests/Unit/Service/PublicationQueryServiceTest.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Unit\Service;
+
+use OCA\OpenCatalogi\Service\PublicationQueryService;
+use OCP\IDBConnection;
+use OCP\IUserSession;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\DB\QueryBuilder\IFunctionBuilder;
+use OCP\DB\QueryBuilder\IExpressionBuilder;
+use OCP\DB\QueryBuilder\IQueryFunction;
+use OCP\DB\IResult;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+
+/**
+ * Unit tests for PublicationQueryService — focused on the findObjectLocation
+ * constraint behaviour added for #734 (no platform-wide table scan).
+ */
+class PublicationQueryServiceTest extends TestCase
+{
+
+    private IDBConnection|MockObject $db;
+    private ContainerInterface|MockObject $container;
+    private IUserSession|MockObject $userSession;
+    private PublicationQueryService $service;
+
+    protected function setUp(): void
+    {
+        $this->db          = $this->createMock(IDBConnection::class);
+        $this->container   = $this->createMock(ContainerInterface::class);
+        $this->userSession = $this->createMock(IUserSession::class);
+
+        $this->service = new PublicationQueryService(
+            $this->db,
+            $this->container,
+            $this->userSession
+        );
+    }
+
+    /**
+     * Security (#734): findObjectLocation MUST return null without touching the
+     * database when no constraint is supplied. The legacy platform-wide table
+     * scan is gone.
+     */
+    public function testFindObjectLocationFailsClosedWithoutConstraint(): void
+    {
+        // The DB must NOT be touched at all.
+        $this->db->expects($this->never())->method('executeQuery');
+        $this->db->expects($this->never())->method('getQueryBuilder');
+
+        $this->assertNull($this->service->findObjectLocation('any-uuid'));
+        $this->assertNull(
+            $this->service->findObjectLocation('any-uuid', allowedRegisters: [], allowedSchemas: [])
+        );
+        $this->assertNull(
+            $this->service->findObjectLocation('any-uuid', allowedRegisters: [1], allowedSchemas: [])
+        );
+        $this->assertNull(
+            $this->service->findObjectLocation('any-uuid', allowedRegisters: [], allowedSchemas: [1])
+        );
+    }
+
+    /**
+     * Security (#734): when a constraint IS supplied, the lookup is bounded to
+     * the catalog's (register × schema) magic tables — no information_schema
+     * pattern scan. The deterministic table name is the only thing queried.
+     */
+    public function testFindObjectLocationLooksUpOnlyConstrainedTables(): void
+    {
+        // Stub magicTableExists to claim only one table exists, then assert the
+        // UNION-ALL query runs once and returns its result.
+        $this->stubMagicTableExists(['oc_openregister_table_21_11' => true]);
+
+        $resultRow = ['register_id' => 21, 'schema_id' => 11];
+        $unionResult = $this->createMock(IResult::class);
+        $unionResult->method('fetch')->willReturn($resultRow);
+        $unionResult->method('closeCursor');
+
+        $this->db->method('quote')->willReturn("'uuid-found'");
+        $this->db->expects($this->once())
+            ->method('executeQuery')
+            ->with($this->stringContains('oc_openregister_table_21_11'))
+            ->willReturn($unionResult);
+
+        $location = $this->service->findObjectLocation(
+            uuid: 'uuid-found',
+            allowedRegisters: [21],
+            allowedSchemas: [11]
+        );
+
+        $this->assertSame(['register' => 21, 'schema' => 11], $location);
+    }
+
+    /**
+     * Security (#734): non-existent tables are skipped — they never appear in
+     * the UNION query. When every (register × schema) pair has no backing table,
+     * findObjectLocation returns null without running any UNION query.
+     */
+    public function testFindObjectLocationReturnsNullWhenNoTablesExist(): void
+    {
+        $this->stubMagicTableExists([]);
+
+        // No UNION query should ever execute — only the existence probes.
+        $this->db->expects($this->never())->method('executeQuery');
+
+        $location = $this->service->findObjectLocation(
+            uuid: 'uuid-missing',
+            allowedRegisters: [1],
+            allowedSchemas: [2]
+        );
+
+        $this->assertNull($location);
+    }
+
+    /**
+     * Helper: stub the IQueryBuilder chain used by magicTableExists().
+     *
+     * @param array<string, bool> $tableExistence Map of table_name => exists?
+     */
+    private function stubMagicTableExists(array $tableExistence): void
+    {
+        $this->db->method('getQueryBuilder')->willReturnCallback(function () use ($tableExistence) {
+            $qb = $this->createMock(IQueryBuilder::class);
+            $funcBuilder = $this->createMock(IFunctionBuilder::class);
+            $funcBuilder->method('count')->willReturn($this->createMock(IQueryFunction::class));
+            $expr = $this->createMock(IExpressionBuilder::class);
+            $expr->method('eq')->willReturn('eq');
+
+            $qb->method('select')->willReturnSelf();
+            $qb->method('from')->willReturnSelf();
+            $qb->method('func')->willReturn($funcBuilder);
+            $qb->method('expr')->willReturn($expr);
+            $qb->method('createNamedParameter')->willReturnCallback(fn($v) => $v);
+
+            // Use the *most recently bound* table name (createNamedParameter)
+            // to decide the exists value via where().
+            $boundTable = null;
+            $qb->method('where')->willReturnCallback(function () use (&$boundTable, $qb) {
+                return $qb;
+            });
+
+            // We can't easily intercept createNamedParameter to pull the table name
+            // back out — but we don't need to. executeQuery returns the configured
+            // existence for ALL tables in this stub.
+            $qb->method('executeQuery')->willReturnCallback(function () use ($tableExistence) {
+                $result = $this->createMock(IResult::class);
+                // Map total count: true => 1, false/absent => 0.
+                // If any tableExistence entry is true, return 1; else 0.
+                $anyExists = !empty(array_filter($tableExistence));
+                $result->method('fetch')->willReturn(['cnt' => $anyExists ? 1 : 0]);
+                $result->method('closeCursor');
+                return $result;
+            });
+
+            return $qb;
+        });
+    }
+}

--- a/tests/Unit/Service/PublicationServiceTest.php
+++ b/tests/Unit/Service/PublicationServiceTest.php
@@ -1510,6 +1510,37 @@ class PublicationServiceTest extends TestCase
         $this->assertSame([], $result);
     }
 
+    /**
+     * Robustness (#736): under the SOLR backend, searchObjectsPaginated returns
+     * array shapes (not ObjectEntity instances). filterUnwantedProperties MUST
+     * accept arrays without fataling with "Call to a member function jsonSerialize()
+     * on array".
+     */
+    public function testFilterUnwantedPropertiesAcceptsArrayShape(): void
+    {
+        $method = new \ReflectionMethod(PublicationService::class, 'filterUnwantedProperties');
+        $method->setAccessible(true);
+
+        // SOLR-shape: plain associative array, no jsonSerialize().
+        $solrShape = [
+            '@self' => [
+                'id'            => 'pub-solr-1',
+                'title'         => 'Keep',
+                'schemaVersion' => 'remove',
+            ],
+            'extra' => 'kept',
+        ];
+
+        $result = $method->invoke($this->service, [$solrShape]);
+
+        $this->assertCount(1, $result);
+        $self = $result[0]['@self'];
+        $this->assertSame('pub-solr-1', $self['id']);
+        $this->assertSame('Keep', $self['title']);
+        $this->assertArrayNotHasKey('schemaVersion', $self);
+        $this->assertSame('kept', $result[0]['extra']);
+    }
+
     // =======================================================================
     // Private method: extractFieldValue (via reflection)
     // =======================================================================


### PR DESCRIPTION
Five team-reviewer findings on the public OpenCatalogi API surface (closes #732, #733, #734, #735, #736). Builds on the #737 PublicationQueryService extraction + SSRF guard + published predicate already on `development`.

## Per-finding summary + verification

### #732 (MEDIUM) — extend allowlist + breadth cap on public show()
**Fix:** `PublicationsController::show` now strips non-`@self.`-prefixed extend entries at the controller layer (mirroring `PublicationService::show()`) AND caps the list at `MAX_PUBLIC_EXTEND` (5). `PublicationService::show()` likewise caps at 5.
**Verify:**
- New unit test `testShowStripsNonSelfExtendOnPublicEndpoint` asserts that `parent` / `children` extends are dropped before `renderEntity`.
- New unit test `testShowCapsExtendBreadthAtFive` asserts twelve valid `@self.*` entries are capped to five.
- Live smoke: `GET /api/publications/{uuid}?_extend[]=@self.files&_extend[]=parent&_extend[]=children` returned the publication with `@self.files` populated; `parent`/`children` keys were NOT in the response.

### #733 (MEDIUM) — catalog-membership validation on show()
**Fix:** After resolving an object, `show()` asserts the object's `register`/`schema` are in the catalog's configured scope; mismatches return 404. Unscoped catalogs (empty `registers`/`schemas`) can no longer disclose individual objects. The `@todo: Catalog validation disabled` placeholder is gone.
**Verify:**
- New unit test `testShowReturns404WhenObjectOutsideCatalogScope` covers the fail-closed path.
- Live smoke: with `Publications` catalog scoped to register=10/schema=28, `GET /api/publications/{uuid-at-14/54}` returned **404** (catalog object outside scope), while `GET /api/publications/{uuid-at-10/28}` returned **200** with full data.

### #734 (MEDIUM) — `findObjectLocation` constrained to catalog scope
**Fix:** `PublicationQueryService::findObjectLocation` now REQUIRES `$allowedRegisters` + `$allowedSchemas`; called without them it fails closed with no DB access. The per-request `information_schema` LIKE-scan over every `oc_openregister_table_*` is gone — the new path computes deterministic table names from the catalog's (register × schema) cross product and probes each candidate via a parameterised `information_schema` lookup cached for the request. `PublicationsController::show`, `uses`, and `used` all pass the catalog scope down.
**Verify:**
- New `tests/Unit/Service/PublicationQueryServiceTest.php` has three tests: fail-closed without constraint, scoped UNION query, non-existent tables skipped without UNION.
- New unit test `testShowCallsFindObjectLocationWithCatalogScope` asserts the controller invokes `findObjectLocation(uuid, allowedRegisters, allowedSchemas)`.
- New unit test `testShowSkipsFindObjectLocationForUnscopedCatalog` asserts `findObjectLocation` is NEVER called for an unscoped catalog.

### #735 (MEDIUM) — CORS allowlist + generic public error bodies
**Fix:** New `IAppConfig` key `cors_allowed_origins` (CSV; default `*`). `resolveAllowedOrigin()` emits the configured value, or — when an allowlist is set — only echoes the caller's Origin if it appears on that list. Arbitrary-Origin reflection is gone across `PublicationsController`, `CatalogiController`, and `DirectoryController`. Public 500 responses (index/show/attachments/download/uses/used/directory.index/directory.update) now return `{"error":"Internal server error"}`; exception details are logged server-side with full trace.
**Verify:**
- New unit tests `testIndexDoesNotReflectArbitraryOriginWhenAllowlistConfigured` (PublicationsController + DirectoryController + CatalogiController) assert a malicious `Origin: https://evil.attacker.test` becomes `Access-Control-Allow-Origin: https://trusted.example` (the allowlist entry, never the caller).
- New unit tests `testShowReturns500WithoutLeakingExceptionMessage` and `testIndexReturns500WithoutLeakingExceptionMessage` assert that secret strings (`PDOException`, `/var/www`, internal hostnames) are absent from the response body.
- Live smoke: with `cors_allowed_origins=https://trusted.example` configured, `Origin: https://evil.attacker.test` was met with `Access-Control-Allow-Origin: https://trusted.example`. With the config key absent, the response was `Access-Control-Allow-Origin: *` regardless of the caller's `Origin`.

### #736 (LOW) — `is_array` guard before `jsonSerialize()`
**Fix:** `PublicationService::filterUnwantedProperties` and `CatalogiService::index()` now accept the array shapes that OR's SOLR backend returns from `searchObjectsPaginated`, mirroring the dual-shape handling already present in `CatalogiController/PublicationsController::index`.
**Verify:**
- New unit test `PublicationServiceTest::testFilterUnwantedPropertiesAcceptsArrayShape` passes a plain assoc array (no `jsonSerialize`) and asserts properties are stripped correctly.
- New unit test `CatalogiServiceTest::testIndexAcceptsArrayShapedResultsFromSolrBackend` returns a SOLR-shape `results` list from `searchObjectsPaginated` and asserts `@self.owner`/`@self.schemaVersion` are stripped while `@self.register` survives.
- Live smoke: SOLR not configured in this env, so runtime smoke is inconclusive on the actual SOLR path; the SOLR shape is exercised purely via unit tests.

## Tests
- 256 tests pass (up from 230, after fixing the pre-existing `DirectoryControllerTest::setUp()` 4-arg constructor bug + adding 13 new tests across six files).
- `php -l` clean on every edited file.
- `phpcs --standard=phpcs.xml` zero errors on all six lib/ files (pre-existing class-level `@spec` warnings remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)