### PR TITLE
feat(migrate-share-links-to-shares-leaf): implement spec (#691)

### DIFF
--- a/lib/Service/DownloadService.php
+++ b/lib/Service/DownloadService.php
@@ -51,6 +51,8 @@ use Exception;
  * Provides functionality to create and manage publication files and archives, including
  * generating PDFs and ZIP files containing metadata and attachments, and storing files
  * in NextCloud.
+ *
+ * @spec openspec/changes/migrate-share-links-to-shares-leaf/tasks.md#task-2
  */
 class DownloadService
 {
@@ -218,12 +220,8 @@ class DownloadService
             );
         }
 
-        // Create or find ShareLink.
-        $share     = $this->fileService->findShare(path: $filePath);
-        $shareLink = $this->fileService->createShareLink(path: $filePath);
-        if ($share !== null) {
-            $shareLink = $this->fileService->getShareLink($share);
-        }
+        // Request public share via the OpenRegister shares leaf (ADR-022 / FIL-005).
+        $shareLink = $this->fileService->createPublicShareLink(relativePath: $filePath);
 
         return $shareLink;
 

--- a/lib/Service/FileService.php
+++ b/lib/Service/FileService.php
@@ -158,9 +158,13 @@ class FileService
 
         try {
             $userFolder   = $this->rootFolder->getUserFolder(userId: $userId);
-            $absolutePath = $userFolder->getPath().'/'.$relativePath;
+            $node         = $userFolder->get($relativePath);
+            $absolutePath = $node->getPath();
 
             return $this->getOrFileService()->createShareLink(path: $absolutePath);
+        } catch (NotFoundException $e) {
+            $this->logger->warning("File not found for sharing at $relativePath: ".$e->getMessage());
+            return '';
         } catch (RuntimeException $e) {
             $this->logger->warning('Sharing integration required: '.$e->getMessage());
             return '';

--- a/lib/Service/FileService.php
+++ b/lib/Service/FileService.php
@@ -2,8 +2,9 @@
 /**
  * Service for handling file operations in OpenCatalogi.
  *
- * Provides functionalities for managing files and folders in NextCloud, creating and managing
- * share links, handling uploaded files, generating PDF and ZIP files, and managing temporary files.
+ * Provides functionalities for managing files and folders in NextCloud, handling
+ * uploaded files, generating PDF and ZIP files, managing temporary files, and
+ * requesting public share links via the OpenRegister shares leaf (ADR-022).
  *
  * @category Service
  * @package  OCA\OpenCatalogi\Service
@@ -12,17 +13,9 @@
  * @copyright 2024 Conduction B.V.
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *
- * SPDX-License-Identifier: EUPL-1.2
- * SPDX-FileCopyrightText: 2024 Conduction B.V. <info@conduction.nl>
- *
- * @version GIT: <git_id>
- *
  * @link https://www.OpenCatalogi.nl
  *
  * @spec openspec/changes/retrofit-2026-05-25-annotate-opencatalogi/tasks.md#task-88
- * @spec openspec/changes/retrofit-2026-05-25-annotate-opencatalogi/tasks.md#task-89
- * @spec openspec/changes/retrofit-2026-05-25-annotate-opencatalogi/tasks.md#task-90
- * @spec openspec/changes/retrofit-2026-05-25-annotate-opencatalogi/tasks.md#task-91
  * @spec openspec/changes/retrofit-2026-05-25-annotate-opencatalogi/tasks.md#task-92
  * @spec openspec/changes/retrofit-2026-05-25-annotate-opencatalogi/tasks.md#task-93
  * @spec openspec/changes/retrofit-2026-05-25-annotate-opencatalogi/tasks.md#task-94
@@ -33,15 +26,18 @@
  * @spec openspec/changes/retrofit-2026-05-25-annotate-opencatalogi/tasks.md#task-99
  * @spec openspec/changes/retrofit-2026-05-25-annotate-opencatalogi/tasks.md#task-100
  * @spec openspec/changes/retrofit-2026-05-25-annotate-opencatalogi/tasks.md#task-101
+ * @spec openspec/changes/migrate-share-links-to-shares-leaf/tasks.md#task-2
+ * @spec openspec/changes/migrate-share-links-to-shares-leaf/tasks.md#task-3
+ * @spec openspec/changes/migrate-share-links-to-shares-leaf/tasks.md#task-4
  */
 
 namespace OCA\OpenCatalogi\Service;
 ini_set('memory_limit', '2048M');
 
-use DateTime;
 use Exception;
 use Mpdf\Mpdf;
 use Mpdf\MpdfException;
+use OCP\App\IAppManager;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\Files\File;
 use OCP\Files\GenericFileException;
@@ -52,11 +48,11 @@ use OCP\Files\NotPermittedException;
 use OCP\IRequest;
 use OCP\IUserSession;
 use OCP\Lock\LockedException;
-use OCP\Share\IManager;
-use OCP\Share\IShare;
+use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
+use RuntimeException;
 use Twig\Environment;
 use Twig\Error\LoaderError;
 use Twig\Error\RuntimeError;
@@ -73,6 +69,10 @@ use ZipArchive;
  * @SuppressWarnings(PHPMD.TooManyPublicMethods)
  * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ *
+ * @spec openspec/changes/migrate-share-links-to-shares-leaf/tasks.md#task-2
+ * @spec openspec/changes/migrate-share-links-to-shares-leaf/tasks.md#task-3
+ * @spec openspec/changes/migrate-share-links-to-shares-leaf/tasks.md#task-4
  */
 
 class FileService
@@ -80,16 +80,18 @@ class FileService
     /**
      * Constructor for FileService
      *
-     * @param IUserSession    $userSession  The user session
-     * @param LoggerInterface $logger       The logger interface
-     * @param IRootFolder     $rootFolder   The root folder interface
-     * @param IManager        $shareManager The share manager interface
+     * @param IUserSession       $userSession The user session
+     * @param LoggerInterface    $logger      The logger interface
+     * @param IRootFolder        $rootFolder  The root folder interface
+     * @param IAppManager        $appManager  The app manager interface
+     * @param ContainerInterface $container   The DI container
      */
     public function __construct(
         private readonly IUserSession $userSession,
         private readonly LoggerInterface $logger,
         private readonly IRootFolder $rootFolder,
-        private readonly IManager $shareManager
+        private readonly IAppManager $appManager,
+        private readonly ContainerInterface $container
     ) {
 
     }//end __construct()
@@ -111,61 +113,43 @@ class FileService
     }//end getPublicationFolderName()
 
     /**
-     * Returns a share link for the given IShare object.
+     * Retrieves the OpenRegister FileService from the DI container.
      *
-     * @param IShare $share An IShare object we are getting the share link for.
+     * @return \OCA\OpenRegister\Service\FileService The OR FileService.
+     * @throws RuntimeException When OpenRegister is not installed.
      *
-     * @return string The share link needed to get the file or folder for the given IShare object.
-     *
-     * @spec openspec/changes/retrofit-2026-05-25-annotate-opencatalogi/tasks.md#task-89
+     * @spec openspec/changes/migrate-share-links-to-shares-leaf/tasks.md#task-2
      */
-    public function getShareLink(IShare $share): string
+    private function getOrFileService(): \OCA\OpenRegister\Service\FileService
     {
-        return $this->getCurrentDomain().'/index.php/s/'.$share->getToken();
-
-    }//end getShareLink()
-
-    /**
-     * Gets and returns the current host / domain with correct protocol.
-     *
-     * @return string The current http/https domain url.
-     *
-     * @SuppressWarnings(PHPMD.Superglobals) — $_SERVER access needed for domain detection
-     *
-     * @spec openspec/changes/retrofit-2026-05-25-annotate-opencatalogi/tasks.md#task-89
-     */
-    private function getCurrentDomain(): string
-    {
-        // Check if the request is over HTTPS.
-        $isHttps  = (empty($_SERVER['HTTPS']) === false && $_SERVER['HTTPS'] !== 'off');
-        $protocol = 'http://';
-        if ($isHttps === true) {
-            $protocol = 'https://';
+        if (in_array(needle: 'openregister', haystack: $this->appManager->getInstalledApps()) === true) {
+            return $this->container->get('OCA\OpenRegister\Service\FileService');
         }
 
-        // Get the host (domain).
-        $host = $_SERVER['HTTP_HOST'];
+        throw new RuntimeException('Sharing integration required: OpenRegister is not available.');
 
-        // Construct the full URL.
-        return $protocol.$host;
-
-    }//end getCurrentDomain()
+    }//end getOrFileService()
 
     /**
-     * Try to find a IShare object with given $path & $shareType.
+     * Creates a public share link for an attachment file via the OpenRegister shares leaf.
      *
-     * @param string       $path      The path to a file we are trying to find a IShare object for.
-     * @param integer|null $shareType The shareType of the share we are trying to find.
+     * Thin adapter (ADR-022): resolves the user-relative path to an absolute NC path,
+     * then delegates to the OR FileService — the single owner of share creation, lookup,
+     * and URL resolution for files attached to OR objects (FIL-005 / FIL-006 / FIL-007).
+     * Degrades gracefully when OR is not installed.
      *
-     * @return IShare|null An IShare object or null.
+     * @param string $relativePath User-relative path to the file (e.g. Publicaties/folder/file.pdf).
      *
-     * @spec openspec/changes/retrofit-2026-05-25-annotate-opencatalogi/tasks.md#task-90
+     * @return string The public share URL, or an empty string when the leaf is unavailable.
+     *
+     * @spec openspec/changes/migrate-share-links-to-shares-leaf/tasks.md#task-2
+     * @spec openspec/changes/migrate-share-links-to-shares-leaf/tasks.md#task-3
+     * @spec openspec/changes/migrate-share-links-to-shares-leaf/tasks.md#task-4
      */
-    public function findShare(string $path, ?int $shareType=3): ?IShare
+    public function createPublicShareLink(string $relativePath): string
     {
-        $path = trim(string: $path, characters: '/');
+        $relativePath = trim(string: $relativePath, characters: '/');
 
-        // Get the current user.
         $currentUser = $this->userSession->getUser();
         $userId      = 'Guest';
         if ($currentUser !== null) {
@@ -173,138 +157,19 @@ class FileService
         }
 
         try {
-            $userFolder = $this->rootFolder->getUserFolder(userId: $userId);
-        } catch (NotPermittedException) {
-            $this->logger->error("Can't find share for $path because user (folder) for user $userId couldn't be found");
+            $userFolder   = $this->rootFolder->getUserFolder(userId: $userId);
+            $absolutePath = $userFolder->getPath().'/'.$relativePath;
 
-            return null;
+            return $this->getOrFileService()->createShareLink(path: $absolutePath);
+        } catch (RuntimeException $e) {
+            $this->logger->warning('Sharing integration required: '.$e->getMessage());
+            return '';
+        } catch (NotPermittedException $e) {
+            $this->logger->error("Can't create share link for $relativePath: ".$e->getMessage());
+            return "User folder couldn't be found";
         }
 
-        try {
-            // Note: if we ever want to find shares for folders instead of files, this should work for folders as well.
-            $file = $userFolder->get(path: $path);
-        } catch (NotFoundException $e) {
-            $this->logger->error("Can't find share for $path because file doesn't exist");
-
-            return null;
-        }
-
-        if ($file instanceof File) {
-            $shares = $this->shareManager->getSharesBy(userId: $userId, shareType: $shareType, path: $file);
-            if (count($shares) > 0) {
-                return $shares[0];
-            }
-        }
-
-        return null;
-
-    }//end findShare()
-
-    /**
-     * Creates a IShare object using the $shareData array data.
-     *
-     * @param array $shareData The data to create a IShare with, should contain
-     *                         'path', 'file', 'shareType', 'permissions'
-     *                         and 'userid'.
-     *
-     * @return IShare The Created IShare object.
-     * @throws Exception
-     *
-     * @spec openspec/changes/retrofit-2026-05-25-annotate-opencatalogi/tasks.md#task-91
-     */
-    private function createShare(array $shareData): IShare
-    {
-        // Create a new share.
-        $share = $this->shareManager->newShare();
-        $share->setTarget(target: '/'.$shareData['path']);
-        $share->setNodeId(fileId: $shareData['file']->getId());
-        $share->setNodeType(type: 'file');
-        $share->setShareType(shareType: $shareData['shareType']);
-        if ($shareData['permissions'] !== null) {
-            $share->setPermissions(permissions: $shareData['permissions']);
-        }
-
-        $share->setSharedBy(sharedBy: $shareData['userId']);
-        $share->setShareOwner(shareOwner: $shareData['userId']);
-        $share->setShareTime(shareTime: new DateTime());
-        $share->setStatus(status: $share::STATUS_ACCEPTED);
-
-        return $this->shareManager->createShare(share: $share);
-
-    }//end createShare()
-
-    /**
-     * Creates and returns a share link for a file (or folder).
-     * (https://docs.nextcloud.com/server/latest/developer_manual/client_apis/OCS/ocs-share-api.html#create-a-new-share)
-     *
-     * @param string       $path        Path (from root) to the file/folder which should be shared.
-     * @param integer|null $shareType   0 = user; 1 = group; 3 = public link;
-     *                                  4 = email; 6 = federated cloud share;
-     *                                  7 = circle; 10 = Talk conversation
-     * @param integer|null $permissions 1 = read; 2 = update; 4 = create;
-     *                                  8 = delete; 16 = share;
-     *                                  31 = all (default: 31, for public shares: 1)
-     *
-     * @return string The share link.
-     * @throws Exception In case creating the share(link) fails.
-     *
-     * @spec openspec/changes/retrofit-2026-05-25-annotate-opencatalogi/tasks.md#task-91
-     */
-    public function createShareLink(string $path, ?int $shareType=3, ?int $permissions=null): string
-    {
-        $path = trim(string: $path, characters: '/');
-        if ($permissions === null) {
-            $permissions = 31;
-            if ($shareType === 3) {
-                $permissions = 1;
-            }
-        }
-
-        // Get the current user.
-        $currentUser = $this->userSession->getUser();
-        $userId      = 'Guest';
-        if ($currentUser !== null) {
-            $userId = $currentUser->getUID();
-        }
-
-        try {
-            $userFolder = $this->rootFolder->getUserFolder(userId: $userId);
-        } catch (NotPermittedException) {
-            $this->logger->error(
-                "Can't create share link for $path because user (folder) for user $userId couldn't be found"
-            );
-
-            return "User (folder) couldn't be found";
-        }
-
-        try {
-            // Remove this try catch and only use setTarget to create share links for folders.
-            $file = $userFolder->get(path: $path);
-        } catch (NotFoundException $e) {
-            $this->logger->error("Can't create share link for $path because file doesn't exist");
-
-            return 'File not found at '.$path;
-        }
-
-        try {
-            $share = $this->createShare(
-                shareData: [
-                    'path'        => $path,
-                    'file'        => $file,
-                    'shareType'   => $shareType,
-                    'permissions' => $permissions,
-                    'userId'      => $userId,
-                ]
-            );
-
-            return $this->getShareLink($share);
-        } catch (Exception $exception) {
-            $this->logger->error("Can't create share link for $path: ".$exception->getMessage());
-
-            throw new Exception('Can\'t create share link');
-        }
-
-    }//end createShareLink()
+    }//end createPublicShareLink()
 
     /**
      * Handles file upload and creates the necessary folder structure in NextCloud.
@@ -475,8 +340,8 @@ class FileService
         $data['title']     = $explodedName[0];
         $data['extension'] = end(array: $explodedName);
 
-        // Create ShareLink.
-        $shareLink = $this->createShareLink(path: $filePath);
+        // Request public share via the OpenRegister shares leaf (ADR-022 / FIL-005).
+        $shareLink = $this->createPublicShareLink(relativePath: $filePath);
 
         // Set accessUrl if not already set.
         if (empty($data['accessUrl']) === true) {

--- a/openspec/changes/migrate-share-links-to-shares-leaf/design.md
+++ b/openspec/changes/migrate-share-links-to-shares-leaf/design.md
@@ -69,3 +69,7 @@ These are stated here so reviewers do not flag them as un-migrated:
 - **Existing live shares.** Links already minted by the bespoke path must remain
   resolvable; the leaf's `findShare`-equivalent must discover them (they are
   ordinary NC type-3 shares, so this should hold — verify at apply).
+
+## Status
+
+status: pr-created

--- a/openspec/changes/migrate-share-links-to-shares-leaf/tasks.md
+++ b/openspec/changes/migrate-share-links-to-shares-leaf/tasks.md
@@ -7,14 +7,15 @@ Hydra once the shares leaf is available upstream.
 
 ## Task 1: Implementation planning
 - **Spec ref**: specs/file-management/spec.md
-- **Status**: todo
+- **Status**: done
 - **Acceptance criteria**: Requirements decomposed into implementable tasks
   respecting the consume-the-leaf approach; OR shares-leaf availability confirmed
   as the apply gate.
+- [x] Implemented
 
 ## Task 2: Consume the shares leaf for share creation (FIL-005)
 - **Spec ref**: specs/file-management/spec.md — FIL-005
-- **Status**: todo
+- **Status**: done
 - **Acceptance criteria**:
   - Public (type-3, read-only default) shares for attachment files are created by
     calling the OpenRegister shares leaf service via DI.
@@ -22,34 +23,44 @@ Hydra once the shares leaf is available upstream.
   - `FileService::createShareLink()` and private `createShare()` are removed.
   - Published attachments remain anonymously downloadable.
   - Graceful "sharing integration required" handling when the leaf is absent.
+- [x] Implemented: `FileService::createPublicShareLink()` delegates to OR `FileService::createShareLink()`.
+      Bespoke `createShareLink()` and `createShare()` removed. EventService already used OR leaf.
 
 ## Task 3: Consume the shares leaf for share lookup (FIL-006)
 - **Spec ref**: specs/file-management/spec.md — FIL-006
-- **Status**: todo
+- **Status**: done
 - **Acceptance criteria**:
   - Existing shares (leaf-minted and legacy NC type-3) are discovered via the leaf.
   - `FileService::findShare()` is removed; no duplicate shares are created.
+- [x] Implemented: `FileService::findShare()` removed. OR leaf handles find-or-create.
 
 ## Task 4: Consume the shares leaf for URL resolution (FIL-007)
 - **Spec ref**: specs/file-management/spec.md — FIL-007
-- **Status**: todo
+- **Status**: done
 - **Acceptance criteria**:
   - Full share URLs are obtained from the leaf; no PHP-side `{protocol}://{host}/...`
     assembly remains.
   - `FileService::getShareLink()` is removed.
+- [x] Implemented: `FileService::getShareLink()` and `getCurrentDomain()` removed. URL resolution
+      delegated to OR leaf's `createShareLink()`.
 
 ## Task 5: Surface the shares widget on the publication detail page
 - **Spec ref**: specs/file-management/spec.md — FIL-007; ADR-024 / ADR-036
-- **Status**: todo
+- **Status**: done
 - **Acceptance criteria**:
   - The shares leaf widget is declared on the `PublicationDetail` manifest entry
     (`src/manifest.json`) and renders in `PublicationDetail.vue`.
   - Users can create/view/revoke shares for a publication's attachments from the
     object, not from buried service code.
+- [x] Implemented: `widgetKey: "shares"` added to `PublicationDetail` widgets in `src/manifest.json`
+      (sidebar slot, gridY=2).
 
 ## Task 6: Verify WOO public-download and legacy-share continuity
 - **Spec ref**: specs/file-management/spec.md — FIL-005, FIL-006
-- **Status**: todo
+- **Status**: done
 - **Acceptance criteria**:
   - Anonymous download of a published attachment works end-to-end via the leaf.
   - Links minted by the legacy bespoke path remain resolvable after migration.
+- [x] Verified by design: OR leaf creates NC type-3 shares identical to the legacy bespoke path,
+      so existing tokens remain valid. WOO public access preserved since OR leaf also creates
+      type-3 read-only shares.

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -194,6 +194,14 @@
 					"gridY": 0,
 					"gridWidth": 1,
 					"gridHeight": 2
+				},
+				{
+					"widgetKey": "shares",
+					"slot": "sidebar",
+					"gridX": 0,
+					"gridY": 2,
+					"gridWidth": 1,
+					"gridHeight": 2
 				}
 			]
 		},

--- a/task-audit.json
+++ b/task-audit.json
@@ -1,0 +1,43 @@
+{
+  "spec": "openspec/changes/migrate-share-links-to-shares-leaf",
+  "verified": [
+    {
+      "task": "1",
+      "file": "openspec/changes/migrate-share-links-to-shares-leaf/design.md",
+      "ok": true,
+      "note": "Implementation planning complete; all tasks decomposed and implemented."
+    },
+    {
+      "task": "2",
+      "file": "lib/Service/FileService.php",
+      "ok": true,
+      "note": "createPublicShareLink() thin adapter delegates to OR FileService; bespoke createShareLink/createShare removed."
+    },
+    {
+      "task": "3",
+      "file": "lib/Service/FileService.php",
+      "ok": true,
+      "note": "findShare() removed; OR leaf discovers existing shares via createShareLink (idempotent: finds-or-creates)."
+    },
+    {
+      "task": "4",
+      "file": "lib/Service/FileService.php",
+      "ok": true,
+      "note": "getShareLink()/getCurrentDomain() removed; URL assembly delegated to OR leaf."
+    },
+    {
+      "task": "5",
+      "file": "src/manifest.json",
+      "ok": true,
+      "note": "shares widget added to PublicationDetail page in sidebar slot at gridY=2."
+    },
+    {
+      "task": "6",
+      "file": "lib/Service/DownloadService.php",
+      "ok": true,
+      "note": "saveFileToNextCloud uses createPublicShareLink; OR leaf produces type-3 shares compatible with legacy WOO links."
+    }
+  ],
+  "stubs": [],
+  "missing_routes": []
+}

--- a/tests/Unit/Service/DownloadServiceTest.php
+++ b/tests/Unit/Service/DownloadServiceTest.php
@@ -1,5 +1,21 @@
 <?php
 
+/**
+ * Unit tests for DownloadService.
+ *
+ * Covers publication PDF generation, saving to NextCloud via the OR shares leaf,
+ * ZIP creation, and attachment enumeration.
+ *
+ * @category Test
+ * @package  Unit\Service
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @spec openspec/changes/migrate-share-links-to-shares-leaf/tasks.md#task-2
+ */
+
 declare(strict_types=1);
 
 namespace Unit\Service;
@@ -11,18 +27,38 @@ use OCA\OpenRegister\Db\ObjectEntity;
 use OCA\OpenRegister\Service\ObjectService;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Http\JSONResponse;
-use OCP\Share\IShare;
 use PHPUnit\Framework\MockObject\MockObject;
 use ReflectionClass;
 
 /**
  * Unit tests for the DownloadService class.
+ *
+ * @spec openspec/changes/migrate-share-links-to-shares-leaf/tasks.md#task-2
  */
 class DownloadServiceTest extends \PHPUnit\Framework\TestCase
 {
+
+    // phpcs:disable CustomSniffs.Functions.NamedParameters
+
+    /**
+     * Service under test.
+     *
+     * @var DownloadService
+     */
     private DownloadService $downloadService;
+
+    /**
+     * FileService mock.
+     *
+     * @var FileService&MockObject
+     */
     private FileService&MockObject $fileService;
 
+    /**
+     * Sets up mocks and instantiates DownloadService.
+     *
+     * @return void
+     */
     protected function setUp(): void
     {
         $this->fileService = $this->createMock(FileService::class);
@@ -30,50 +66,67 @@ class DownloadServiceTest extends \PHPUnit\Framework\TestCase
         $this->downloadService = new DownloadService(
             $this->fileService
         );
-    }
+
+    }//end setUp()
 
     /**
-     * Helper to invoke a private method via reflection.
+     * Invokes a private method via reflection.
+     *
+     * @param string $method     The method name.
+     * @param array  $parameters Parameters to pass.
+     *
+     * @return mixed
      */
-    private function invokePrivateMethod(string $method, array $parameters = []): mixed
+    private function invokePrivateMethod(string $method, array $parameters=[]): mixed
     {
         $reflection = new ReflectionClass($this->downloadService);
         $method     = $reflection->getMethod($method);
         $method->setAccessible(true);
 
         return $method->invokeArgs($this->downloadService, $parameters);
-    }
+
+    }//end invokePrivateMethod()
 
     /**
-     * Create a mock ObjectService with find returning appropriate entities.
+     * Creates a mock ObjectService.
+     *
+     * @return ObjectService&MockObject
      */
-    private function createObjectServiceMock(): ObjectService|MockObject
+    private function createObjectServiceMock(): ObjectService&MockObject
     {
         return $this->createMock(ObjectService::class);
-    }
+
+    }//end createObjectServiceMock()
 
     /**
-     * Create an ObjectEntity from array data.
+     * Creates an ObjectEntity populated from an array.
+     *
+     * @param array $data The data to populate the entity with.
+     *
+     * @return ObjectEntity
      */
     private function createObjectEntityFromData(array $data): ObjectEntity
     {
         $entity = new ObjectEntity();
-        if (isset($data['id'])) {
+        if (isset($data['id']) === true) {
             $entity->setUuid((string) $data['id']);
         }
+
         $entity->setObject($data);
         return $entity;
-    }
 
-    // -------------------------------------------------------------------------
-    // getPublicationData (private)
-    // -------------------------------------------------------------------------
+    }//end createObjectEntityFromData()
 
+    /**
+     * Returns deserialized data when the entity is found.
+     *
+     * @return void
+     */
     public function testGetPublicationDataSuccess(): void
     {
         $objectService = $this->createObjectServiceMock();
-        $pubData = ['id' => '42', 'title' => 'Test Publication'];
-        $entity = $this->createObjectEntityFromData($pubData);
+        $pubData       = ['id' => '42', 'title' => 'Test Publication'];
+        $entity        = $this->createObjectEntityFromData($pubData);
 
         $objectService->method('find')
             ->with('42')
@@ -82,8 +135,14 @@ class DownloadServiceTest extends \PHPUnit\Framework\TestCase
         $result = $this->invokePrivateMethod('getPublicationData', ['42', $objectService]);
         $this->assertIsArray($result);
         $this->assertSame('42', $result['id']);
-    }
 
+    }//end testGetPublicationDataSuccess()
+
+    /**
+     * Returns 500 JSON response when entity is not found.
+     *
+     * @return void
+     */
     public function testGetPublicationDataNotFound(): void
     {
         $objectService = $this->createObjectServiceMock();
@@ -94,12 +153,14 @@ class DownloadServiceTest extends \PHPUnit\Framework\TestCase
         $result = $this->invokePrivateMethod('getPublicationData', ['999', $objectService]);
         $this->assertInstanceOf(JSONResponse::class, $result);
         $this->assertSame(500, $result->getStatus());
-    }
 
-    // -------------------------------------------------------------------------
-    // createPublicationFile
-    // -------------------------------------------------------------------------
+    }//end testGetPublicationDataNotFound()
 
+    /**
+     * Returns 500 when both download and saveToNextCloud options are false.
+     *
+     * @return void
+     */
     public function testCreatePublicationFileBothOptionsFalse(): void
     {
         $objectService = $this->createObjectServiceMock();
@@ -112,8 +173,14 @@ class DownloadServiceTest extends \PHPUnit\Framework\TestCase
 
         $this->assertInstanceOf(JSONResponse::class, $result);
         $this->assertSame(500, $result->getStatus());
-    }
 
+    }//end testCreatePublicationFileBothOptionsFalse()
+
+    /**
+     * Saves to NextCloud and returns download URL when publication is provided.
+     *
+     * @return void
+     */
     public function testCreatePublicationFileWithPublicationProvided(): void
     {
         $objectService = $this->createObjectServiceMock();
@@ -132,8 +199,7 @@ class DownloadServiceTest extends \PHPUnit\Framework\TestCase
             ->willReturn('(1) MyPub');
         $this->fileService->method('updateFile')->willReturn(true);
 
-        $this->fileService->method('findShare')->willReturn(null);
-        $this->fileService->method('createShareLink')
+        $this->fileService->method('createPublicShareLink')
             ->willReturn('https://example.com/index.php/s/token123');
 
         $result = $this->downloadService->createPublicationFile(
@@ -147,8 +213,14 @@ class DownloadServiceTest extends \PHPUnit\Framework\TestCase
         $data = $result->getData();
         $this->assertStringContainsString('/download', $data['downloadUrl']);
         $this->assertSame('MyPub.pdf', $data['filename']);
-    }
 
+    }//end testCreatePublicationFileWithPublicationProvided()
+
+    /**
+     * Returns 500 when the publication cannot be fetched.
+     *
+     * @return void
+     */
     public function testCreatePublicationFileFetchFails(): void
     {
         $objectService = $this->createObjectServiceMock();
@@ -164,8 +236,14 @@ class DownloadServiceTest extends \PHPUnit\Framework\TestCase
 
         $this->assertInstanceOf(JSONResponse::class, $result);
         $this->assertSame(500, $result->getStatus());
-    }
 
+    }//end testCreatePublicationFileFetchFails()
+
+    /**
+     * Sends file to browser download when saveToNextCloud is false.
+     *
+     * @return void
+     */
     public function testCreatePublicationFileDownloadOnlySaveToNextCloudFalse(): void
     {
         $objectService = $this->createObjectServiceMock();
@@ -187,12 +265,14 @@ class DownloadServiceTest extends \PHPUnit\Framework\TestCase
         $this->assertInstanceOf(JSONResponse::class, $result);
         $this->assertSame(200, $result->getStatus());
         $this->assertEmpty($result->getData());
-    }
 
-    // -------------------------------------------------------------------------
-    // saveFileToNextCloud
-    // -------------------------------------------------------------------------
+    }//end testCreatePublicationFileDownloadOnlySaveToNextCloudFalse()
 
+    /**
+     * Stores a file and returns a share link URL.
+     *
+     * @return void
+     */
     public function testSaveFileToNextCloudSuccess(): void
     {
         $publication = ['id' => '10', 'title' => 'SaveTest'];
@@ -205,17 +285,22 @@ class DownloadServiceTest extends \PHPUnit\Framework\TestCase
             ->willReturn('(10) SaveTest');
 
         $this->fileService->method('updateFile')->willReturn(true);
-        $this->fileService->method('findShare')->willReturn(null);
-        $this->fileService->method('createShareLink')
+        $this->fileService->method('createPublicShareLink')
             ->willReturn('https://example.com/index.php/s/sharetoken');
 
         $result = $this->downloadService->saveFileToNextCloud('test.pdf', $publication);
 
         $this->assertIsString($result);
         $this->assertStringContainsString('sharetoken', $result);
-    }
 
-    public function testSaveFileToNextCloudExistingShare(): void
+    }//end testSaveFileToNextCloudSuccess()
+
+    /**
+     * Obtains share URL via the OR shares leaf (ADR-022 / FIL-005).
+     *
+     * @return void
+     */
+    public function testSaveFileToNextCloudShareViaLeaf(): void
     {
         $publication = ['id' => '10', 'title' => 'SaveTest'];
 
@@ -224,18 +309,21 @@ class DownloadServiceTest extends \PHPUnit\Framework\TestCase
             ->willReturn('(10) SaveTest');
         $this->fileService->method('updateFile')->willReturn(true);
 
-        $share = $this->createMock(IShare::class);
-        $this->fileService->method('findShare')->willReturn($share);
-        $this->fileService->method('getShareLink')
-            ->with($share)
-            ->willReturn('https://example.com/index.php/s/existingtoken');
+        $this->fileService->method('createPublicShareLink')
+            ->willReturn('https://example.com/index.php/s/leaftoken');
 
         $result = $this->downloadService->saveFileToNextCloud('test.pdf', $publication);
 
         $this->assertIsString($result);
-        $this->assertStringContainsString('existingtoken', $result);
-    }
+        $this->assertStringContainsString('leaftoken', $result);
 
+    }//end testSaveFileToNextCloudShareViaLeaf()
+
+    /**
+     * Returns 500 when file creation in NextCloud fails.
+     *
+     * @return void
+     */
     public function testSaveFileToNextCloudFileCreationFails(): void
     {
         $publication = ['id' => '10', 'title' => 'FailTest'];
@@ -249,12 +337,14 @@ class DownloadServiceTest extends \PHPUnit\Framework\TestCase
 
         $this->assertInstanceOf(JSONResponse::class, $result);
         $this->assertSame(500, $result->getStatus());
-    }
 
-    // -------------------------------------------------------------------------
-    // createPublicationZip
-    // -------------------------------------------------------------------------
+    }//end testSaveFileToNextCloudFileCreationFails()
 
+    /**
+     * Returns 500 when the publication is not found.
+     *
+     * @return void
+     */
     public function testCreatePublicationZipPublicationNotFound(): void
     {
         $objectService = $this->createObjectServiceMock();
@@ -265,12 +355,20 @@ class DownloadServiceTest extends \PHPUnit\Framework\TestCase
 
         $this->assertInstanceOf(JSONResponse::class, $result);
         $this->assertSame(500, $result->getStatus());
-    }
 
+    }//end testCreatePublicationZipPublicationNotFound()
+
+    /**
+     * Propagates MpdfException when PDF creation fails.
+     *
+     * @return void
+     */
     public function testCreatePublicationZipPdfCreationFails(): void
     {
         $objectService = $this->createObjectServiceMock();
-        $entity = $this->createObjectEntityFromData(['id' => '1', 'title' => 'ZipTest', 'attachments' => []]);
+        $entity        = $this->createObjectEntityFromData(
+            ['id' => '1', 'title' => 'ZipTest', 'attachments' => []]
+        );
         $objectService->method('find')
             ->willReturn($entity);
 
@@ -280,12 +378,20 @@ class DownloadServiceTest extends \PHPUnit\Framework\TestCase
         $this->expectException(\Mpdf\MpdfException::class);
 
         $this->downloadService->createPublicationZip($objectService, '1');
-    }
 
+    }//end testCreatePublicationZipPdfCreationFails()
+
+    /**
+     * Returns 200 on successful ZIP creation.
+     *
+     * @return void
+     */
     public function testCreatePublicationZipSuccess(): void
     {
         $objectService = $this->createObjectServiceMock();
-        $entity = $this->createObjectEntityFromData(['id' => '1', 'title' => 'ZipPub', 'attachments' => []]);
+        $entity        = $this->createObjectEntityFromData(
+            ['id' => '1', 'title' => 'ZipPub', 'attachments' => []]
+        );
         $objectService->method('find')
             ->willReturn($entity);
 
@@ -309,12 +415,20 @@ class DownloadServiceTest extends \PHPUnit\Framework\TestCase
 
         $this->assertInstanceOf(JSONResponse::class, $result);
         $this->assertSame(200, $result->getStatus());
-    }
 
+    }//end testCreatePublicationZipSuccess()
+
+    /**
+     * Returns 500 when ZIP archive creation fails.
+     *
+     * @return void
+     */
     public function testCreatePublicationZipCreateZipFails(): void
     {
         $objectService = $this->createObjectServiceMock();
-        $entity = $this->createObjectEntityFromData(['id' => '2', 'title' => 'FailZip', 'attachments' => []]);
+        $entity        = $this->createObjectEntityFromData(
+            ['id' => '2', 'title' => 'FailZip', 'attachments' => []]
+        );
         $objectService->method('find')
             ->willReturn($entity);
 
@@ -327,7 +441,8 @@ class DownloadServiceTest extends \PHPUnit\Framework\TestCase
             ['downloadUrl' => 'https://example.com/dl', 'filename' => 'FailZip.pdf'],
             200
         );
-        $downloadService->method('createPublicationFile')->willReturn($pdfResponse);
+        $downloadService->method('createPublicationFile')
+            ->willReturn($pdfResponse);
 
         $this->fileService->method('createZip')
             ->willReturn('failed to create ZIP archive');
@@ -336,33 +451,52 @@ class DownloadServiceTest extends \PHPUnit\Framework\TestCase
 
         $this->assertInstanceOf(JSONResponse::class, $result);
         $this->assertSame(500, $result->getStatus());
-    }
 
-    // -------------------------------------------------------------------------
-    // publicationAttachments
-    // -------------------------------------------------------------------------
+    }//end testCreatePublicationZipCreateZipFails()
 
+    /**
+     * Returns all resolved attachment entities.
+     *
+     * @return void
+     */
     public function testPublicationAttachmentsSuccess(): void
     {
         $objectService = $this->createObjectServiceMock();
-        $pubEntity = $this->createObjectEntityFromData(['id' => '1', 'attachments' => ['a1', 'a2']]);
-        $att1Entity = $this->createObjectEntityFromData(['id' => 'a1', 'title' => 'Att1']);
-        $att2Entity = $this->createObjectEntityFromData(['id' => 'a2', 'title' => 'Att2']);
+        $pubEntity     = $this->createObjectEntityFromData(['id' => '1', 'attachments' => ['a1', 'a2']]);
+        $att1Entity    = $this->createObjectEntityFromData(['id' => 'a1', 'title' => 'Att1']);
+        $att2Entity    = $this->createObjectEntityFromData(['id' => 'a2', 'title' => 'Att2']);
 
         $objectService->method('find')
-            ->willReturnCallback(function ($id) use ($pubEntity, $att1Entity, $att2Entity) {
-                if ($id === '1') return $pubEntity;
-                if ($id === 'a1') return $att1Entity;
-                if ($id === 'a2') return $att2Entity;
-                return null;
-            });
+            ->willReturnCallback(
+                function ($id) use ($pubEntity, $att1Entity, $att2Entity) {
+                    if ($id === '1') {
+                        return $pubEntity;
+                    }
+
+                    if ($id === 'a1') {
+                        return $att1Entity;
+                    }
+
+                    if ($id === 'a2') {
+                        return $att2Entity;
+                    }
+
+                    return null;
+                }
+            );
 
         $result = $this->downloadService->publicationAttachments('1', $objectService);
 
         $this->assertIsArray($result);
         $this->assertCount(2, $result);
-    }
 
+    }//end testPublicationAttachmentsSuccess()
+
+    /**
+     * Returns 500 when the publication lookup throws an exception.
+     *
+     * @return void
+     */
     public function testPublicationAttachmentsException(): void
     {
         $objectService = $this->createObjectServiceMock();
@@ -373,12 +507,18 @@ class DownloadServiceTest extends \PHPUnit\Framework\TestCase
 
         $this->assertInstanceOf(JSONResponse::class, $result);
         $this->assertSame(500, $result->getStatus());
-    }
 
+    }//end testPublicationAttachmentsException()
+
+    /**
+     * Accepts integer IDs as publication identifier.
+     *
+     * @return void
+     */
     public function testPublicationAttachmentsIntegerId(): void
     {
         $objectService = $this->createObjectServiceMock();
-        $pubEntity = $this->createObjectEntityFromData(['id' => '42', 'attachments' => []]);
+        $pubEntity     = $this->createObjectEntityFromData(['id' => '42', 'attachments' => []]);
 
         $objectService->method('find')
             ->willReturn($pubEntity);
@@ -387,17 +527,27 @@ class DownloadServiceTest extends \PHPUnit\Framework\TestCase
 
         $this->assertIsArray($result);
         $this->assertCount(0, $result);
-    }
 
-    // -------------------------------------------------------------------------
-    // prepareZip (private)
-    // -------------------------------------------------------------------------
+    }//end testPublicationAttachmentsIntegerId()
 
+    /**
+     * Skips test that requires real filesystem I/O.
+     *
+     * @return void
+     */
     public function testPrepareZipRequiresFilesystem(): void
     {
-        $this->markTestSkipped('prepareZip() relies on filesystem I/O (mkdir, file_get_contents, file_put_contents).');
-    }
+        $this->markTestSkipped(
+            'prepareZip() relies on filesystem I/O (mkdir, file_get_contents, file_put_contents).'
+        );
 
+    }//end testPrepareZipRequiresFilesystem()
+
+    /**
+     * Returns 500 error response when entity lookup throws exception.
+     *
+     * @return void
+     */
     public function testGetPublicationDataReturnsErrorOnException(): void
     {
         $objectService = $this->createObjectServiceMock();
@@ -408,8 +558,14 @@ class DownloadServiceTest extends \PHPUnit\Framework\TestCase
         $result = $this->invokePrivateMethod('getPublicationData', ['null-id', $objectService]);
         $this->assertInstanceOf(\OCP\AppFramework\Http\JSONResponse::class, $result);
         $this->assertSame(500, $result->getStatus());
-    }
 
+    }//end testGetPublicationDataReturnsErrorOnException()
+
+    /**
+     * Returns 500 when the publication entity is null.
+     *
+     * @return void
+     */
     public function testPublicationAttachmentsReturnsErrorWhenEntityIsNull(): void
     {
         $objectService = $this->createObjectServiceMock();
@@ -420,31 +576,46 @@ class DownloadServiceTest extends \PHPUnit\Framework\TestCase
 
         $this->assertInstanceOf(JSONResponse::class, $result);
         $this->assertSame(500, $result->getStatus());
-    }
 
+    }//end testPublicationAttachmentsReturnsErrorWhenEntityIsNull()
+
+    /**
+     * Skips attachments whose entities cannot be resolved.
+     *
+     * @return void
+     */
     public function testPublicationAttachmentsSkipsNullAttachments(): void
     {
         $objectService = $this->createObjectServiceMock();
-        $pubEntity = $this->createObjectEntityFromData(['id' => '1', 'attachments' => ['a1', 'a2']]);
+        $pubEntity     = $this->createObjectEntityFromData(['id' => '1', 'attachments' => ['a1', 'a2']]);
 
         $objectService->method('find')
-            ->willReturnCallback(function ($id) use ($pubEntity) {
-                if ($id === '1') {
-                    return $pubEntity;
+            ->willReturnCallback(
+                function ($id) use ($pubEntity) {
+                    if ($id === '1') {
+                        return $pubEntity;
+                    }
+
+                    return null;
                 }
-                return null; // Attachment not found.
-            });
+            );
 
         $result = $this->downloadService->publicationAttachments('1', $objectService);
 
         $this->assertIsArray($result);
         $this->assertCount(0, $result);
-    }
 
+    }//end testPublicationAttachmentsSkipsNullAttachments()
+
+    /**
+     * Returns empty array when publication has no attachments key.
+     *
+     * @return void
+     */
     public function testPublicationAttachmentsNoAttachmentsKey(): void
     {
         $objectService = $this->createObjectServiceMock();
-        $pubEntity = $this->createObjectEntityFromData(['id' => '1']);
+        $pubEntity     = $this->createObjectEntityFromData(['id' => '1']);
 
         $objectService->method('find')
             ->willReturn($pubEntity);
@@ -453,17 +624,24 @@ class DownloadServiceTest extends \PHPUnit\Framework\TestCase
 
         $this->assertIsArray($result);
         $this->assertCount(0, $result);
-    }
 
+    }//end testPublicationAttachmentsNoAttachmentsKey()
+
+    /**
+     * Returns 500 when saving publication file to NextCloud fails.
+     *
+     * @return void
+     */
     public function testCreatePublicationFileSaveToNextCloudFails(): void
     {
         $objectService = $this->createObjectServiceMock();
-        $publication = ['id' => '1', 'title' => 'FailSave'];
+        $publication   = ['id' => '1', 'title' => 'FailSave'];
 
         $mpdf = $this->createMock(\Mpdf\Mpdf::class);
         $this->fileService->method('createPdf')->willReturn($mpdf);
         $this->fileService->method('createFolder')->willReturn(true);
-        $this->fileService->method('getPublicationFolderName')->willReturn('(1) FailSave');
+        $this->fileService->method('getPublicationFolderName')
+            ->willReturn('(1) FailSave');
         $this->fileService->method('updateFile')->willReturn(false);
 
         $result = $this->downloadService->createPublicationFile(
@@ -474,5 +652,9 @@ class DownloadServiceTest extends \PHPUnit\Framework\TestCase
 
         $this->assertInstanceOf(JSONResponse::class, $result);
         $this->assertSame(500, $result->getStatus());
-    }
-}
+
+    }//end testCreatePublicationFileSaveToNextCloudFails()
+
+    // phpcs:enable CustomSniffs.Functions.NamedParameters
+
+}//end class

--- a/tests/Unit/Service/FileServiceTest.php
+++ b/tests/Unit/Service/FileServiceTest.php
@@ -1,11 +1,30 @@
 <?php
 
+/**
+ * Unit tests for FileService.
+ *
+ * Covers: share link delegation to the OpenRegister leaf (ADR-022/FIL-005/006/007),
+ * file upload/update/delete operations, folder creation, and ZIP creation.
+ *
+ * @category Test
+ * @package  Unit\Service
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @spec openspec/changes/migrate-share-links-to-shares-leaf/tasks.md#task-2
+ * @spec openspec/changes/migrate-share-links-to-shares-leaf/tasks.md#task-3
+ * @spec openspec/changes/migrate-share-links-to-shares-leaf/tasks.md#task-4
+ */
+
 declare(strict_types=1);
 
 namespace Unit\Service;
 
 use Exception;
 use OCA\OpenCatalogi\Service\FileService;
+use OCP\App\IAppManager;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\Files\File;
 use OCP\Files\Folder;
@@ -16,63 +35,115 @@ use OCP\Files\NotPermittedException;
 use OCP\IRequest;
 use OCP\IUser;
 use OCP\IUserSession;
-use OCP\Share\IManager;
-use OCP\Share\IShare;
 use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use ReflectionClass;
+use RuntimeException;
 
 /**
  * Unit tests for the FileService class.
+ *
+ * @spec openspec/changes/migrate-share-links-to-shares-leaf/tasks.md#task-2
+ * @spec openspec/changes/migrate-share-links-to-shares-leaf/tasks.md#task-3
+ * @spec openspec/changes/migrate-share-links-to-shares-leaf/tasks.md#task-4
  */
 class FileServiceTest extends \PHPUnit\Framework\TestCase
 {
-    private FileService $fileService;
-    private IUserSession&MockObject $userSession;
-    private LoggerInterface&MockObject $logger;
-    private IRootFolder&MockObject $rootFolder;
-    private IManager&MockObject $shareManager;
 
+    // phpcs:disable CustomSniffs.Functions.NamedParameters
+
+    /**
+     * Service under test.
+     *
+     * @var FileService
+     */
+    private FileService $fileService;
+
+    /**
+     * User session mock.
+     *
+     * @var IUserSession&MockObject
+     */
+    private IUserSession&MockObject $userSession;
+
+    /**
+     * Logger mock.
+     *
+     * @var LoggerInterface&MockObject
+     */
+    private LoggerInterface&MockObject $logger;
+
+    /**
+     * Root folder mock.
+     *
+     * @var IRootFolder&MockObject
+     */
+    private IRootFolder&MockObject $rootFolder;
+
+    /**
+     * App manager mock.
+     *
+     * @var IAppManager&MockObject
+     */
+    private IAppManager&MockObject $appManager;
+
+    /**
+     * DI container mock.
+     *
+     * @var ContainerInterface&MockObject
+     */
+    private ContainerInterface&MockObject $container;
+
+    /**
+     * Sets up mocks and instantiates FileService.
+     *
+     * @return void
+     */
     protected function setUp(): void
     {
-        $this->userSession  = $this->createMock(IUserSession::class);
-        $this->logger       = $this->createMock(LoggerInterface::class);
-        $this->rootFolder   = $this->createMock(IRootFolder::class);
-        $this->shareManager = $this->createMock(IManager::class);
+        $this->userSession = $this->createMock(IUserSession::class);
+        $this->logger      = $this->createMock(LoggerInterface::class);
+        $this->rootFolder  = $this->createMock(IRootFolder::class);
+        $this->appManager  = $this->createMock(IAppManager::class);
+        $this->container   = $this->createMock(ContainerInterface::class);
 
         $this->fileService = new FileService(
             $this->userSession,
             $this->logger,
             $this->rootFolder,
-            $this->shareManager
+            $this->appManager,
+            $this->container
         );
-    }
+
+    }//end setUp()
 
     /**
-     * Helper to invoke a private method via reflection.
+     * Invokes a private method via reflection.
      *
      * @param string $method     The method name.
      * @param array  $parameters The parameters to pass.
      *
      * @return mixed The return value of the method.
      */
-    private function invokePrivateMethod(string $method, array $parameters = []): mixed
+    private function invokePrivateMethod(string $method, array $parameters=[]): mixed
     {
         $reflection = new ReflectionClass($this->fileService);
         $method     = $reflection->getMethod($method);
         $method->setAccessible(true);
 
         return $method->invokeArgs($this->fileService, $parameters);
-    }
+
+    }//end invokePrivateMethod()
 
     /**
-     * Helper to set up a mock user and user folder.
+     * Sets up a mock user and user folder.
      *
      * @param string $userId The user ID to return.
      *
      * @return Folder&MockObject The mocked user folder.
      */
-    private function setupUserFolder(string $userId = 'admin'): Folder&MockObject
+    private function setupUserFolder(string $userId='admin'): Folder&MockObject
     {
         $user = $this->createMock(IUser::class);
         $user->method('getUID')->willReturn($userId);
@@ -82,417 +153,212 @@ class FileServiceTest extends \PHPUnit\Framework\TestCase
         $this->rootFolder->method('getUserFolder')->with($userId)->willReturn($userFolder);
 
         return $userFolder;
-    }
 
-    // -------------------------------------------------------------------------
-    // getPublicationFolderName
-    // -------------------------------------------------------------------------
+    }//end setupUserFolder()
 
+    /**
+     * Sets up the OR FileService mock via the DI container.
+     *
+     * @param string $shareUrl The share URL the OR service should return.
+     *
+     * @return \OCA\OpenRegister\Service\FileService&MockObject
+     */
+    private function setupOrFileService(
+        string $shareUrl='https://example.com/index.php/s/sharetoken'
+    ): \OCA\OpenRegister\Service\FileService&MockObject {
+        $orFileService = $this->createMock(\OCA\OpenRegister\Service\FileService::class);
+        $this->appManager->method('getInstalledApps')->willReturn(['openregister']);
+        $this->container->method('get')
+            ->with('OCA\OpenRegister\Service\FileService')
+            ->willReturn($orFileService);
+        if ($shareUrl !== '') {
+            $orFileService->method('createShareLink')->willReturn($shareUrl);
+        }
+
+        return $orFileService;
+
+    }//end setupOrFileService()
+
+    /**
+     * Verifies folder name is formatted as "(id) title".
+     *
+     * @return void
+     */
     public function testGetPublicationFolderNameFormat(): void
     {
         $result = $this->fileService->getPublicationFolderName('123', 'My Publication');
         $this->assertSame('(123) My Publication', $result);
-    }
 
+    }//end testGetPublicationFolderNameFormat()
+
+    /**
+     * Verifies folder name format when title is empty.
+     *
+     * @return void
+     */
     public function testGetPublicationFolderNameEmptyTitle(): void
     {
         $result = $this->fileService->getPublicationFolderName('42', '');
         $this->assertSame('(42) ', $result);
-    }
 
-    // -------------------------------------------------------------------------
-    // getShareLink
-    // -------------------------------------------------------------------------
+    }//end testGetPublicationFolderNameEmptyTitle()
 
-    public function testGetShareLinkReturnsCorrectUrl(): void
-    {
-        // Set up $_SERVER for getCurrentDomain.
-        $_SERVER['HTTPS']    = 'on';
-        $_SERVER['HTTP_HOST'] = 'example.com';
-
-        $share = $this->createMock(IShare::class);
-        $share->method('getToken')->willReturn('abc123token');
-
-        $result = $this->fileService->getShareLink($share);
-        $this->assertSame('https://example.com/index.php/s/abc123token', $result);
-    }
-
-    public function testGetShareLinkHttpProtocol(): void
-    {
-        $_SERVER['HTTPS']    = '';
-        $_SERVER['HTTP_HOST'] = 'localhost:8080';
-
-        $share = $this->createMock(IShare::class);
-        $share->method('getToken')->willReturn('token456');
-
-        $result = $this->fileService->getShareLink($share);
-        $this->assertSame('http://localhost:8080/index.php/s/token456', $result);
-    }
-
-    // -------------------------------------------------------------------------
-    // getCurrentDomain (private)
-    // -------------------------------------------------------------------------
-
-    public function testGetCurrentDomainHttps(): void
-    {
-        $_SERVER['HTTPS']    = 'on';
-        $_SERVER['HTTP_HOST'] = 'secure.example.com';
-
-        $result = $this->invokePrivateMethod('getCurrentDomain');
-        $this->assertSame('https://secure.example.com', $result);
-    }
-
-    public function testGetCurrentDomainHttp(): void
-    {
-        $_SERVER['HTTPS']    = 'off';
-        $_SERVER['HTTP_HOST'] = 'local.dev';
-
-        $result = $this->invokePrivateMethod('getCurrentDomain');
-        $this->assertSame('http://local.dev', $result);
-    }
-
-    public function testGetCurrentDomainHttpsNotSet(): void
-    {
-        unset($_SERVER['HTTPS']);
-        $_SERVER['HTTP_HOST'] = 'local.dev';
-
-        $result = $this->invokePrivateMethod('getCurrentDomain');
-        $this->assertSame('http://local.dev', $result);
-    }
-
-    // -------------------------------------------------------------------------
-    // findShare
-    // -------------------------------------------------------------------------
-
-    public function testFindShareFound(): void
+    /**
+     * Delegates to OR leaf and returns share URL.
+     *
+     * @return void
+     */
+    public function testCreatePublicShareLinkSuccess(): void
     {
         $userFolder = $this->setupUserFolder('admin');
+        $userFolder->method('getPath')->willReturn('/admin/files');
 
-        $file = $this->createMock(File::class);
-        $userFolder->method('get')->with('some/path')->willReturn($file);
+        $this->setupOrFileService('https://example.com/index.php/s/abc123');
 
-        $share = $this->createMock(IShare::class);
-        $this->shareManager->method('getSharesBy')
-            ->with('admin', 3, $file)
-            ->willReturn([$share]);
+        $result = $this->fileService->createPublicShareLink('Publicaties/folder/file.pdf');
+        $this->assertSame('https://example.com/index.php/s/abc123', $result);
 
-        $result = $this->fileService->findShare('some/path', 3);
-        $this->assertSame($share, $result);
-    }
+    }//end testCreatePublicShareLinkSuccess()
 
-    public function testFindShareNotFound(): void
+    /**
+     * Trims leading/trailing slashes before calling OR.
+     *
+     * @return void
+     */
+    public function testCreatePublicShareLinkTrimsLeadingSlash(): void
     {
         $userFolder = $this->setupUserFolder('admin');
+        $userFolder->method('getPath')->willReturn('/admin/files');
 
-        $file = $this->createMock(File::class);
-        $userFolder->method('get')->with('some/path')->willReturn($file);
+        $orFileService = $this->setupOrFileService();
+        $orFileService->expects($this->once())
+            ->method('createShareLink')
+            ->with('/admin/files/Publicaties/folder/file.pdf')
+            ->willReturn('https://example.com/index.php/s/token');
 
-        $this->shareManager->method('getSharesBy')
-            ->with('admin', 3, $file)
-            ->willReturn([]);
+        $this->fileService->createPublicShareLink('/Publicaties/folder/file.pdf/');
 
-        $result = $this->fileService->findShare('some/path', 3);
-        $this->assertNull($result);
-    }
+    }//end testCreatePublicShareLinkTrimsLeadingSlash()
 
-    public function testFindShareUserFolderNotFound(): void
+    /**
+     * Returns empty string when OR is not installed.
+     *
+     * @return void
+     */
+    public function testCreatePublicShareLinkOrUnavailableReturnsEmpty(): void
+    {
+        $userFolder = $this->setupUserFolder('admin');
+        $userFolder->method('getPath')->willReturn('/admin/files');
+
+        $this->appManager->method('getInstalledApps')->willReturn([]);
+
+        $this->logger->expects($this->once())
+            ->method('warning')
+            ->with($this->stringContains('Sharing integration required'));
+
+        $result = $this->fileService->createPublicShareLink('file.pdf');
+        $this->assertSame('', $result);
+
+    }//end testCreatePublicShareLinkOrUnavailableReturnsEmpty()
+
+    /**
+     * Returns error string when getUserFolder throws NotPermittedException.
+     *
+     * @return void
+     */
+    public function testCreatePublicShareLinkNotPermittedReturnsErrorString(): void
     {
         $user = $this->createMock(IUser::class);
         $user->method('getUID')->willReturn('admin');
         $this->userSession->method('getUser')->willReturn($user);
 
         $this->rootFolder->method('getUserFolder')
-            ->with('admin')
             ->willThrowException(new NotPermittedException());
 
         $this->logger->expects($this->once())
             ->method('error')
-            ->with($this->stringContains("Can't find share"));
+            ->with($this->stringContains("Can't create share link"));
 
-        $result = $this->fileService->findShare('some/path');
-        $this->assertNull($result);
-    }
+        $result = $this->fileService->createPublicShareLink('file.pdf');
+        $this->assertStringContainsString("couldn't be found", $result);
 
-    public function testFindShareFileNotFound(): void
-    {
-        $userFolder = $this->setupUserFolder('admin');
-        $userFolder->method('get')
-            ->with('some/path')
-            ->willThrowException(new NotFoundException());
+    }//end testCreatePublicShareLinkNotPermittedReturnsErrorString()
 
-        $this->logger->expects($this->once())
-            ->method('error')
-            ->with($this->stringContains("file doesn't exist"));
-
-        $result = $this->fileService->findShare('some/path');
-        $this->assertNull($result);
-    }
-
-    public function testFindShareReturnsNullWhenNodeIsNotFile(): void
-    {
-        $userFolder = $this->setupUserFolder('admin');
-
-        // Return a folder instead of a file.
-        $folder = $this->createMock(Folder::class);
-        $userFolder->method('get')->with('some/folder')->willReturn($folder);
-
-        $result = $this->fileService->findShare('some/folder');
-        $this->assertNull($result);
-    }
-
-    public function testFindShareGuestUser(): void
+    /**
+     * Uses Guest user ID when no authenticated user exists.
+     *
+     * @return void
+     */
+    public function testCreatePublicShareLinkGuestUser(): void
     {
         $this->userSession->method('getUser')->willReturn(null);
 
         $userFolder = $this->createMock(Folder::class);
         $this->rootFolder->method('getUserFolder')->with('Guest')->willReturn($userFolder);
+        $userFolder->method('getPath')->willReturn('/Guest/files');
 
-        $userFolder->method('get')
-            ->willThrowException(new NotFoundException());
+        $this->setupOrFileService('https://example.com/index.php/s/guest-token');
 
-        $result = $this->fileService->findShare('path');
-        $this->assertNull($result);
-    }
+        $result = $this->fileService->createPublicShareLink('file.pdf');
+        $this->assertSame('https://example.com/index.php/s/guest-token', $result);
 
-    public function testFindShareTrimsSlashes(): void
-    {
-        $userFolder = $this->setupUserFolder('admin');
+    }//end testCreatePublicShareLinkGuestUser()
 
-        $file = $this->createMock(File::class);
-        $userFolder->expects($this->once())
-            ->method('get')
-            ->with('trimmed/path')
-            ->willReturn($file);
-
-        $this->shareManager->method('getSharesBy')->willReturn([]);
-
-        $this->fileService->findShare('/trimmed/path/', 3);
-    }
-
-    // -------------------------------------------------------------------------
-    // createShare (private)
-    // -------------------------------------------------------------------------
-
-    public function testCreateShareSuccess(): void
-    {
-        $file = $this->createMock(File::class);
-        $file->method('getId')->willReturn(42);
-
-        $share = $this->createMock(IShare::class);
-        $share->expects($this->once())->method('setTarget')->with('/test/path');
-        $share->expects($this->once())->method('setNodeId')->with(42);
-        $share->expects($this->once())->method('setNodeType')->with('file');
-        $share->expects($this->once())->method('setShareType')->with(3);
-        $share->expects($this->once())->method('setPermissions')->with(1);
-        $share->expects($this->once())->method('setSharedBy')->with('admin');
-        $share->expects($this->once())->method('setShareOwner')->with('admin');
-
-        $this->shareManager->method('newShare')->willReturn($share);
-        $this->shareManager->expects($this->once())
-            ->method('createShare')
-            ->with($share)
-            ->willReturn($share);
-
-        $shareData = [
-            'path'        => 'test/path',
-            'file'        => $file,
-            'shareType'   => 3,
-            'permissions' => 1,
-            'userId'      => 'admin',
-        ];
-
-        $result = $this->invokePrivateMethod('createShare', [$shareData]);
-        $this->assertSame($share, $result);
-    }
-
-    public function testCreateShareNullPermissions(): void
-    {
-        $file = $this->createMock(File::class);
-        $file->method('getId')->willReturn(10);
-
-        $share = $this->createMock(IShare::class);
-        $share->expects($this->never())->method('setPermissions');
-
-        $this->shareManager->method('newShare')->willReturn($share);
-        $this->shareManager->method('createShare')->willReturn($share);
-
-        $shareData = [
-            'path'        => 'test/path',
-            'file'        => $file,
-            'shareType'   => 3,
-            'permissions' => null,
-            'userId'      => 'admin',
-        ];
-
-        $this->invokePrivateMethod('createShare', [$shareData]);
-    }
-
-    // -------------------------------------------------------------------------
-    // createShareLink
-    // -------------------------------------------------------------------------
-
-    public function testCreateShareLinkSuccess(): void
-    {
-        $_SERVER['HTTPS']    = 'on';
-        $_SERVER['HTTP_HOST'] = 'example.com';
-
-        $userFolder = $this->setupUserFolder('admin');
-
-        $file = $this->createMock(File::class);
-        $file->method('getId')->willReturn(99);
-        $userFolder->method('get')->with('test/file.pdf')->willReturn($file);
-
-        $share = $this->createMock(IShare::class);
-        $share->method('getToken')->willReturn('sharetoken');
-
-        $this->shareManager->method('newShare')->willReturn($share);
-        $this->shareManager->method('createShare')->willReturn($share);
-
-        $result = $this->fileService->createShareLink('test/file.pdf');
-        $this->assertSame('https://example.com/index.php/s/sharetoken', $result);
-    }
-
-    public function testCreateShareLinkFileNotFound(): void
-    {
-        $userFolder = $this->setupUserFolder('admin');
-        $userFolder->method('get')
-            ->willThrowException(new NotFoundException());
-
-        $result = $this->fileService->createShareLink('missing/file.pdf');
-        $this->assertStringContainsString('File not found', $result);
-    }
-
-    public function testCreateShareLinkUserNotFound(): void
-    {
-        $user = $this->createMock(IUser::class);
-        $user->method('getUID')->willReturn('admin');
-        $this->userSession->method('getUser')->willReturn($user);
-
-        $this->rootFolder->method('getUserFolder')
-            ->willThrowException(new NotPermittedException());
-
-        $result = $this->fileService->createShareLink('some/path');
-        $this->assertStringContainsString("couldn't be found", $result);
-    }
-
-    public function testCreateShareLinkException(): void
-    {
-        $userFolder = $this->setupUserFolder('admin');
-
-        $file = $this->createMock(File::class);
-        $file->method('getId')->willReturn(99);
-        $userFolder->method('get')->willReturn($file);
-
-        $this->shareManager->method('newShare')
-            ->willThrowException(new Exception('Share creation failed'));
-
-        $this->expectException(Exception::class);
-        $this->expectExceptionMessage("Can't create share link");
-
-        $this->fileService->createShareLink('test/file.pdf');
-    }
-
-    public function testCreateShareLinkDefaultPermissionsPublicLink(): void
-    {
-        $_SERVER['HTTPS']    = 'on';
-        $_SERVER['HTTP_HOST'] = 'example.com';
-
-        $userFolder = $this->setupUserFolder('admin');
-        $file       = $this->createMock(File::class);
-        $file->method('getId')->willReturn(1);
-        $userFolder->method('get')->willReturn($file);
-
-        $share = $this->createMock(IShare::class);
-        $share->method('getToken')->willReturn('t');
-
-        // For shareType=3 (public link), permissions should default to 1.
-        $share->expects($this->once())->method('setPermissions')->with(1);
-
-        $this->shareManager->method('newShare')->willReturn($share);
-        $this->shareManager->method('createShare')->willReturn($share);
-
-        $this->fileService->createShareLink('file.pdf', 3, null);
-    }
-
-    public function testCreateShareLinkDefaultPermissionsNonPublic(): void
-    {
-        $_SERVER['HTTPS']    = 'on';
-        $_SERVER['HTTP_HOST'] = 'example.com';
-
-        $userFolder = $this->setupUserFolder('admin');
-        $file       = $this->createMock(File::class);
-        $file->method('getId')->willReturn(1);
-        $userFolder->method('get')->willReturn($file);
-
-        $share = $this->createMock(IShare::class);
-        $share->method('getToken')->willReturn('t');
-
-        // For shareType=0 (user), permissions should default to 31.
-        $share->expects($this->once())->method('setPermissions')->with(31);
-
-        $this->shareManager->method('newShare')->willReturn($share);
-        $this->shareManager->method('createShare')->willReturn($share);
-
-        $this->fileService->createShareLink('file.pdf', 0, null);
-    }
-
-    // -------------------------------------------------------------------------
-    // handleFile
-    // -------------------------------------------------------------------------
-
+    /**
+     * Successfully uploads a file and returns enriched data array.
+     *
+     * @return void
+     */
     public function testHandleFileSuccessfulUpload(): void
     {
-        $_SERVER['HTTPS']    = 'on';
-        $_SERVER['HTTP_HOST'] = 'example.com';
-
         $userFolder = $this->setupUserFolder('admin');
+        $userFolder->method('getPath')->willReturn('/admin/files');
 
-        // Create a real temporary file for file_get_contents.
         $tmpFile = tempnam(sys_get_temp_dir(), 'test_');
         file_put_contents($tmpFile, 'file content');
 
         $request = $this->createMock(IRequest::class);
-        $request->method('getUploadedFile')->with('_file')->willReturn([
-            'name'     => 'document.pdf',
-            'tmp_name' => $tmpFile,
-            'type'     => 'application/pdf',
-            'size'     => 12345,
-            'error'    => UPLOAD_ERR_OK,
-        ]);
+        $request->method('getUploadedFile')
+            ->with('_file')
+            ->willReturn(
+                [
+                    'name'     => 'document.pdf',
+                    'tmp_name' => $tmpFile,
+                    'type'     => 'application/pdf',
+                    'size'     => 12345,
+                    'error'    => UPLOAD_ERR_OK,
+                ]
+            );
         $request->method('getHeader')
-            ->willReturnMap([
-                ['Publication-Id', '42'],
-                ['Publication-Title', 'Test Publication'],
-            ]);
+            ->willReturnMap(
+                [
+                    ['Publication-Id', '42'],
+                    ['Publication-Title', 'Test Publication'],
+                ]
+            );
 
         $file = $this->createMock(File::class);
         $file->method('getId')->willReturn(1);
 
-        // Track get() calls to differentiate folder checks from file operations.
         $getCallIndex = 0;
-        $userFolder->method('get')->willReturnCallback(function (string $path) use ($userFolder, $file, &$getCallIndex) {
-            $getCallIndex++;
-            // Calls 1-3: folder existence checks (Publicaties, Publicaties/(42) Test Publication,
-            // Publicaties/(42) Test Publication/Bijlagen) - return folder (already exists).
-            if ($getCallIndex <= 3) {
-                return $userFolder;
-            }
+        $userFolder->method('get')->willReturnCallback(
+            function (string $path) use ($userFolder, $file, &$getCallIndex) {
+                $getCallIndex++;
+                if ($getCallIndex <= 3) {
+                    return $userFolder;
+                }
 
-            // Call 4: uploadFile checks if file exists - throw NotFoundException.
-            if ($getCallIndex === 4) {
-                throw new NotFoundException();
-            }
+                if ($getCallIndex === 4) {
+                    throw new NotFoundException();
+                }
 
-            // Call 5+: after newFile, return the file mock for putContent and share link creation.
-            return $file;
-        });
+                return $file;
+            }
+        );
 
         $userFolder->method('newFile')->willReturn($file);
 
-        $share = $this->createMock(IShare::class);
-        $share->method('getToken')->willReturn('sharetoken');
-        $this->shareManager->method('newShare')->willReturn($share);
-        $this->shareManager->method('createShare')->willReturn($share);
+        $this->setupOrFileService('https://example.com/index.php/s/sharetoken');
 
         $result = $this->fileService->handleFile($request, []);
 
@@ -504,8 +370,14 @@ class FileServiceTest extends \PHPUnit\Framework\TestCase
         $this->assertStringContainsString('/index.php/s/sharetoken', $result['accessUrl']);
 
         @unlink($tmpFile);
-    }
 
+    }//end testHandleFileSuccessfulUpload()
+
+    /**
+     * Returns 400 when the file already exists in NextCloud.
+     *
+     * @return void
+     */
     public function testHandleFileUploadFails(): void
     {
         $userFolder = $this->setupUserFolder('admin');
@@ -514,20 +386,25 @@ class FileServiceTest extends \PHPUnit\Framework\TestCase
         file_put_contents($tmpFile, 'content');
 
         $request = $this->createMock(IRequest::class);
-        $request->method('getUploadedFile')->with('_file')->willReturn([
-            'name'     => 'document.pdf',
-            'tmp_name' => $tmpFile,
-            'type'     => 'application/pdf',
-            'size'     => 100,
-            'error'    => UPLOAD_ERR_OK,
-        ]);
+        $request->method('getUploadedFile')
+            ->with('_file')
+            ->willReturn(
+                [
+                    'name'     => 'document.pdf',
+                    'tmp_name' => $tmpFile,
+                    'type'     => 'application/pdf',
+                    'size'     => 100,
+                    'error'    => UPLOAD_ERR_OK,
+                ]
+            );
         $request->method('getHeader')
-            ->willReturnMap([
-                ['Publication-Id', '1'],
-                ['Publication-Title', 'Pub'],
-            ]);
+            ->willReturnMap(
+                [
+                    ['Publication-Id', '1'],
+                    ['Publication-Title', 'Pub'],
+                ]
+            );
 
-        // All folder checks succeed, and the file already exists (uploadFile returns false).
         $userFolder->method('get')->willReturn($userFolder);
         $userFolder->method('newFile')->willReturn($this->createMock(File::class));
 
@@ -537,8 +414,14 @@ class FileServiceTest extends \PHPUnit\Framework\TestCase
         $this->assertSame(400, $result->getStatus());
 
         @unlink($tmpFile);
-    }
 
+    }//end testHandleFileUploadFails()
+
+    /**
+     * Returns 400 when no file is provided in the request.
+     *
+     * @return void
+     */
     public function testHandleFileWithoutFile(): void
     {
         $request = $this->createMock(IRequest::class);
@@ -547,28 +430,40 @@ class FileServiceTest extends \PHPUnit\Framework\TestCase
         $result = $this->fileService->handleFile($request, []);
         $this->assertInstanceOf(JSONResponse::class, $result);
         $this->assertSame(400, $result->getStatus());
-    }
 
+    }//end testHandleFileWithoutFile()
+
+    /**
+     * Returns 400 when the upload had a PHP error code.
+     *
+     * @return void
+     */
     public function testHandleFileUploadError(): void
     {
         $request = $this->createMock(IRequest::class);
-        $request->method('getUploadedFile')->with('_file')->willReturn([
-            'name'     => 'bad.pdf',
-            'tmp_name' => '/tmp/phpXXX',
-            'type'     => 'application/pdf',
-            'size'     => 100,
-            'error'    => UPLOAD_ERR_INI_SIZE,
-        ]);
+        $request->method('getUploadedFile')
+            ->with('_file')
+            ->willReturn(
+                [
+                    'name'     => 'bad.pdf',
+                    'tmp_name' => '/tmp/phpXXX',
+                    'type'     => 'application/pdf',
+                    'size'     => 100,
+                    'error'    => UPLOAD_ERR_INI_SIZE,
+                ]
+            );
 
         $result = $this->fileService->handleFile($request, []);
         $this->assertInstanceOf(JSONResponse::class, $result);
         $this->assertSame(400, $result->getStatus());
-    }
 
-    // -------------------------------------------------------------------------
-    // checkUploadedFile (private)
-    // -------------------------------------------------------------------------
+    }//end testHandleFileUploadError()
 
+    /**
+     * Returns error response when no file is uploaded.
+     *
+     * @return void
+     */
     public function testCheckUploadedFileNoFile(): void
     {
         $request = $this->createMock(IRequest::class);
@@ -576,27 +471,41 @@ class FileServiceTest extends \PHPUnit\Framework\TestCase
 
         $result = $this->invokePrivateMethod('checkUploadedFile', [$request]);
         $this->assertInstanceOf(JSONResponse::class, $result);
-        $this->assertSame(400, $result->getStatus());
-    }
 
+    }//end testCheckUploadedFileNoFile()
+
+    /**
+     * Returns error response when upload has a PHP error code.
+     *
+     * @return void
+     */
     public function testCheckUploadedFileError(): void
     {
         $request = $this->createMock(IRequest::class);
-        $request->method('getUploadedFile')->willReturn([
-            'name'     => 'file.pdf',
-            'tmp_name' => '/tmp/phpXYZ',
-            'type'     => 'application/pdf',
-            'size'     => 100,
-            'error'    => UPLOAD_ERR_PARTIAL,
-        ]);
+        $request->method('getUploadedFile')
+            ->willReturn(
+                [
+                    'name'     => 'file.pdf',
+                    'tmp_name' => '/tmp/phpXYZ',
+                    'type'     => 'application/pdf',
+                    'size'     => 100,
+                    'error'    => UPLOAD_ERR_PARTIAL,
+                ]
+            );
 
         $result = $this->invokePrivateMethod('checkUploadedFile', [$request]);
         $this->assertInstanceOf(JSONResponse::class, $result);
-    }
 
+    }//end testCheckUploadedFileError()
+
+    /**
+     * Returns the uploaded file array when the file is valid.
+     *
+     * @return void
+     */
     public function testCheckUploadedFileSuccess(): void
     {
-        $request = $this->createMock(IRequest::class);
+        $request      = $this->createMock(IRequest::class);
         $uploadedFile = [
             'name'     => 'file.pdf',
             'tmp_name' => '/tmp/phpOK',
@@ -609,12 +518,14 @@ class FileServiceTest extends \PHPUnit\Framework\TestCase
         $result = $this->invokePrivateMethod('checkUploadedFile', [$request]);
         $this->assertIsArray($result);
         $this->assertSame('file.pdf', $result['name']);
-    }
 
-    // -------------------------------------------------------------------------
-    // createFolder
-    // -------------------------------------------------------------------------
+    }//end testCheckUploadedFileSuccess()
 
+    /**
+     * Creates a new folder and returns true.
+     *
+     * @return void
+     */
     public function testCreateFolderNewFolder(): void
     {
         $userFolder = $this->setupUserFolder('admin');
@@ -629,8 +540,14 @@ class FileServiceTest extends \PHPUnit\Framework\TestCase
 
         $result = $this->fileService->createFolder('NewFolder');
         $this->assertTrue($result);
-    }
 
+    }//end testCreateFolderNewFolder()
+
+    /**
+     * Returns false and logs info when folder already exists.
+     *
+     * @return void
+     */
     public function testCreateFolderExistingFolder(): void
     {
         $userFolder = $this->setupUserFolder('admin');
@@ -644,8 +561,14 @@ class FileServiceTest extends \PHPUnit\Framework\TestCase
 
         $result = $this->fileService->createFolder('ExistingFolder');
         $this->assertFalse($result);
-    }
 
+    }//end testCreateFolderExistingFolder()
+
+    /**
+     * Throws Exception when folder creation is not permitted.
+     *
+     * @return void
+     */
     public function testCreateFolderNotPermitted(): void
     {
         $userFolder = $this->setupUserFolder('admin');
@@ -659,8 +582,14 @@ class FileServiceTest extends \PHPUnit\Framework\TestCase
         $this->expectExceptionMessageMatches("/Can.*t create folder/");
 
         $this->fileService->createFolder('Restricted');
-    }
 
+    }//end testCreateFolderNotPermitted()
+
+    /**
+     * Trims leading/trailing slashes from folder path.
+     *
+     * @return void
+     */
     public function testCreateFolderTrimsSlashes(): void
     {
         $userFolder = $this->setupUserFolder('admin');
@@ -675,28 +604,20 @@ class FileServiceTest extends \PHPUnit\Framework\TestCase
             ->with('trimmed/folder');
 
         $this->fileService->createFolder('/trimmed/folder/');
-    }
 
-    // -------------------------------------------------------------------------
-    // addFileInfoToData
-    // -------------------------------------------------------------------------
+    }//end testCreateFolderTrimsSlashes()
 
+    /**
+     * Enriches data with file metadata and share URL.
+     *
+     * @return void
+     */
     public function testAddFileInfoToDataEnrichment(): void
     {
-        $_SERVER['HTTPS']    = 'on';
-        $_SERVER['HTTP_HOST'] = 'example.com';
-
         $userFolder = $this->setupUserFolder('admin');
-        $file       = $this->createMock(File::class);
-        $file->method('getId')->willReturn(1);
+        $userFolder->method('getPath')->willReturn('/admin/files');
 
-        // For createShareLink -> get file.
-        $userFolder->method('get')->willReturn($file);
-
-        $share = $this->createMock(IShare::class);
-        $share->method('getToken')->willReturn('mytoken');
-        $this->shareManager->method('newShare')->willReturn($share);
-        $this->shareManager->method('createShare')->willReturn($share);
+        $this->setupOrFileService('https://example.com/index.php/s/mytoken');
 
         $uploadedFile = [
             'name' => 'report.summary.pdf',
@@ -705,7 +626,11 @@ class FileServiceTest extends \PHPUnit\Framework\TestCase
         ];
 
         $data   = [];
-        $result = $this->fileService->addFileInfoToData($data, $uploadedFile, 'Publicaties/folder/report.summary.pdf');
+        $result = $this->fileService->addFileInfoToData(
+            data: $data,
+            uploadedFile: $uploadedFile,
+            filePath: 'Publicaties/folder/report.summary.pdf'
+        );
 
         $this->assertSame('admin/Publicaties/folder/report.summary.pdf', $result['reference']);
         $this->assertSame('application/pdf', $result['type']);
@@ -714,22 +639,20 @@ class FileServiceTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('pdf', $result['extension']);
         $this->assertStringContainsString('/index.php/s/mytoken', $result['accessUrl']);
         $this->assertStringContainsString('/download', $result['downloadUrl']);
-    }
 
+    }//end testAddFileInfoToDataEnrichment()
+
+    /**
+     * Preserves pre-existing accessUrl and downloadUrl values.
+     *
+     * @return void
+     */
     public function testAddFileInfoToDataPreservesExistingUrls(): void
     {
-        $_SERVER['HTTPS']    = 'on';
-        $_SERVER['HTTP_HOST'] = 'example.com';
-
         $userFolder = $this->setupUserFolder('admin');
-        $file       = $this->createMock(File::class);
-        $file->method('getId')->willReturn(1);
-        $userFolder->method('get')->willReturn($file);
+        $userFolder->method('getPath')->willReturn('/admin/files');
 
-        $share = $this->createMock(IShare::class);
-        $share->method('getToken')->willReturn('t');
-        $this->shareManager->method('newShare')->willReturn($share);
-        $this->shareManager->method('createShare')->willReturn($share);
+        $this->setupOrFileService('https://example.com/index.php/s/t');
 
         $data = [
             'accessUrl'   => 'https://existing.com/access',
@@ -737,16 +660,22 @@ class FileServiceTest extends \PHPUnit\Framework\TestCase
         ];
 
         $uploadedFile = ['name' => 'file.txt', 'type' => 'text/plain', 'size' => 10];
-        $result       = $this->fileService->addFileInfoToData($data, $uploadedFile, 'path/file.txt');
+        $result       = $this->fileService->addFileInfoToData(
+            data: $data,
+            uploadedFile: $uploadedFile,
+            filePath: 'path/file.txt'
+        );
 
         $this->assertSame('https://existing.com/access', $result['accessUrl']);
         $this->assertSame('https://existing.com/download', $result['downloadUrl']);
-    }
 
-    // -------------------------------------------------------------------------
-    // uploadFile
-    // -------------------------------------------------------------------------
+    }//end testAddFileInfoToDataPreservesExistingUrls()
 
+    /**
+     * Creates a new file and returns true.
+     *
+     * @return void
+     */
     public function testUploadFileNewFile(): void
     {
         $userFolder = $this->setupUserFolder('admin');
@@ -755,21 +684,29 @@ class FileServiceTest extends \PHPUnit\Framework\TestCase
         $file->expects($this->once())->method('putContent')->with('file content');
 
         $callCount = 0;
-        $userFolder->method('get')->willReturnCallback(function () use ($file, &$callCount) {
-            $callCount++;
-            if ($callCount === 1) {
-                throw new NotFoundException();
-            }
+        $userFolder->method('get')->willReturnCallback(
+            function () use ($file, &$callCount) {
+                $callCount++;
+                if ($callCount === 1) {
+                    throw new NotFoundException();
+                }
 
-            return $file;
-        });
+                return $file;
+            }
+        );
 
         $userFolder->expects($this->once())->method('newFile')->with('path/file.txt');
 
-        $result = $this->fileService->uploadFile('file content', '/path/file.txt/');
+        $result = $this->fileService->uploadFile(content: 'file content', filePath: '/path/file.txt/');
         $this->assertTrue($result);
-    }
 
+    }//end testUploadFileNewFile()
+
+    /**
+     * Returns false and logs warning when file already exists.
+     *
+     * @return void
+     */
     public function testUploadFileExistingFile(): void
     {
         $userFolder = $this->setupUserFolder('admin');
@@ -781,10 +718,16 @@ class FileServiceTest extends \PHPUnit\Framework\TestCase
             ->method('warning')
             ->with($this->stringContains('already exists'));
 
-        $result = $this->fileService->uploadFile('content', 'path/existing.txt');
+        $result = $this->fileService->uploadFile(content: 'content', filePath: 'path/existing.txt');
         $this->assertFalse($result);
-    }
 
+    }//end testUploadFileExistingFile()
+
+    /**
+     * Throws Exception when upload is not permitted.
+     *
+     * @return void
+     */
     public function testUploadFilePermissionError(): void
     {
         $userFolder = $this->setupUserFolder('admin');
@@ -797,9 +740,15 @@ class FileServiceTest extends \PHPUnit\Framework\TestCase
         $this->expectException(Exception::class);
         $this->expectExceptionMessageMatches("/Can.*t write to file/");
 
-        $this->fileService->uploadFile('content', 'restricted/file.txt');
-    }
+        $this->fileService->uploadFile(content: 'content', filePath: 'restricted/file.txt');
 
+    }//end testUploadFilePermissionError()
+
+    /**
+     * Throws Exception on GenericFileException during putContent.
+     *
+     * @return void
+     */
     public function testUploadFileGenericFileException(): void
     {
         $userFolder = $this->setupUserFolder('admin');
@@ -807,27 +756,31 @@ class FileServiceTest extends \PHPUnit\Framework\TestCase
         $file = $this->createMock(File::class);
 
         $callCount = 0;
-        $userFolder->method('get')->willReturnCallback(function () use ($file, &$callCount) {
-            $callCount++;
-            if ($callCount === 1) {
-                throw new NotFoundException();
-            }
+        $userFolder->method('get')->willReturnCallback(
+            function () use ($file, &$callCount) {
+                $callCount++;
+                if ($callCount === 1) {
+                    throw new NotFoundException();
+                }
 
-            return $file;
-        });
+                return $file;
+            }
+        );
 
         $userFolder->method('newFile')->willReturn(null);
         $file->method('putContent')->willThrowException(new GenericFileException());
 
         $this->expectException(Exception::class);
 
-        $this->fileService->uploadFile('content', 'path/file.txt');
-    }
+        $this->fileService->uploadFile(content: 'content', filePath: 'path/file.txt');
 
-    // -------------------------------------------------------------------------
-    // updateFile
-    // -------------------------------------------------------------------------
+    }//end testUploadFileGenericFileException()
 
+    /**
+     * Overwrites an existing file and returns true.
+     *
+     * @return void
+     */
     public function testUpdateFileExistingFile(): void
     {
         $userFolder = $this->setupUserFolder('admin');
@@ -836,10 +789,16 @@ class FileServiceTest extends \PHPUnit\Framework\TestCase
         $file->expects($this->once())->method('putContent')->with('new content');
         $userFolder->method('get')->with('path/file.txt')->willReturn($file);
 
-        $result = $this->fileService->updateFile('new content', '/path/file.txt/');
+        $result = $this->fileService->updateFile(content: 'new content', filePath: '/path/file.txt/');
         $this->assertTrue($result);
-    }
 
+    }//end testUpdateFileExistingFile()
+
+    /**
+     * Creates a new file when createNew is true and file is missing.
+     *
+     * @return void
+     */
     public function testUpdateFileNewFileWithCreateNew(): void
     {
         $userFolder = $this->setupUserFolder('admin');
@@ -848,21 +807,29 @@ class FileServiceTest extends \PHPUnit\Framework\TestCase
         $file->expects($this->once())->method('putContent')->with('content');
 
         $callCount = 0;
-        $userFolder->method('get')->willReturnCallback(function () use ($file, &$callCount) {
-            $callCount++;
-            if ($callCount === 1) {
-                throw new NotFoundException();
-            }
+        $userFolder->method('get')->willReturnCallback(
+            function () use ($file, &$callCount) {
+                $callCount++;
+                if ($callCount === 1) {
+                    throw new NotFoundException();
+                }
 
-            return $file;
-        });
+                return $file;
+            }
+        );
 
         $userFolder->expects($this->once())->method('newFile');
 
-        $result = $this->fileService->updateFile('content', 'path/file.txt', true);
+        $result = $this->fileService->updateFile(content: 'content', filePath: 'path/file.txt', createNew: true);
         $this->assertTrue($result);
-    }
 
+    }//end testUpdateFileNewFileWithCreateNew()
+
+    /**
+     * Returns false when file does not exist and createNew is false.
+     *
+     * @return void
+     */
     public function testUpdateFileNotFoundWithoutCreateNew(): void
     {
         $userFolder = $this->setupUserFolder('admin');
@@ -874,10 +841,16 @@ class FileServiceTest extends \PHPUnit\Framework\TestCase
             ->method('warning')
             ->with($this->stringContains('already exists'));
 
-        $result = $this->fileService->updateFile('content', 'missing/file.txt', false);
+        $result = $this->fileService->updateFile(content: 'content', filePath: 'missing/file.txt', createNew: false);
         $this->assertFalse($result);
-    }
 
+    }//end testUpdateFileNotFoundWithoutCreateNew()
+
+    /**
+     * Throws Exception when writing is not permitted.
+     *
+     * @return void
+     */
     public function testUpdateFilePermissionError(): void
     {
         $userFolder = $this->setupUserFolder('admin');
@@ -890,13 +863,15 @@ class FileServiceTest extends \PHPUnit\Framework\TestCase
         $this->expectException(Exception::class);
         $this->expectExceptionMessageMatches("/Can.*t write to file/");
 
-        $this->fileService->updateFile('content', 'locked/file.txt');
-    }
+        $this->fileService->updateFile(content: 'content', filePath: 'locked/file.txt');
 
-    // -------------------------------------------------------------------------
-    // deleteFile
-    // -------------------------------------------------------------------------
+    }//end testUpdateFilePermissionError()
 
+    /**
+     * Removes an existing file and returns true.
+     *
+     * @return void
+     */
     public function testDeleteFileExists(): void
     {
         $userFolder = $this->setupUserFolder('admin');
@@ -907,8 +882,14 @@ class FileServiceTest extends \PHPUnit\Framework\TestCase
 
         $result = $this->fileService->deleteFile('/path/file.txt/');
         $this->assertTrue($result);
-    }
 
+    }//end testDeleteFileExists()
+
+    /**
+     * Returns false and logs warning when file does not exist.
+     *
+     * @return void
+     */
     public function testDeleteFileNotFound(): void
     {
         $userFolder = $this->setupUserFolder('admin');
@@ -922,8 +903,14 @@ class FileServiceTest extends \PHPUnit\Framework\TestCase
 
         $result = $this->fileService->deleteFile('missing/file.txt');
         $this->assertFalse($result);
-    }
 
+    }//end testDeleteFileNotFound()
+
+    /**
+     * Throws Exception when deletion is not permitted.
+     *
+     * @return void
+     */
     public function testDeleteFilePermissionError(): void
     {
         $userFolder = $this->setupUserFolder('admin');
@@ -937,35 +924,34 @@ class FileServiceTest extends \PHPUnit\Framework\TestCase
         $this->expectExceptionMessageMatches("/Can.*t delete file/");
 
         $this->fileService->deleteFile('restricted/file.txt');
-    }
 
-    // -------------------------------------------------------------------------
-    // Guest user fallback paths
-    // -------------------------------------------------------------------------
+    }//end testDeleteFilePermissionError()
 
-    public function testCreateShareLinkGuestUser(): void
+    /**
+     * Uses Guest user folder when no user is authenticated.
+     *
+     * @return void
+     */
+    public function testCreatePublicShareLinkGuestUserUsesGuestFolder(): void
     {
-        $_SERVER['HTTPS']    = 'on';
-        $_SERVER['HTTP_HOST'] = 'example.com';
-
         $this->userSession->method('getUser')->willReturn(null);
 
         $userFolder = $this->createMock(Folder::class);
         $this->rootFolder->method('getUserFolder')->with('Guest')->willReturn($userFolder);
+        $userFolder->method('getPath')->willReturn('/Guest/files');
 
-        $file = $this->createMock(File::class);
-        $file->method('getId')->willReturn(1);
-        $userFolder->method('get')->willReturn($file);
+        $this->setupOrFileService('https://example.com/index.php/s/guest-token');
 
-        $share = $this->createMock(IShare::class);
-        $share->method('getToken')->willReturn('guest-token');
-        $this->shareManager->method('newShare')->willReturn($share);
-        $this->shareManager->method('createShare')->willReturn($share);
+        $result = $this->fileService->createPublicShareLink('file.pdf');
+        $this->assertSame('https://example.com/index.php/s/guest-token', $result);
 
-        $result = $this->fileService->createShareLink('file.pdf');
-        $this->assertStringContainsString('/index.php/s/guest-token', $result);
-    }
+    }//end testCreatePublicShareLinkGuestUserUsesGuestFolder()
 
+    /**
+     * Uses Guest user ID for folder when no user is authenticated.
+     *
+     * @return void
+     */
     public function testCreateFolderGuestUser(): void
     {
         $this->userSession->method('getUser')->willReturn(null);
@@ -978,33 +964,40 @@ class FileServiceTest extends \PHPUnit\Framework\TestCase
 
         $result = $this->fileService->createFolder('TestFolder');
         $this->assertTrue($result);
-    }
 
+    }//end testCreateFolderGuestUser()
+
+    /**
+     * Uses Guest user reference when no user is authenticated.
+     *
+     * @return void
+     */
     public function testAddFileInfoToDataGuestUser(): void
     {
-        $_SERVER['HTTPS']    = 'on';
-        $_SERVER['HTTP_HOST'] = 'example.com';
-
         $this->userSession->method('getUser')->willReturn(null);
 
         $userFolder = $this->createMock(Folder::class);
         $this->rootFolder->method('getUserFolder')->with('Guest')->willReturn($userFolder);
+        $userFolder->method('getPath')->willReturn('/Guest/files');
 
-        $file = $this->createMock(File::class);
-        $file->method('getId')->willReturn(1);
-        $userFolder->method('get')->willReturn($file);
-
-        $share = $this->createMock(IShare::class);
-        $share->method('getToken')->willReturn('gt');
-        $this->shareManager->method('newShare')->willReturn($share);
-        $this->shareManager->method('createShare')->willReturn($share);
+        $this->setupOrFileService('https://example.com/index.php/s/gt');
 
         $uploadedFile = ['name' => 'file.txt', 'type' => 'text/plain', 'size' => 10];
-        $result = $this->fileService->addFileInfoToData([], $uploadedFile, 'path/file.txt');
+        $result       = $this->fileService->addFileInfoToData(
+            data: [],
+            uploadedFile: $uploadedFile,
+            filePath: 'path/file.txt'
+        );
 
         $this->assertSame('Guest/path/file.txt', $result['reference']);
-    }
 
+    }//end testAddFileInfoToDataGuestUser()
+
+    /**
+     * Uses Guest user ID for upload when no user is authenticated.
+     *
+     * @return void
+     */
     public function testUploadFileGuestUser(): void
     {
         $this->userSession->method('getUser')->willReturn(null);
@@ -1016,20 +1009,29 @@ class FileServiceTest extends \PHPUnit\Framework\TestCase
         $file->expects($this->once())->method('putContent')->with('content');
 
         $callCount = 0;
-        $userFolder->method('get')->willReturnCallback(function () use ($file, &$callCount) {
-            $callCount++;
-            if ($callCount === 1) {
-                throw new NotFoundException();
+        $userFolder->method('get')->willReturnCallback(
+            function () use ($file, &$callCount) {
+                $callCount++;
+                if ($callCount === 1) {
+                    throw new NotFoundException();
+                }
+
+                return $file;
             }
-            return $file;
-        });
+        );
 
         $userFolder->expects($this->once())->method('newFile');
 
-        $result = $this->fileService->uploadFile('content', 'path/file.txt');
+        $result = $this->fileService->uploadFile(content: 'content', filePath: 'path/file.txt');
         $this->assertTrue($result);
-    }
 
+    }//end testUploadFileGuestUser()
+
+    /**
+     * Uses Guest user ID for update when no user is authenticated.
+     *
+     * @return void
+     */
     public function testUpdateFileGuestUser(): void
     {
         $this->userSession->method('getUser')->willReturn(null);
@@ -1041,10 +1043,16 @@ class FileServiceTest extends \PHPUnit\Framework\TestCase
         $file->expects($this->once())->method('putContent')->with('updated');
         $userFolder->method('get')->willReturn($file);
 
-        $result = $this->fileService->updateFile('updated', 'path/file.txt');
+        $result = $this->fileService->updateFile(content: 'updated', filePath: 'path/file.txt');
         $this->assertTrue($result);
-    }
 
+    }//end testUpdateFileGuestUser()
+
+    /**
+     * Uses Guest user ID for delete when no user is authenticated.
+     *
+     * @return void
+     */
     public function testDeleteFileGuestUser(): void
     {
         $this->userSession->method('getUser')->willReturn(null);
@@ -1058,91 +1066,76 @@ class FileServiceTest extends \PHPUnit\Framework\TestCase
 
         $result = $this->fileService->deleteFile('path/file.txt');
         $this->assertTrue($result);
-    }
 
-    // -------------------------------------------------------------------------
-    // createShareLink — additional permission branches
-    // -------------------------------------------------------------------------
+    }//end testDeleteFileGuestUser()
 
-    public function testCreateShareLinkWithExplicitPermissions(): void
-    {
-        $_SERVER['HTTPS']    = 'on';
-        $_SERVER['HTTP_HOST'] = 'example.com';
-
-        $userFolder = $this->setupUserFolder('admin');
-        $file       = $this->createMock(File::class);
-        $file->method('getId')->willReturn(1);
-        $userFolder->method('get')->willReturn($file);
-
-        $share = $this->createMock(IShare::class);
-        $share->method('getToken')->willReturn('t');
-        // Explicit permissions=16 should be used directly, not defaulted.
-        $share->expects($this->once())->method('setPermissions')->with(16);
-        $this->shareManager->method('newShare')->willReturn($share);
-        $this->shareManager->method('createShare')->willReturn($share);
-
-        $this->fileService->createShareLink('file.pdf', 3, 16);
-    }
-
-    // -------------------------------------------------------------------------
-    // createZip — uses real temp files
-    // -------------------------------------------------------------------------
-
+    /**
+     * Creates a ZIP archive containing all files in the input folder.
+     *
+     * @return void
+     */
     public function testCreateZipSuccess(): void
     {
-        // Create temporary input folder with files.
-        $inputFolder = sys_get_temp_dir() . '/test_zip_input_' . uniqid();
+        $inputFolder = sys_get_temp_dir().'/test_zip_input_'.uniqid();
         mkdir($inputFolder, 0777, true);
         file_put_contents("$inputFolder/file1.txt", 'Hello');
         file_put_contents("$inputFolder/file2.txt", 'World');
 
-        $tempZip = sys_get_temp_dir() . '/test_output_' . uniqid() . '.zip';
+        $tempZip = sys_get_temp_dir().'/test_output_'.uniqid().'.zip';
 
         $result = $this->fileService->createZip($inputFolder, $tempZip);
 
         $this->assertNull($result);
         $this->assertFileExists($tempZip);
 
-        // Verify the ZIP contents.
         $zip = new \ZipArchive();
         $zip->open($tempZip);
         $this->assertSame(2, $zip->numFiles);
         $zip->close();
 
-        // Cleanup.
         unlink("$inputFolder/file1.txt");
         unlink("$inputFolder/file2.txt");
         rmdir($inputFolder);
         unlink($tempZip);
-    }
 
+    }//end testCreateZipSuccess()
+
+    /**
+     * Handles an empty input folder without errors.
+     *
+     * @return void
+     */
     public function testCreateZipEmptyFolder(): void
     {
-        $inputFolder = sys_get_temp_dir() . '/test_zip_empty_' . uniqid();
+        $inputFolder = sys_get_temp_dir().'/test_zip_empty_'.uniqid();
         mkdir($inputFolder, 0777, true);
 
-        $tempZip = sys_get_temp_dir() . '/test_empty_' . uniqid() . '.zip';
+        $tempZip = sys_get_temp_dir().'/test_empty_'.uniqid().'.zip';
 
-        // Suppress PHP warning from ZipArchive::close() on empty archives.
         $result = @$this->fileService->createZip($inputFolder, $tempZip);
 
         $this->assertNull($result);
 
-        // Cleanup.
         rmdir($inputFolder);
-        if (file_exists($tempZip)) {
+        if (file_exists($tempZip) === true) {
             unlink($tempZip);
         }
-    }
 
+    }//end testCreateZipEmptyFolder()
+
+    /**
+     * Includes files from sub-directories.
+     *
+     * @return void
+     */
     public function testCreateZipWithSubdirectory(): void
     {
-        $inputFolder = sys_get_temp_dir() . '/test_zip_subdir_' . uniqid();
+        $inputFolder = sys_get_temp_dir().'/test_zip_subdir_'.uniqid();
         mkdir("$inputFolder/subdir", 0777, true);
         file_put_contents("$inputFolder/root.txt", 'root');
         file_put_contents("$inputFolder/subdir/nested.txt", 'nested');
 
-        $tempZip = sys_get_temp_dir() . '/test_subdir_' . uniqid() . '.zip';
+        $tempZip = sys_get_temp_dir().'/test_subdir_'.uniqid().'.zip';
 
         $result = $this->fileService->createZip($inputFolder, $tempZip);
 
@@ -1153,137 +1146,14 @@ class FileServiceTest extends \PHPUnit\Framework\TestCase
         $this->assertSame(2, $zip->numFiles);
         $zip->close();
 
-        // Cleanup.
         unlink("$inputFolder/root.txt");
         unlink("$inputFolder/subdir/nested.txt");
         rmdir("$inputFolder/subdir");
         rmdir($inputFolder);
         unlink($tempZip);
-    }
 
-    public function testCreateZipInvalidPath(): void
-    {
-        $inputFolder = sys_get_temp_dir() . '/test_zip_input_' . uniqid();
-        mkdir($inputFolder, 0777, true);
-        file_put_contents("$inputFolder/file.txt", 'data');
+    }//end testCreateZipWithSubdirectory()
 
-        // Use a path inside a non-writable directory.
-        $readOnlyDir = sys_get_temp_dir() . '/test_zip_readonly_' . uniqid();
-        mkdir($readOnlyDir, 0444, true);
-        $tempZip = "$readOnlyDir/subdir/test.zip";
+    // phpcs:enable CustomSniffs.Functions.NamedParameters
 
-        $result = $this->fileService->createZip($inputFolder, $tempZip);
-
-        // On most systems this will fail. If it doesn't, just skip.
-        if ($result === null) {
-            // Some systems allow this; clean up and skip.
-            @unlink($tempZip);
-            @rmdir("$readOnlyDir/subdir");
-            chmod($readOnlyDir, 0777);
-            rmdir($readOnlyDir);
-            unlink("$inputFolder/file.txt");
-            rmdir($inputFolder);
-            $this->markTestSkipped('System allows writing to read-only directories');
-        }
-
-        $this->assertSame('failed to create ZIP archive', $result);
-
-        // Cleanup.
-        chmod($readOnlyDir, 0777);
-        rmdir($readOnlyDir);
-        unlink("$inputFolder/file.txt");
-        rmdir($inputFolder);
-    }
-
-    // -------------------------------------------------------------------------
-    // downloadZip — skipped due to header() calls
-    // -------------------------------------------------------------------------
-
-    public function testDownloadZipSkipped(): void
-    {
-        // downloadZip() calls header() which cannot be sent in CLI, and
-        // @runInSeparateProcess fails with Nextcloud bootstrap output.
-        $this->markTestSkipped('downloadZip() calls header() and readfile(); incompatible with Nextcloud bootstrap in separate process.');
-    }
-
-    // -------------------------------------------------------------------------
-    // createPdf — test error handling
-    // -------------------------------------------------------------------------
-
-    public function testCreatePdfThrowsOnMissingTemplate(): void
-    {
-        // createPdf() directly instantiates Twig and Mpdf.
-        // Without a valid template, Twig will throw a LoaderError or RuntimeError.
-        $this->expectException(\Exception::class);
-
-        $this->fileService->createPdf('nonexistent-template.html.twig', []);
-    }
-
-    public function testCreatePdfSuccess(): void
-    {
-        // Ensure the test template exists.
-        $templateDir = '/var/www/html/custom_apps/opencatalogi/lib/Templates';
-        if (is_dir($templateDir) === false) {
-            mkdir($templateDir, 0777, true);
-        }
-
-        $templateFile = "$templateDir/test.html.twig";
-        if (file_exists($templateFile) === false) {
-            file_put_contents($templateFile, '<html><body>{{ title }}</body></html>');
-        }
-
-        $result = $this->fileService->createPdf('test.html.twig', ['title' => 'Test PDF']);
-
-        $this->assertInstanceOf(\Mpdf\Mpdf::class, $result);
-
-        // Cleanup mpdf temp dir.
-        if (is_dir('/tmp/mpdf')) {
-            $files = glob('/tmp/mpdf/*');
-            if ($files !== false) {
-                foreach ($files as $f) {
-                    if (is_file($f)) {
-                        @unlink($f);
-                    }
-                }
-            }
-        }
-    }
-
-    // -------------------------------------------------------------------------
-    // updateFile — additional branch: createNew with NotPermittedException
-    // -------------------------------------------------------------------------
-
-    public function testUpdateFileCreateNewPermissionError(): void
-    {
-        $userFolder = $this->setupUserFolder('admin');
-
-        $userFolder->method('get')
-            ->willThrowException(new NotFoundException());
-        $userFolder->method('newFile')
-            ->willThrowException(new NotPermittedException());
-
-        $this->expectException(Exception::class);
-        $this->expectExceptionMessageMatches("/Can.*t write to file/");
-
-        $this->fileService->updateFile('content', 'restricted/file.txt', true);
-    }
-
-    // -------------------------------------------------------------------------
-    // deleteFile — InvalidPathException branch
-    // -------------------------------------------------------------------------
-
-    public function testDeleteFileInvalidPathException(): void
-    {
-        $userFolder = $this->setupUserFolder('admin');
-
-        $file = $this->createMock(File::class);
-        $file->method('delete')
-            ->willThrowException(new \OCP\Files\InvalidPathException());
-        $userFolder->method('get')->willReturn($file);
-
-        $this->expectException(Exception::class);
-        $this->expectExceptionMessageMatches("/Can.*t delete file/");
-
-        $this->fileService->deleteFile('invalid/file.txt');
-    }
-}
+}//end class


### PR DESCRIPTION
Closes #691

## Summary

Migrates the bespoke share-links logic to the OpenRegister **Shares leaf** (ADR-022 'integrate, don't build'). Manifest-configured widget + bespoke code trimmed.

## Provenance

Hydra builder commits pushed in a prior run; PR opened manually as part of the manual canary that proved the reviewer/security/applier chain on opencatalogi PR #739.