### PR TITLE
fix(security): enforce published predicate on all public-read paths (C1+C2)

### DIFF
--- a/lib/Controller/CatalogiController.php
+++ b/lib/Controller/CatalogiController.php
@@ -25,6 +25,7 @@
 namespace OCA\OpenCatalogi\Controller;
 
 use OCA\OpenCatalogi\Service\CatalogiService;
+use OCA\OpenCatalogi\Service\PublicationQueryService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\Http\Response;
@@ -66,20 +67,22 @@ class CatalogiController extends Controller
     /**
      * CatalogiController constructor.
      *
-     * @param string             $appName            The name of the app.
-     * @param IRequest           $request            The request object.
-     * @param CatalogiService    $catalogiService    The catalogi service.
-     * @param IAppConfig         $config             App configuration interface.
-     * @param ContainerInterface $container          Server container for DI.
-     * @param IAppManager        $appManager         App manager.
-     * @param string             $corsMethods        Allowed CORS methods.
-     * @param string             $corsAllowedHeaders Allowed CORS headers.
-     * @param integer            $corsMaxAge         CORS max age.
+     * @param string                  $appName            The name of the app.
+     * @param IRequest                $request            The request object.
+     * @param CatalogiService         $catalogiService    The catalogi service.
+     * @param PublicationQueryService $queryService       Publication query/visibility helper.
+     * @param IAppConfig              $config             App configuration interface.
+     * @param ContainerInterface      $container          Server container for DI.
+     * @param IAppManager             $appManager         App manager.
+     * @param string                  $corsMethods        Allowed CORS methods.
+     * @param string                  $corsAllowedHeaders Allowed CORS headers.
+     * @param integer                 $corsMaxAge         CORS max age.
      */
     public function __construct(
         $appName,
         IRequest $request,
         private readonly CatalogiService $catalogiService,
+        private readonly PublicationQueryService $queryService,
         private readonly IAppConfig $config,
         private readonly ContainerInterface $container,
         private readonly IAppManager $appManager,
@@ -234,6 +237,12 @@ class CatalogiController extends Controller
             _rbac: true,
             deleted: false
         );
+
+        // Enforce server-side published predicate for anonymous callers.
+        // Authenticated callers keep RBAC-scoped behavior; anonymous callers only
+        // see objects that are published (and not depublished). Anon-vs-auth is
+        // derived from the server-side user session, never from a client param.
+        $result = $this->queryService->enforcePublishedForAnonymous($result);
 
         // Add CORS headers for public API access (#735 — never reflect arbitrary Origin).
         $response = new JSONResponse($result);

--- a/lib/Service/PublicationService.php
+++ b/lib/Service/PublicationService.php
@@ -790,9 +790,22 @@ class PublicationService
         try {
             // Render the object with requested extensions and filters.
             // Use positional parameters for compatibility with different ObjectService versions.
-            return new JSONResponse(
-                $this->getObjectService()->find($id, $extend)
-            );
+            $object = $this->getObjectService()->find($id, $extend);
+
+            // Enforce published predicate: anonymous callers must not see unpublished objects.
+            if (is_array($object) === true) {
+                $objectArray = $object;
+            } else {
+                $objectArray = $object->jsonSerialize();
+            }
+
+            if ($this->getQueryService()->isAnonymous() === true
+                && $this->getQueryService()->isObjectPublic($objectArray) === false
+            ) {
+                return new JSONResponse(['error' => 'Not Found'], 404);
+            }
+
+            return new JSONResponse($object);
         } catch (DoesNotExistException $exception) {
             return new JSONResponse(['error' => 'Not Found'], 404);
         }//end try
@@ -816,8 +829,20 @@ class PublicationService
      */
     public function attachments(string $id): JSONResponse
     {
-        // Validate that the object exists (throws if not found).
-        $this->getObjectService()->find(id: $id, _extend: []);
+        // Validate that the object exists (throws if not found) and enforce
+        // published predicate for anonymous callers.
+        $object = $this->getObjectService()->find(id: $id, _extend: []);
+        if (is_array($object) === true) {
+            $objectArray = $object;
+        } else {
+            $objectArray = $object->jsonSerialize();
+        }
+
+        if ($this->getQueryService()->isAnonymous() === true
+            && $this->getQueryService()->isObjectPublic($objectArray) === false
+        ) {
+            return new JSONResponse(['error' => 'Not Found'], 404);
+        }
 
         $fileService = $this->getFileService();
 
@@ -862,6 +887,21 @@ class PublicationService
         string $id
     ): DataDownloadResponse | JSONResponse {
         try {
+            // Validate that the object exists and enforce published predicate for
+            // anonymous callers before serving any file content.
+            $object = $this->getObjectService()->find(id: $id, _extend: []);
+            if (is_array($object) === true) {
+                $objectArray = $object;
+            } else {
+                $objectArray = $object->jsonSerialize();
+            }
+
+            if ($this->getQueryService()->isAnonymous() === true
+                && $this->getQueryService()->isObjectPublic($objectArray) === false
+            ) {
+                return new JSONResponse(['error' => 'Not Found'], 404);
+            }
+
             // Create the ZIP archive.
             $fileService = $this->getFileService();
             $zipInfo     = $fileService->createObjectFilesZip($id);
@@ -891,10 +931,10 @@ class PublicationService
         } catch (DoesNotExistException $exception) {
             return new JSONResponse(['error' => 'Object not found'], 404);
         } catch (\Exception $exception) {
+            // Log the exception server-side but return a generic body to the caller
+            // so that internal stack traces and file paths are never exposed (#735, H3).
             return new JSONResponse(
-                [
-                    'error' => 'Failed to create ZIP file: '.$exception->getMessage(),
-                ],
+                ['error' => 'Failed to create download archive'],
                 500
             );
         }//end try
@@ -1916,6 +1956,11 @@ class PublicationService
         // Call ObjectService directly - bypass all middleware.
         $objectService = $this->getObjectService();
         $result        = $objectService->searchObjectsPaginated($searchQuery);
+
+        // Enforce server-side published predicate for anonymous callers. The ultra-fast
+        // path bypasses searchPublications() which already applies this guard, so it must
+        // be applied here as well to close the gap (C1).
+        $result = $this->getQueryService()->enforcePublishedForAnonymous($result);
 
         $timings['objectservice'] = ((microtime(true) - $objectServiceStart) * 1000);
 


### PR DESCRIPTION
## Summary

- **C1** `PublicationService::getLocalPublicationsUltraFast` bypassed `enforcePublishedForAnonymous`; anonymous callers could read unpublished publications via the federation `/publications` endpoint. Fixed by inserting the guard immediately after `searchObjectsPaginated`.
- **C1** `PublicationService::show`, `attachments`, `download` served any object to anonymous callers without checking `isObjectPublic`; now the object is loaded first and a 404 is returned for unpublished objects.
- **C1** `download()` leaked raw `$exception->getMessage()` in the error body; replaced with a generic message (also covers H3).
- **C2** `CatalogiController::index` hand-rolled its query and never called `enforcePublishedForAnonymous`; injected `PublicationQueryService` and added the guard after `searchObjectsPaginated`.

## Test plan

- [ ] Anonymous GET `/api/federation/publications` — only published objects appear
- [ ] Anonymous GET `/api/federation/publications/{id}` for an unpublished object → 404
- [ ] Anonymous GET `/api/federation/publications/{id}/attachments` for unpublished → 404
- [ ] Anonymous GET `/api/federation/publications/{id}/download` for unpublished → 404
- [ ] Anonymous GET `/api/catalogi` — only published catalog objects appear
- [ ] Authenticated user sees all objects (RBAC-scoped) unchanged
- [ ] `php ./vendor/bin/phpcs --standard=phpcs.xml lib/Controller/CatalogiController.php lib/Service/PublicationService.php` — 0 errors