### PR TITLE
fix(security): enforce published predicate and SSRF guards on sitemap/broadcast/directory paths

### DIFF
--- a/lib/Controller/GlossaryController.php
+++ b/lib/Controller/GlossaryController.php
@@ -24,6 +24,7 @@
 
 namespace OCA\OpenCatalogi\Controller;
 
+use OCA\OpenCatalogi\Service\PublicationQueryService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\Http\Response;
@@ -75,15 +76,16 @@ class GlossaryController extends Controller
     /**
      * GlossaryController constructor.
      *
-     * @param string             $appName            The name of the app
-     * @param IRequest           $request            The request object
-     * @param IAppConfig         $config             App configuration interface
-     * @param ContainerInterface $container          Server container for dependency injection
-     * @param IAppManager        $appManager         App manager for checking installed apps
-     * @param IL10N              $l10n               Localization service
-     * @param string             $corsMethods        Allowed CORS methods
-     * @param string             $corsAllowedHeaders Allowed CORS headers
-     * @param integer            $corsMaxAge         CORS max age
+     * @param string                  $appName            The name of the app
+     * @param IRequest                $request            The request object
+     * @param IAppConfig              $config             App configuration interface
+     * @param ContainerInterface      $container          Server container for dependency injection
+     * @param IAppManager             $appManager         App manager for checking installed apps
+     * @param IL10N                   $l10n               Localization service
+     * @param PublicationQueryService $queryService       Publication query/visibility helper
+     * @param string                  $corsMethods        Allowed CORS methods
+     * @param string                  $corsAllowedHeaders Allowed CORS headers
+     * @param integer                 $corsMaxAge         CORS max age
      */
     public function __construct(
         $appName,
@@ -92,6 +94,7 @@ class GlossaryController extends Controller
         private readonly ContainerInterface $container,
         private readonly IAppManager $appManager,
         private readonly IL10N $l10n,
+        private readonly PublicationQueryService $queryService,
         string $corsMethods='PUT, POST, GET, DELETE, PATCH',
         string $corsAllowedHeaders='Authorization, Content-Type, Accept',
         int $corsMaxAge=1728000
@@ -238,8 +241,11 @@ class GlossaryController extends Controller
         $searchQuery['_source'] = 'database';
 
         // Use searchObjectsPaginated for better performance and pagination support.
-        // Set rbac=false, multi=false for public glossary access.
-        $result = $this->getObjectService()->searchObjectsPaginated($searchQuery, _rbac: false, _multitenancy: false);
+        // rbac=true enforces schema authorization; multi=false for public glossary access.
+        $result = $this->getObjectService()->searchObjectsPaginated($searchQuery, _rbac: true, _multitenancy: false);
+
+        // Enforce server-side published predicate for anonymous callers.
+        $result = $this->queryService->enforcePublishedForAnonymous($result);
 
         // Build paginated response structure.
         $responseData = [
@@ -307,13 +313,26 @@ class GlossaryController extends Controller
             '_limit'  => 1,
             '_source' => 'database',
         ];
-        $result      = $this->getObjectService()->searchObjectsPaginated($searchQuery, _rbac: false, _multitenancy: false);
+        $result      = $this->getObjectService()->searchObjectsPaginated($searchQuery, _rbac: true, _multitenancy: false);
 
         if (empty($result['results']) === true) {
             return new JSONResponse(['error' => $this->l10n->t('Glossary term not found')], 404);
         }
 
         $glossaryTerm = $result['results'][0];
+
+        // Enforce published predicate for anonymous callers on single-item lookup.
+        if (is_array($glossaryTerm) === true) {
+            $termArray = $glossaryTerm;
+        } else {
+            $termArray = $glossaryTerm->jsonSerialize();
+        }
+
+        if ($this->queryService->isAnonymous() === true
+            && $this->queryService->isObjectPublic($termArray) === false
+        ) {
+            return new JSONResponse(['error' => $this->l10n->t('Glossary term not found')], 404);
+        }
 
         $data = $glossaryTerm;
         if ($glossaryTerm instanceof \OCP\AppFramework\Db\Entity) {

--- a/lib/Controller/MenusController.php
+++ b/lib/Controller/MenusController.php
@@ -24,6 +24,7 @@
 
 namespace OCA\OpenCatalogi\Controller;
 
+use OCA\OpenCatalogi\Service\PublicationQueryService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\Http\Response;
@@ -66,15 +67,16 @@ class MenusController extends Controller
     /**
      * MenusController constructor.
      *
-     * @param string             $appName            The name of the app.
-     * @param IRequest           $request            The request object.
-     * @param IAppConfig         $config             App configuration interface.
-     * @param ContainerInterface $container          Server container for DI.
-     * @param IAppManager        $appManager         App manager.
-     * @param IL10N              $l10n               The localization service.
-     * @param string             $corsMethods        Allowed CORS methods.
-     * @param string             $corsAllowedHeaders Allowed CORS headers.
-     * @param integer            $corsMaxAge         CORS max age.
+     * @param string                  $appName            The name of the app.
+     * @param IRequest                $request            The request object.
+     * @param IAppConfig              $config             App configuration interface.
+     * @param ContainerInterface      $container          Server container for DI.
+     * @param IAppManager             $appManager         App manager.
+     * @param IL10N                   $l10n               The localization service.
+     * @param PublicationQueryService $queryService       Publication query/visibility helper.
+     * @param string                  $corsMethods        Allowed CORS methods.
+     * @param string                  $corsAllowedHeaders Allowed CORS headers.
+     * @param integer                 $corsMaxAge         CORS max age.
      */
     public function __construct(
         $appName,
@@ -83,6 +85,7 @@ class MenusController extends Controller
         private readonly ContainerInterface $container,
         private readonly IAppManager $appManager,
         private readonly IL10N $l10n,
+        private readonly PublicationQueryService $queryService,
         string $corsMethods='PUT, POST, GET, DELETE, PATCH',
         string $corsAllowedHeaders='Authorization, Content-Type, Accept',
         int $corsMaxAge=1728000
@@ -227,11 +230,15 @@ class MenusController extends Controller
         }
 
         // Use searchObjectsPaginated for better performance and pagination support.
+        // Rbac=true enforces schema authorization; multi=false for public menu access.
         $result = $this->getObjectService()->searchObjectsPaginated(
             $searchQuery,
-            _rbac: false,
+            _rbac: true,
             _multitenancy: false
         );
+
+        // Enforce server-side published predicate for anonymous callers.
+        $result = $this->queryService->enforcePublishedForAnonymous($result);
 
         // Add CORS headers for public API access.
         $response = new JSONResponse($result);
@@ -266,9 +273,10 @@ class MenusController extends Controller
             '_limit'  => 1,
             '_source' => 'database',
         ];
-        $result      = $this->getObjectService()->searchObjectsPaginated(
+        // Rbac=true enforces schema authorization; multi=false for public menu access.
+        $result = $this->getObjectService()->searchObjectsPaginated(
             $searchQuery,
-            _rbac: false,
+            _rbac: true,
             _multitenancy: false
         );
 
@@ -277,6 +285,19 @@ class MenusController extends Controller
         }
 
         $menu = $result['results'][0];
+
+        // Enforce published predicate for anonymous callers on single-item lookup.
+        if (is_array($menu) === true) {
+            $menuArray = $menu;
+        } else {
+            $menuArray = $menu->jsonSerialize();
+        }
+
+        if ($this->queryService->isAnonymous() === true
+            && $this->queryService->isObjectPublic($menuArray) === false
+        ) {
+            return new JSONResponse(data: ['error' => $this->l10n->t('Menu not found')], statusCode: 404);
+        }
 
         $data = $menu;
         if ($menu instanceof \OCP\AppFramework\Db\Entity) {

--- a/lib/Controller/PagesController.php
+++ b/lib/Controller/PagesController.php
@@ -24,6 +24,7 @@
 
 namespace OCA\OpenCatalogi\Controller;
 
+use OCA\OpenCatalogi\Service\PublicationQueryService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\Http\Response;
@@ -76,15 +77,16 @@ class PagesController extends Controller
     /**
      * PagesController constructor.
      *
-     * @param string             $appName            The name of the app
-     * @param IRequest           $request            The request object
-     * @param IAppConfig         $config             App configuration interface
-     * @param ContainerInterface $container          Server container for dependency injection
-     * @param IAppManager        $appManager         App manager for checking installed apps
-     * @param IL10N              $l10n               Localization service
-     * @param string             $corsMethods        Allowed CORS methods
-     * @param string             $corsAllowedHeaders Allowed CORS headers
-     * @param integer            $corsMaxAge         CORS max age
+     * @param string                  $appName            The name of the app
+     * @param IRequest                $request            The request object
+     * @param IAppConfig              $config             App configuration interface
+     * @param ContainerInterface      $container          Server container for dependency injection
+     * @param IAppManager             $appManager         App manager for checking installed apps
+     * @param IL10N                   $l10n               Localization service
+     * @param PublicationQueryService $queryService       Publication query/visibility helper
+     * @param string                  $corsMethods        Allowed CORS methods
+     * @param string                  $corsAllowedHeaders Allowed CORS headers
+     * @param integer                 $corsMaxAge         CORS max age
      */
     public function __construct(
         $appName,
@@ -93,6 +95,7 @@ class PagesController extends Controller
         private readonly ContainerInterface $container,
         private readonly IAppManager $appManager,
         private readonly IL10N $l10n,
+        private readonly PublicationQueryService $queryService,
         string $corsMethods='PUT, POST, GET, DELETE, PATCH',
         string $corsAllowedHeaders='Authorization, Content-Type, Accept',
         int $corsMaxAge=1728000
@@ -233,8 +236,11 @@ class PagesController extends Controller
         }
 
         // Use searchObjectsPaginated for better performance and pagination support.
-        // Set rbac=false and multi=false for public page access.
-        $result = $this->getObjectService()->searchObjectsPaginated($searchQuery, _rbac: false, _multitenancy: false);
+        // Rbac=true enforces schema authorization; multi=false for public page access.
+        $result = $this->getObjectService()->searchObjectsPaginated($searchQuery, _rbac: true, _multitenancy: false);
+
+        // Enforce server-side published predicate for anonymous callers.
+        $result = $this->queryService->enforcePublishedForAnonymous($result);
 
         // Add CORS headers for public API access (#735 — never reflect arbitrary Origin).
         $response = new JSONResponse($result);
@@ -283,17 +289,27 @@ class PagesController extends Controller
         }
 
         // Use searchObjectsPaginated for better performance.
-        // Set rbac=false and multi=false as schema authorization handles access.
-        $result = $this->getObjectService()->searchObjectsPaginated($searchQuery, _rbac: false, _multitenancy: false);
+        // Rbac=true enforces schema authorization; multi=false for public page access.
+        $result = $this->getObjectService()->searchObjectsPaginated($searchQuery, _rbac: true, _multitenancy: false);
 
         if (empty($result['results']) === true) {
             $response = new JSONResponse(['error' => $this->l10n->t('Page not found')], 404);
-        }
+        } else {
+            // Return the first matching page; enforce published predicate for anonymous callers.
+            $page = $result['results'][0];
+            if (is_array($page) === true) {
+                $pageArray = $page;
+            } else {
+                $pageArray = $page->jsonSerialize();
+            }
 
-        if (empty($result['results']) === false) {
-            // Return the first matching page.
-            $page     = $result['results'][0];
-            $response = new JSONResponse($page);
+            if ($this->queryService->isAnonymous() === true
+                && $this->queryService->isObjectPublic($pageArray) === false
+            ) {
+                $response = new JSONResponse(['error' => $this->l10n->t('Page not found')], 404);
+            } else {
+                $response = new JSONResponse($page);
+            }
         }
 
         // Add CORS headers for public API access (#735 — never reflect arbitrary Origin).

--- a/lib/Controller/RobotsController.php
+++ b/lib/Controller/RobotsController.php
@@ -23,8 +23,10 @@
 
 namespace OCA\OpenCatalogi\Controller;
 
-use OCA\OpenCatalogi\Service\SettingsService;
 use OCA\OpenCatalogi\Http\TextResponse;
+use OCA\OpenCatalogi\Service\PublicationQueryService;
+use OCA\OpenCatalogi\Service\SettingsService;
+use OCA\OpenCatalogi\Service\SitemapService;
 use OCP\AppFramework\Controller;
 use OCP\IL10N;
 use OCP\IRequest;
@@ -33,7 +35,6 @@ use OCP\IURLGenerator;
 use Psr\Container\ContainerInterface;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\NotFoundExceptionInterface;
-use OCA\OpenCatalogi\Service\SitemapService;
 use RuntimeException;
 
 /**
@@ -54,13 +55,14 @@ class RobotsController extends Controller
     /**
      * RobotsController constructor.
      *
-     * @param string             $appName         The name of the app.
-     * @param IRequest           $request         The request object.
-     * @param SettingsService    $settingsService The settings service.
-     * @param ContainerInterface $container       The container for DI.
-     * @param IAppManager        $appManager      The app manager.
-     * @param IURLGenerator      $urlGenerator    The URL generator.
-     * @param IL10N              $l10n            The localization service.
+     * @param string                  $appName         The name of the app.
+     * @param IRequest                $request         The request object.
+     * @param SettingsService         $settingsService The settings service.
+     * @param ContainerInterface      $container       The container for DI.
+     * @param IAppManager             $appManager      The app manager.
+     * @param IURLGenerator           $urlGenerator    The URL generator.
+     * @param IL10N                   $l10n            The localization service.
+     * @param PublicationQueryService $queryService    Publication query/visibility helper.
      */
     public function __construct(
         $appName,
@@ -70,6 +72,7 @@ class RobotsController extends Controller
         private readonly IAppManager $appManager,
         private readonly IURLGenerator $urlGenerator,
         private readonly IL10N $l10n,
+        private readonly PublicationQueryService $queryService,
     ) {
         parent::__construct(appName: $appName, request: $request);
 
@@ -102,12 +105,17 @@ class RobotsController extends Controller
         $searchQuery['@self']['register'] = $settings['configuration']['catalog_register'];
         $searchQuery['@self']['schema']   = $settings['configuration']['catalog_schema'];
 
-        $catalogs = ($this->getObjectService()->searchObjectsPaginated(
+        // Rbac=true enforces schema authorization; multi=false for public robots.txt.
+        $catalogResult = $this->getObjectService()->searchObjectsPaginated(
             query: $searchQuery,
-            _rbac: false,
+            _rbac: true,
             _multitenancy: false,
             deleted: false
-        )['results'] ?? []);
+        );
+
+        // Enforce published predicate: robots.txt should only reference public catalogs.
+        $catalogResult = $this->queryService->enforcePublishedForAnonymous($catalogResult);
+        $catalogs      = ($catalogResult['results'] ?? []);
 
         $baseUrl = rtrim($this->urlGenerator->getBaseUrl(), '/');
 

--- a/lib/Controller/ThemesController.php
+++ b/lib/Controller/ThemesController.php
@@ -24,6 +24,7 @@
 
 namespace OCA\OpenCatalogi\Controller;
 
+use OCA\OpenCatalogi\Service\PublicationQueryService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\Http\Response;
@@ -65,14 +66,15 @@ class ThemesController extends Controller
     /**
      * ThemesController constructor.
      *
-     * @param string             $appName            The name of the app.
-     * @param IRequest           $request            The request object.
-     * @param IAppConfig         $config             App configuration interface.
-     * @param ContainerInterface $container          Server container for DI.
-     * @param IAppManager        $appManager         App manager.
-     * @param string             $corsMethods        Allowed CORS methods.
-     * @param string             $corsAllowedHeaders Allowed CORS headers.
-     * @param integer            $corsMaxAge         CORS max age.
+     * @param string                  $appName            The name of the app.
+     * @param IRequest                $request            The request object.
+     * @param IAppConfig              $config             App configuration interface.
+     * @param ContainerInterface      $container          Server container for DI.
+     * @param IAppManager             $appManager         App manager.
+     * @param PublicationQueryService $queryService       Publication query/visibility helper.
+     * @param string                  $corsMethods        Allowed CORS methods.
+     * @param string                  $corsAllowedHeaders Allowed CORS headers.
+     * @param integer                 $corsMaxAge         CORS max age.
      */
     public function __construct(
         $appName,
@@ -80,6 +82,7 @@ class ThemesController extends Controller
         private readonly IAppConfig $config,
         private readonly ContainerInterface $container,
         private readonly IAppManager $appManager,
+        private readonly PublicationQueryService $queryService,
         string $corsMethods='PUT, POST, GET, DELETE, PATCH',
         string $corsAllowedHeaders='Authorization, Content-Type, Accept',
         int $corsMaxAge=1728000
@@ -225,11 +228,15 @@ class ThemesController extends Controller
         }
 
         // Use searchObjectsPaginated for better performance and pagination support.
+        // rbac=true enforces schema authorization; multi=false for public theme access.
         $result = $this->getObjectService()->searchObjectsPaginated(
             $searchQuery,
-            _rbac: false,
+            _rbac: true,
             _multitenancy: false
         );
+
+        // Enforce server-side published predicate for anonymous callers.
+        $result = $this->queryService->enforcePublishedForAnonymous($result);
 
         // Build paginated response structure.
         $responseData = [
@@ -292,8 +299,21 @@ class ThemesController extends Controller
      */
     public function show(string|int $id): JSONResponse
     {
-        // Set _rbac=false, _multitenancy=false for public theme access.
-        $theme = $this->getObjectService()->find($id, _rbac: false, _multitenancy: false);
+        // Rbac=true enforces schema authorization; multi=false for public theme access.
+        $theme = $this->getObjectService()->find($id, _rbac: true, _multitenancy: false);
+
+        // Enforce published predicate for anonymous callers on single-item lookup.
+        if (is_array($theme) === true) {
+            $themeArray = $theme;
+        } else {
+            $themeArray = $theme->jsonSerialize();
+        }
+
+        if ($this->queryService->isAnonymous() === true
+            && $this->queryService->isObjectPublic($themeArray) === false
+        ) {
+            return new JSONResponse(['error' => 'Not found'], 404);
+        }
 
         $data = $theme;
         if ($theme instanceof \OCP\AppFramework\Db\Entity) {

--- a/lib/Service/BroadcastService.php
+++ b/lib/Service/BroadcastService.php
@@ -342,6 +342,15 @@ class BroadcastService
                 continue;
             }
 
+            // Validate outbound URL before broadcasting — rejects private/internal addresses.
+            try {
+                $this->assertSafeOutboundUrl($targetUrl);
+            } catch (InvalidArgumentException $e) {
+                $this->logger->warning("Skipping unsafe broadcast target: {$targetUrl}");
+                $results[$targetUrl] = false;
+                continue;
+            }
+
             // Attempt to send broadcast request.
             $success = $this->sendBroadcastRequest($targetUrl, $directoryUrl);
             $results[$targetUrl] = $success;
@@ -355,4 +364,155 @@ class BroadcastService
         return $results;
 
     }//end broadcast()
+
+    /**
+     * Assert that a URL is safe for outbound HTTP requests.
+     *
+     * Performs DNS resolution and rejects URLs that resolve to private/loopback
+     * address ranges to prevent SSRF attacks.
+     *
+     * @param string $url The URL to validate.
+     *
+     * @return void
+     *
+     * @throws InvalidArgumentException When the URL or its resolved host is not safe.
+     */
+    private function assertSafeOutboundUrl(string $url): void
+    {
+        $parsed = parse_url($url);
+        if ($parsed === false || isset($parsed['scheme']) === false || isset($parsed['host']) === false) {
+            throw new InvalidArgumentException('Invalid broadcast URL provided');
+        }
+
+        $scheme = strtolower($parsed['scheme']);
+        if (in_array($scheme, ['http', 'https'], true) === false) {
+            throw new InvalidArgumentException('Broadcast URL scheme must be http or https');
+        }
+
+        $host = strtolower($parsed['host']);
+
+        // Reject obvious local hostnames outright.
+        if ($host === 'localhost' || str_ends_with($host, '.local') === true
+            || str_ends_with($host, '.localhost') === true
+        ) {
+            throw new InvalidArgumentException('Broadcast URL host is not allowed');
+        }
+
+        // Collect IPs to check: literal IP or DNS-resolved addresses.
+        $ipsToCheck = [];
+        if (filter_var($host, FILTER_VALIDATE_IP) !== false) {
+            $ipsToCheck[] = $host;
+        } else {
+            $lookupHost = trim($host, '[]');
+            if (filter_var($lookupHost, FILTER_VALIDATE_IP) !== false) {
+                $ipsToCheck[] = $lookupHost;
+            } else {
+                $records = @dns_get_record($lookupHost, (DNS_A | DNS_AAAA));
+                if ($records !== false) {
+                    foreach ($records as $record) {
+                        if (isset($record['ip']) === true) {
+                            $ipsToCheck[] = $record['ip'];
+                        }
+
+                        if (isset($record['ipv6']) === true) {
+                            $ipsToCheck[] = $record['ipv6'];
+                        }
+                    }
+                }
+
+                if (empty($ipsToCheck) === true) {
+                    $resolved = gethostbyname($lookupHost);
+                    if ($resolved !== $lookupHost && filter_var($resolved, FILTER_VALIDATE_IP) !== false) {
+                        $ipsToCheck[] = $resolved;
+                    }
+                }
+            }//end if
+        }//end if
+
+        if (empty($ipsToCheck) === true) {
+            throw new InvalidArgumentException('Broadcast URL host could not be resolved');
+        }
+
+        foreach ($ipsToCheck as $ip) {
+            if ($this->isBlockedIp($ip) === true) {
+                throw new InvalidArgumentException('Broadcast URL resolves to a disallowed (internal) address');
+            }
+        }
+
+    }//end assertSafeOutboundUrl()
+
+    /**
+     * Determine whether an IP address falls in a blocked range.
+     *
+     * Checks private, loopback, link-local, and reserved ranges.
+     *
+     * @param string $ip The IP address to check.
+     *
+     * @return boolean True if the IP is blocked, false if it is safe.
+     */
+    private function isBlockedIp(string $ip): bool
+    {
+        $blockedRanges = [
+            '10.0.0.0/8',
+            '172.16.0.0/12',
+            '192.168.0.0/16',
+            '127.0.0.0/8',
+            '169.254.0.0/16',
+            '::1/128',
+            'fc00::/7',
+            'fe80::/10',
+        ];
+
+        foreach ($blockedRanges as $range) {
+            if ($this->ipInRange($ip, $range) === true) {
+                return true;
+            }
+        }
+
+        return false;
+
+    }//end isBlockedIp()
+
+    /**
+     * Check if an IP address falls within a CIDR range.
+     *
+     * @param string $ip    The IP address to check.
+     * @param string $range The CIDR range (e.g. 10.0.0.0/8).
+     *
+     * @return boolean True if the IP is in the range, false otherwise.
+     */
+    private function ipInRange(string $ip, string $range): bool
+    {
+        [$subnet, $bits] = explode('/', $range);
+
+        if (filter_var(value: $ip, filter: FILTER_VALIDATE_IP, options: FILTER_FLAG_IPV6) !== false
+            && filter_var(value: $subnet, filter: FILTER_VALIDATE_IP, options: FILTER_FLAG_IPV6) !== false
+        ) {
+            $ipBin     = inet_pton($ip);
+            $subnetBin = inet_pton($subnet);
+            if ($ipBin === false || $subnetBin === false) {
+                return false;
+            }
+
+            $mask = str_repeat("\xff", (int) ($bits / 8));
+            if (((int) $bits % 8) !== 0) {
+                $mask .= chr(0xff & (0xff << (8 - ((int) $bits % 8))));
+            }
+
+            $mask = str_pad($mask, 16, "\x00");
+            return (($ipBin & $mask) === ($subnetBin & $mask));
+        }//end if
+
+        if (filter_var(value: $ip, filter: FILTER_VALIDATE_IP, options: FILTER_FLAG_IPV4) !== false
+            && filter_var(value: $subnet, filter: FILTER_VALIDATE_IP, options: FILTER_FLAG_IPV4) !== false
+        ) {
+            $ipLong     = ip2long($ip);
+            $subnetLong = ip2long($subnet);
+            $maskLong   = (~0 << (32 - (int) $bits));
+            return (($ipLong & $maskLong) === ($subnetLong & $maskLong));
+        }
+
+        return false;
+
+    }//end ipInRange()
 }//end class

--- a/lib/Service/CatalogiService.php
+++ b/lib/Service/CatalogiService.php
@@ -527,7 +527,7 @@ class CatalogiService
                 '_limit'    => 1,
             ];
 
-            $catalogs = $this->getObjectService()->searchObjects(query: $query, _rbac: false, _multitenancy: false);
+            $catalogs = $this->getObjectService()->searchObjects(query: $query, _rbac: true, _multitenancy: false);
 
             if (empty($catalogs) === true) {
                 $this->logger->error(
@@ -542,6 +542,13 @@ class CatalogiService
             }
 
             $catalog = $catalogs[0]->jsonSerialize();
+
+            // Enforce published predicate: anonymous callers may not see unpublished catalogs.
+            if ($this->getQueryService()->isAnonymous() === true
+                && $this->getQueryService()->isObjectPublic($catalog) === false
+            ) {
+                return null;
+            }
 
             // Step 3: Store in cache (TTL: 1 hour = 3600 seconds).
             $this->cache->set($cacheKey, $catalog, 3600);

--- a/lib/Service/DirectoryService.php
+++ b/lib/Service/DirectoryService.php
@@ -932,14 +932,15 @@ class DirectoryService
 
         // Create promises for each directory.
         foreach ($directories as $index => $directoryUrl) {
-            // Skip our own directory and local URLs.
+            // Skip our own directory.
             if ($directoryUrl === $ourDirectoryUrl) {
-                // Removed redundant logging.
                 continue;
             }
 
-            if ($this->isLocalUrl($directoryUrl) === true) {
-                // Removed redundant logging.
+            // Skip local/unsafe URLs — assertSafeOutboundUrl performs DNS resolution.
+            try {
+                $this->assertSafeOutboundUrl($directoryUrl);
+            } catch (InvalidArgumentException $e) {
                 continue;
             }
 
@@ -1747,8 +1748,15 @@ class DirectoryService
 
         // Create promises for each directory.
         foreach ($directories as $index => $directoryUrl) {
-            // Skip our own directory and local URLs.
-            if ($directoryUrl === $ourDirectoryUrl || $this->isLocalUrl($directoryUrl) === true) {
+            // Skip our own directory.
+            if ($directoryUrl === $ourDirectoryUrl) {
+                continue;
+            }
+
+            // Skip local/unsafe URLs — assertSafeOutboundUrl performs DNS resolution.
+            try {
+                $this->assertSafeOutboundUrl($directoryUrl);
+            } catch (InvalidArgumentException $e) {
                 continue;
             }
 
@@ -1902,8 +1910,15 @@ class DirectoryService
 
         // Create promises for each directory.
         foreach ($directories as $index => $directoryUrl) {
-            // Skip our own directory and local URLs.
-            if ($directoryUrl === $ourDirectoryUrl || $this->isLocalUrl($directoryUrl) === true) {
+            // Skip our own directory.
+            if ($directoryUrl === $ourDirectoryUrl) {
+                continue;
+            }
+
+            // Skip local/unsafe URLs — assertSafeOutboundUrl performs DNS resolution.
+            try {
+                $this->assertSafeOutboundUrl($directoryUrl);
+            } catch (InvalidArgumentException $e) {
                 continue;
             }
 

--- a/lib/Service/SitemapService.php
+++ b/lib/Service/SitemapService.php
@@ -29,6 +29,7 @@ namespace OCA\OpenCatalogi\Service;
 
 use OCP\App\IAppManager;
 use OCA\OpenCatalogi\Http\XMLResponse;
+use OCA\OpenCatalogi\Service\PublicationQueryService;
 use Psr\Container\ContainerInterface;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\NotFoundExceptionInterface;
@@ -70,16 +71,18 @@ class SitemapService
     /**
      * Constructor for SitemapService.
      *
-     * @param ContainerInterface $container       Server container for dependency injection
-     * @param IAppManager        $appManager      App manager for checking installed apps
-     * @param SettingsService    $settingsService The settings service
-     * @param IURLGenerator      $urlGenerator    The Nextcloud URL generator
+     * @param ContainerInterface      $container       Server container for dependency injection
+     * @param IAppManager             $appManager      App manager for checking installed apps
+     * @param SettingsService         $settingsService The settings service
+     * @param IURLGenerator           $urlGenerator    The Nextcloud URL generator
+     * @param PublicationQueryService $queryService    Publication query/visibility helper
      */
     public function __construct(
         private readonly ContainerInterface $container,
         private readonly IAppManager $appManager,
         private readonly SettingsService $settingsService,
         private readonly IURLGenerator $urlGenerator,
+        private readonly PublicationQueryService $queryService,
     ) {
 
     }//end __construct()
@@ -159,10 +162,13 @@ class SitemapService
         // First call: only to retrieve total publications count.
         $firstPage = $objectService->searchObjectsPaginated(
             query: $searchQuery,
-            _rbac: false,
+            _rbac: true,
             _multitenancy: false,
             deleted: false
         );
+
+        // Enforce published predicate: sitemaps expose only public publications.
+        $firstPage = $this->queryService->enforcePublishedForAnonymous($firstPage);
 
         $baseUrl = rtrim($this->urlGenerator->getBaseUrl(), '/');
 
@@ -199,11 +205,13 @@ class SitemapService
 
             $batch = $objectService->searchObjectsPaginated(
                 query: $searchQuery,
-                _rbac: false,
+                _rbac: true,
                 _multitenancy: false,
                 deleted: false
             );
 
+            // Enforce published predicate for each paginated batch.
+            $batch   = $this->queryService->enforcePublishedForAnonymous($batch);
             $next    = $batch['next'] ?? null;
             $results = ($batch['results'] ?? []);
 
@@ -268,12 +276,16 @@ class SitemapService
         $searchQuery['_limit']            = $this::MAX_PER_PAGE;
         $searchQuery['_page'] = $page;
 
-        $publications = ($objectService->searchObjectsPaginated(
+        $publicationResult = $objectService->searchObjectsPaginated(
             query: $searchQuery,
-            _rbac: false,
+            _rbac: true,
             _multitenancy: false,
             deleted: false
-        )['results'] ?? []);
+        );
+
+        // Enforce published predicate: sitemaps expose only public publications.
+        $publicationResult = $this->queryService->enforcePublishedForAnonymous($publicationResult);
+        $publications      = ($publicationResult['results'] ?? []);
 
         $fileService = $this->getFileService();
 
@@ -406,12 +418,16 @@ class SitemapService
             'hasWooSitemap' => true,
         ];
 
-        $catalog = ($objectService->searchObjectsPaginated(
+        $catalogResult = $objectService->searchObjectsPaginated(
             query: $searchQuery,
-            _rbac: false,
+            _rbac: true,
             _multitenancy: false,
             deleted: false
-        )['results'][0] ?? []);
+        );
+
+        // Enforce published predicate: sitemap catalog must be public.
+        $catalogResult = $this->queryService->enforcePublishedForAnonymous($catalogResult);
+        $catalog       = ($catalogResult['results'][0] ?? []);
 
         if (empty($catalog) === true) {
             return new XMLResponse('Invalid Woo catalog', 400);


### PR DESCRIPTION
## Changes

**H1 - _rbac:false sweep (6 public-data paths)**
- GlossaryController, ThemesController, PagesController, MenusController, RobotsController: switched _rbac:false to _rbac:true on all searchObjectsPaginated calls; added PublicationQueryService injection; apply enforcePublishedForAnonymous on list results and per-item isObjectPublic check on single-item lookups.
- SitemapService: same switch on all 4 searchObjectsPaginated calls; apply enforcePublishedForAnonymous on each result set.

**H4 - SSRF via isLocalUrl (no DNS)**
- DirectoryService::getPublications, getUsed, getPublication: replaced isLocalUrl guards with assertSafeOutboundUrl (DNS-resolving) wrapped in try/catch(InvalidArgumentException).
- BroadcastService::broadcast: added SSRF validation before each outbound POST using a private assertSafeOutboundUrl + isBlockedIp + ipInRange implementation.

**M1 - getCatalogBySlug anonymous bypass**
- CatalogiService::getCatalogBySlug: switched to _rbac:true; added isAnonymous() + isObjectPublic() guard.

## Test plan
- Anonymous GET /api/{catalogSlug}/sitemaps/{code} returns only published publications
- Anonymous GET /api/glossary, /api/themes, /api/pages, /api/menus return only published objects
- broadcast() with a private-IP target is skipped
- getPublications/getUsed/getPublication skip directories resolving to RFC-1918 addresses
- phpcs passes with 0 errors on all modified files