### PR TITLE
fix(security): bump twig/twig to ^3.27.0 (CVE-2026-48805/06/07/08, CVE-2026-46636)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -68,7 +68,8 @@
 		"react/promise": "^3.0",
 		"symfony/process": "^6.4.33",
 		"symfony/twig-bundle": "^6.4",
-		"symfony/uid": "^6.4"
+		"symfony/uid": "^6.4",
+		"twig/twig": "^3.27.0"
 	},
 	"require-dev": {
 		"cyclonedx/cyclonedx-php-composer": "^6.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c710358ed1805aecf5353731ba7562cf",
+    "content-hash": "cef4caf2465c1ca6625197fb00cfea62",
     "packages": [
         {
             "name": "adbario/php-dot-notation",
@@ -3245,16 +3245,16 @@
         },
         {
             "name": "twig/twig",
-            "version": "v3.26.0",
+            "version": "v3.27.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "1fcae487b180d78e6351f4e0afa91f9eab96a2bc"
+                "reference": "04ae1bfe9463c816cf72ca0abe7eae2c77a9a9ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/1fcae487b180d78e6351f4e0afa91f9eab96a2bc",
-                "reference": "1fcae487b180d78e6351f4e0afa91f9eab96a2bc",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/04ae1bfe9463c816cf72ca0abe7eae2c77a9a9ed",
+                "reference": "04ae1bfe9463c816cf72ca0abe7eae2c77a9a9ed",
                 "shasum": ""
             },
             "require": {
@@ -3309,7 +3309,7 @@
             ],
             "support": {
                 "issues": "https://github.com/twigphp/Twig/issues",
-                "source": "https://github.com/twigphp/Twig/tree/v3.26.0"
+                "source": "https://github.com/twigphp/Twig/tree/v3.27.0"
             },
             "funding": [
                 {
@@ -3321,7 +3321,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-20T07:31:59+00:00"
+            "time": "2026-05-27T13:05:51+00:00"
         }
     ],
     "packages-dev": [
@@ -9200,16 +9200,16 @@
         },
         {
             "name": "symfony/polyfill-php81",
-            "version": "v1.37.0",
+            "version": "v1.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php81.git",
-                "reference": "4a4cfc2d253c21a5ad0e53071df248ed48c6ce5c"
+                "reference": "6bfb9c766cacffbc8e118cb87217d08ed84e5cd7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php81/zipball/4a4cfc2d253c21a5ad0e53071df248ed48c6ce5c",
-                "reference": "4a4cfc2d253c21a5ad0e53071df248ed48c6ce5c",
+                "url": "https://api.github.com/repos/symfony/polyfill-php81/zipball/6bfb9c766cacffbc8e118cb87217d08ed84e5cd7",
+                "reference": "6bfb9c766cacffbc8e118cb87217d08ed84e5cd7",
                 "shasum": ""
             },
             "require": {
@@ -9256,7 +9256,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php81/tree/v1.37.0"
+                "source": "https://github.com/symfony/polyfill-php81/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -9276,7 +9276,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2026-05-26T12:45:58+00:00"
         },
         {
             "name": "symfony/string",

--- a/lib/Service/BroadcastService.php
+++ b/lib/Service/BroadcastService.php
@@ -513,7 +513,7 @@ class BroadcastService
                 return false;
             }
 
-            $mask = str_repeat("\xff", (int) ($bits / 8));
+            $mask = str_repeat("\xff", (int) $bits / 8);
             if (((int) $bits % 8) !== 0) {
                 $mask .= chr(0xff & (0xff << (8 - ((int) $bits % 8))));
             }


### PR DESCRIPTION
## Summary

- Bumps `twig/twig` from `v3.26.0` to `^3.27.0` to fix **5 sandbox bypass CVEs** reported 2026-05-27
- Adds explicit `"twig/twig": "^3.27.0"` to `require` in `composer.json` to prevent future installs resolving a vulnerable version
- Fixes pre-existing PHPStan error in `BroadcastService::ipInRange` (binary `/` on `string` type)

## CVEs addressed

| CVE | Title |
|-----|-------|
| CVE-2026-48805 | Sandbox state regression in deprecated internal wrappers in `src/Resources/core.php` |
| CVE-2026-48806 | Sandbox `__toString()` policy bypass via dynamic mapping keys |
| CVE-2026-48807 | Sandbox `__toString()` policy bypass via `Traversable` in `join`/`replace` and `in`/`not in` operators |
| CVE-2026-48808 | Sandbox property allowlist bypass via the `column` filter under `SourcePolicyInterface` |
| CVE-2026-46636 | Sandbox filter, tag and function allow-list bypass when sandbox state changes between renders |

## Direct vs transitive

`twig/twig` was **transitive** (pulled in by `symfony/twig-bundle` and `symfony/twig-bridge`). An explicit `^3.27.0` constraint is now added to `require` to pin the minimum safe version.

## Verification

- `composer audit` → **No security vulnerability advisories found**
- `phpstan analyse` → **No errors**
- `phpcs` → **0 errors** (pre-existing `@spec` warnings only, unrelated)