### PR TITLE
fix(psalm): resolve strict check failures and add check:strict script

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,6 +49,7 @@
 		"phpqa": "./vendor/bin/phpqa --report --analyzedDirs lib --buildDir phpqa",
 		"phpqa:full": "./vendor/bin/phpqa --report --analyzedDirs lib --buildDir phpqa --tools phpcs:0,phpmd:0,phploc:0,phpmetrics,phpcpd:0,parallel-lint:0",
 		"phpqa:ci": "./vendor/bin/phpqa --report --analyzedDirs lib --buildDir phpqa --tools phpcs,phpmd,phploc,phpmetrics,phpcpd,parallel-lint",
+		"check:strict": "E=0; for CMD in lint phpcs phpmd psalm phpstan test:all; do echo; echo \"=== $CMD ===\"; composer $CMD || E=1; done; echo; if [ $E -eq 0 ]; then echo \"ALL CHECKS PASSED\"; else echo \"SOME CHECKS FAILED (see above)\"; fi; exit $E",
 		"qa:check": [
 			"@phpqa"
 		],

--- a/lib/Service/BroadcastService.php
+++ b/lib/Service/BroadcastService.php
@@ -513,7 +513,7 @@ class BroadcastService
                 return false;
             }
 
-            $mask = str_repeat("\xff", (int) $bits / 8);
+            $mask = str_repeat("\xff", intdiv((int) $bits, 8));
             if (((int) $bits % 8) !== 0) {
                 $mask .= chr(0xff & (0xff << (8 - ((int) $bits % 8))));
             }

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -6,11 +6,6 @@
     </UndefinedClass>
   </file>
   <file src="lib/Controller/CatalogiController.php">
-    <InvalidTemplateParam>
-      <code><![CDATA[$response->addHeader('Access-Control-Allow-Headers', $this->corsAllowedHeaders)]]></code>
-      <code><![CDATA[$response->addHeader('Access-Control-Allow-Methods', $this->corsMethods)]]></code>
-      <code><![CDATA[$response->addHeader('Access-Control-Allow-Origin', $origin)]]></code>
-    </InvalidTemplateParam>
     <NoInterfaceProperties>
       <code><![CDATA[$this->request->server]]></code>
     </NoInterfaceProperties>
@@ -24,24 +19,24 @@
     <InvalidTemplateParam>
       <code><![CDATA[$response->addHeader('Access-Control-Allow-Headers', $this->corsAllowedHeaders)]]></code>
       <code><![CDATA[$response->addHeader('Access-Control-Allow-Methods', $this->corsMethods)]]></code>
-      <code><![CDATA[$response->addHeader('Access-Control-Allow-Origin', $origin)]]></code>
+      <code><![CDATA[$response->addHeader('Access-Control-Allow-Origin', $this->resolveAllowedOrigin())]]></code>
     </InvalidTemplateParam>
     <NoInterfaceProperties>
       <code><![CDATA[$this->request->server]]></code>
+    </NoInterfaceProperties>
+  </file>
+  <file src="lib/Controller/ListingsController.php">
+    <NoInterfaceProperties>
       <code><![CDATA[$this->request->server]]></code>
     </NoInterfaceProperties>
   </file>
   <file src="lib/Controller/MenusController.php">
     <InvalidTemplateParam>
       <code><![CDATA[$response->addHeader('Access-Control-Allow-Headers', $this->corsAllowedHeaders)]]></code>
-      <code><![CDATA[$response->addHeader('Access-Control-Allow-Headers', $this->corsAllowedHeaders)]]></code>
       <code><![CDATA[$response->addHeader('Access-Control-Allow-Methods', $this->corsMethods)]]></code>
-      <code><![CDATA[$response->addHeader('Access-Control-Allow-Methods', $this->corsMethods)]]></code>
-      <code><![CDATA[$response->addHeader('Access-Control-Allow-Origin', $origin)]]></code>
-      <code><![CDATA[$response->addHeader('Access-Control-Allow-Origin', $origin)]]></code>
+      <code><![CDATA[$response->addHeader('Access-Control-Allow-Origin', $this->resolveAllowedOrigin())]]></code>
     </InvalidTemplateParam>
     <NoInterfaceProperties>
-      <code><![CDATA[$this->request->server]]></code>
       <code><![CDATA[$this->request->server]]></code>
     </NoInterfaceProperties>
   </file>
@@ -49,7 +44,7 @@
     <InvalidTemplateParam>
       <code><![CDATA[$response->addHeader('Access-Control-Allow-Headers', $this->corsAllowedHeaders)]]></code>
       <code><![CDATA[$response->addHeader('Access-Control-Allow-Methods', $this->corsMethods)]]></code>
-      <code><![CDATA[$response->addHeader('Access-Control-Allow-Origin', $origin)]]></code>
+      <code><![CDATA[$response->addHeader('Access-Control-Allow-Origin', $this->resolveAllowedOrigin())]]></code>
     </InvalidTemplateParam>
     <NoInterfaceProperties>
       <code><![CDATA[$this->request->server]]></code>
@@ -64,10 +59,9 @@
     <InvalidTemplateParam>
       <code><![CDATA[$response->addHeader('Access-Control-Allow-Headers', $this->corsAllowedHeaders)]]></code>
       <code><![CDATA[$response->addHeader('Access-Control-Allow-Methods', $this->corsMethods)]]></code>
-      <code><![CDATA[$response->addHeader('Access-Control-Allow-Origin', $origin)]]></code>
+      <code><![CDATA[$response->addHeader('Access-Control-Allow-Origin', $this->resolveAllowedOrigin())]]></code>
     </InvalidTemplateParam>
     <NoInterfaceProperties>
-      <code><![CDATA[$this->request->server]]></code>
       <code><![CDATA[$this->request->server]]></code>
     </NoInterfaceProperties>
   </file>


### PR DESCRIPTION
## Summary

- **Fix `InvalidScalarArgument` in `BroadcastService`**: replaced `(int) $bits / 8` (produces `float|int`) with `intdiv((int) $bits, 8)` (pure `int`) in the IPv6 subnet mask calculation
- **Regenerate `psalm-baseline.xml`**: removed 9 stale `UnusedBaselineEntry` items (old code used a `$origin` variable; new code uses `$this->resolveAllowedOrigin()` inline) and added correct baseline entries for the current code — `InvalidTemplateParam` (NC framework `JSONResponse` generic stub limitation) and `NoInterfaceProperties` (`$request->server` accessed via `@property-read` on an interface, not supported by Psalm)
- **Add `check:strict` composer script** following the fleet convention

## Result

`composer check:strict` → `ALL CHECKS PASSED` (exit 0). Psalm: 14 errors before → 0 errors after.

## Test plan

- [ ] `composer install --ignore-platform-reqs`
- [ ] `composer psalm` → No errors found
- [ ] `composer check:strict` → ALL CHECKS PASSED