### PR TITLE
fix(wave5): resolve 4 regression items R1/R2/N1/N2 from wave-4 verification

### DIFF
--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -162,8 +162,6 @@ class SettingsController extends Controller
      *
      * @return JSONResponse JSON response containing the updated publishing options.
      *
-     * @NoCSRFRequired
-     *
      * @spec openspec/changes/retrofit-2026-05-25-annotate-opencatalogi/tasks.md#task-40
      */
     public function updatePublishingOptions(): JSONResponse
@@ -207,8 +205,6 @@ class SettingsController extends Controller
      * Manually trigger configuration import.
      *
      * @return JSONResponse JSON response containing import results.
-     *
-     * @NoCSRFRequired
      *
      * @spec openspec/changes/retrofit-2026-05-25-annotate-opencatalogi/tasks.md#task-42
      */

--- a/lib/Service/DirectoryService.php
+++ b/lib/Service/DirectoryService.php
@@ -2071,8 +2071,8 @@ class DirectoryService
 
             try {
                 // RBAC handles public visibility via conditional published date rule.
-                // Disable multitenancy so listings from all orgs are visible.
-                $listingResult = $objectService->searchObjects($query, _multitenancy: false);
+                // ADR-002: each tenant queries only its own listings; multitenancy must stay enabled.
+                $listingResult = $objectService->searchObjects($query);
 
                 // Get our directory URL to identify locally-created listings.
                 $ourDirectoryUrl = $this->urlGenerator->getAbsoluteURL(
@@ -2136,8 +2136,8 @@ class DirectoryService
 
             try {
                 // RBAC handles public visibility via conditional published date rule.
-                // Disable multitenancy so catalogs from all orgs are visible.
-                $catalogResult = $objectService->searchObjects($query, _multitenancy: false);
+                // ADR-002: each tenant queries only its own catalogs; multitenancy must stay enabled.
+                $catalogResult = $objectService->searchObjects($query);
 
                 // Convert catalog objects to listing format and expand schemas.
                 $catalogsAsListings = array_map(

--- a/tests/Unit/Service/DownloadServiceTest.php
+++ b/tests/Unit/Service/DownloadServiceTest.php
@@ -341,118 +341,21 @@ class DownloadServiceTest extends \PHPUnit\Framework\TestCase
     }//end testSaveFileToNextCloudFileCreationFails()
 
     /**
-     * Returns 500 when the publication is not found.
+     * Asserts that createPublicationZip no longer exists (removed in wave-3 fix C5).
+     *
+     * The ZIP-creation path was eliminated; callers should use createPublicationFile
+     * directly. These tests document the removal so regressions are caught.
      *
      * @return void
      */
-    public function testCreatePublicationZipPublicationNotFound(): void
+    public function testCreatePublicationZipMethodDoesNotExist(): void
     {
-        $objectService = $this->createObjectServiceMock();
-        $objectService->method('find')
-            ->willThrowException(new DoesNotExistException('Not found'));
-
-        $result = $this->downloadService->createPublicationZip($objectService, '999');
-
-        $this->assertInstanceOf(JSONResponse::class, $result);
-        $this->assertSame(500, $result->getStatus());
-
-    }//end testCreatePublicationZipPublicationNotFound()
-
-    /**
-     * Propagates MpdfException when PDF creation fails.
-     *
-     * @return void
-     */
-    public function testCreatePublicationZipPdfCreationFails(): void
-    {
-        $objectService = $this->createObjectServiceMock();
-        $entity        = $this->createObjectEntityFromData(
-            ['id' => '1', 'title' => 'ZipTest', 'attachments' => []]
-        );
-        $objectService->method('find')
-            ->willReturn($entity);
-
-        $this->fileService->method('createPdf')
-            ->willThrowException(new \Mpdf\MpdfException('PDF generation failed'));
-
-        $this->expectException(\Mpdf\MpdfException::class);
-
-        $this->downloadService->createPublicationZip($objectService, '1');
-
-    }//end testCreatePublicationZipPdfCreationFails()
-
-    /**
-     * Returns 200 on successful ZIP creation.
-     *
-     * @return void
-     */
-    public function testCreatePublicationZipSuccess(): void
-    {
-        $objectService = $this->createObjectServiceMock();
-        $entity        = $this->createObjectEntityFromData(
-            ['id' => '1', 'title' => 'ZipPub', 'attachments' => []]
-        );
-        $objectService->method('find')
-            ->willReturn($entity);
-
-        $downloadService = $this->getMockBuilder(DownloadService::class)
-            ->setConstructorArgs([$this->fileService])
-            ->onlyMethods(['createPublicationFile'])
-            ->getMock();
-
-        $pdfResponse = new JSONResponse(
-            ['downloadUrl' => 'https://example.com/dl', 'filename' => 'ZipPub.pdf'],
-            200
+        $this->assertFalse(
+            method_exists($this->downloadService, 'createPublicationZip'),
+            'createPublicationZip was removed in wave-3 (C5) and must not be re-introduced.'
         );
 
-        $downloadService->method('createPublicationFile')
-            ->willReturn($pdfResponse);
-
-        $this->fileService->method('createZip')->willReturn(null);
-        $this->fileService->method('downloadZip');
-
-        $result = $downloadService->createPublicationZip($objectService, '1');
-
-        $this->assertInstanceOf(JSONResponse::class, $result);
-        $this->assertSame(200, $result->getStatus());
-
-    }//end testCreatePublicationZipSuccess()
-
-    /**
-     * Returns 500 when ZIP archive creation fails.
-     *
-     * @return void
-     */
-    public function testCreatePublicationZipCreateZipFails(): void
-    {
-        $objectService = $this->createObjectServiceMock();
-        $entity        = $this->createObjectEntityFromData(
-            ['id' => '2', 'title' => 'FailZip', 'attachments' => []]
-        );
-        $objectService->method('find')
-            ->willReturn($entity);
-
-        $downloadService = $this->getMockBuilder(DownloadService::class)
-            ->setConstructorArgs([$this->fileService])
-            ->onlyMethods(['createPublicationFile'])
-            ->getMock();
-
-        $pdfResponse = new JSONResponse(
-            ['downloadUrl' => 'https://example.com/dl', 'filename' => 'FailZip.pdf'],
-            200
-        );
-        $downloadService->method('createPublicationFile')
-            ->willReturn($pdfResponse);
-
-        $this->fileService->method('createZip')
-            ->willReturn('failed to create ZIP archive');
-
-        $result = $downloadService->createPublicationZip($objectService, '2');
-
-        $this->assertInstanceOf(JSONResponse::class, $result);
-        $this->assertSame(500, $result->getStatus());
-
-    }//end testCreatePublicationZipCreateZipFails()
+    }//end testCreatePublicationZipMethodDoesNotExist()
 
     /**
      * Returns all resolved attachment entities.

--- a/tests/Unit/Service/SettingsServiceTest.php
+++ b/tests/Unit/Service/SettingsServiceTest.php
@@ -30,18 +30,25 @@ use RuntimeException;
 class SettingsServiceTest extends \PHPUnit\Framework\TestCase
 {
 
-    /** @var IAppConfig|MockObject */
+    /**
+     * @var IAppConfig|MockObject
+     */
     private IAppConfig|MockObject $config;
 
-    /** @var ContainerInterface|MockObject */
+    /**
+     * @var ContainerInterface|MockObject
+     */
     private ContainerInterface|MockObject $container;
 
-    /** @var IAppManager|MockObject */
+    /**
+     * @var IAppManager|MockObject
+     */
     private IAppManager|MockObject $appManager;
 
-    /** @var SettingsService */
+    /**
+     * @var SettingsService
+     */
     private SettingsService $service;
-
 
     protected function setUp(): void
     {
@@ -55,8 +62,7 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
             $this->appManager
         );
 
-    }
-
+    }//end setUp()
 
     /**
      * Helper: invoke a private method via reflection.
@@ -67,7 +73,7 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
      *
      * @return mixed The return value of the method.
      */
-    private function invokePrivateMethod(object $object, string $methodName, array $parameters = []): mixed
+    private function invokePrivateMethod(object $object, string $methodName, array $parameters=[]): mixed
     {
         $reflection = new \ReflectionClass(get_class($object));
         $method     = $reflection->getMethod($methodName);
@@ -75,8 +81,7 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
 
         return $method->invokeArgs($object, $parameters);
 
-    }
-
+    }//end invokePrivateMethod()
 
     /**
      * Create a mock ConfigurationService.
@@ -85,7 +90,7 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
      *
      * @return ConfigurationService|MockObject
      */
-    private function createConfigServiceMock(?string $storedVersion = null): ConfigurationService|MockObject
+    private function createConfigServiceMock(?string $storedVersion=null): ConfigurationService|MockObject
     {
         $mock = $this->createMock(ConfigurationService::class);
         $mock->method('getConfiguredAppVersion')
@@ -93,8 +98,7 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
 
         return $mock;
 
-    }
-
+    }//end createConfigServiceMock()
 
     /**
      * Create a mock RegisterMapper that returns specified registers.
@@ -103,7 +107,7 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
      *
      * @return RegisterMapper|MockObject
      */
-    private function createRegisterMapperMock(array $registers = []): RegisterMapper|MockObject
+    private function createRegisterMapperMock(array $registers=[]): RegisterMapper|MockObject
     {
         $mock = $this->createMock(RegisterMapper::class);
         $mock->method('findAll')
@@ -111,8 +115,7 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
 
         return $mock;
 
-    }
-
+    }//end createRegisterMapperMock()
 
     /**
      * Create a mock SchemaMapper with a find callback.
@@ -121,32 +124,33 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
      *
      * @return SchemaMapper|MockObject
      */
-    private function createSchemaMapperMock(array $schemaMap = []): SchemaMapper|MockObject
+    private function createSchemaMapperMock(array $schemaMap=[]): SchemaMapper|MockObject
     {
         $mock = $this->createMock(SchemaMapper::class);
 
         if (empty($schemaMap) === false) {
             $mock->method('find')
-                ->willReturnCallback(function (int $id) use ($schemaMap) {
-                    if (isset($schemaMap[$id]) === false) {
-                        throw new \Exception('Schema not found');
-                    }
-                    $schemaMock = $this->createMock(Schema::class);
-                    $schemaMock->method('jsonSerialize')
-                        ->willReturn($schemaMap[$id]);
-                    return $schemaMock;
-                });
+                ->willReturnCallback(
+                        function (int $id) use ($schemaMap) {
+                            if (isset($schemaMap[$id]) === false) {
+                                throw new \Exception('Schema not found');
+                            }
+
+                            $schemaMock = $this->createMock(Schema::class);
+                            $schemaMock->method('jsonSerialize')
+                                ->willReturn($schemaMap[$id]);
+                            return $schemaMock;
+                        }
+                        );
         }
 
         return $mock;
 
-    }
-
+    }//end createSchemaMapperMock()
 
     // ---------------------------------------------------------------
     // isOpenRegisterInstalled
     // ---------------------------------------------------------------
-
     public function testIsOpenRegisterInstalledReturnsTrueWhenInstalledAndVersionMet(): void
     {
         $this->appManager->method('isInstalled')
@@ -159,8 +163,7 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
 
         $this->assertTrue($this->service->isOpenRegisterInstalled('0.1.7'));
 
-    }
-
+    }//end testIsOpenRegisterInstalledReturnsTrueWhenInstalledAndVersionMet()
 
     public function testIsOpenRegisterInstalledReturnsFalseWhenNotInstalled(): void
     {
@@ -170,8 +173,7 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
 
         $this->assertFalse($this->service->isOpenRegisterInstalled());
 
-    }
-
+    }//end testIsOpenRegisterInstalledReturnsFalseWhenNotInstalled()
 
     public function testIsOpenRegisterInstalledReturnsTrueWithNullVersion(): void
     {
@@ -181,8 +183,7 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
 
         $this->assertTrue($this->service->isOpenRegisterInstalled(null));
 
-    }
-
+    }//end testIsOpenRegisterInstalledReturnsTrueWithNullVersion()
 
     public function testIsOpenRegisterInstalledReturnsFalseWhenVersionTooLow(): void
     {
@@ -196,8 +197,7 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
 
         $this->assertFalse($this->service->isOpenRegisterInstalled('0.2.0'));
 
-    }
-
+    }//end testIsOpenRegisterInstalledReturnsFalseWhenVersionTooLow()
 
     public function testIsOpenRegisterInstalledReturnsTrueWhenVersionEqual(): void
     {
@@ -211,8 +211,7 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
 
         $this->assertTrue($this->service->isOpenRegisterInstalled('0.1.7'));
 
-    }
-
+    }//end testIsOpenRegisterInstalledReturnsTrueWhenVersionEqual()
 
     public function testIsOpenRegisterInstalledUsesDefaultMinVersion(): void
     {
@@ -226,13 +225,11 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
 
         $this->assertTrue($this->service->isOpenRegisterInstalled());
 
-    }
-
+    }//end testIsOpenRegisterInstalledUsesDefaultMinVersion()
 
     // ---------------------------------------------------------------
     // isOpenRegisterEnabled
     // ---------------------------------------------------------------
-
     public function testIsOpenRegisterEnabledReturnsTrue(): void
     {
         $this->appManager->method('isEnabledForUser')
@@ -241,8 +238,7 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
 
         $this->assertTrue($this->service->isOpenRegisterEnabled());
 
-    }
-
+    }//end testIsOpenRegisterEnabledReturnsTrue()
 
     public function testIsOpenRegisterEnabledReturnsFalse(): void
     {
@@ -252,13 +248,11 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
 
         $this->assertFalse($this->service->isOpenRegisterEnabled());
 
-    }
-
+    }//end testIsOpenRegisterEnabledReturnsFalse()
 
     // ---------------------------------------------------------------
     // getObjectService
     // ---------------------------------------------------------------
-
     public function testGetObjectServiceReturnsServiceWhenAvailable(): void
     {
         $mockObjectService = $this->createMock(ObjectService::class);
@@ -273,8 +267,7 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
         $result = $this->service->getObjectService();
         $this->assertSame($mockObjectService, $result);
 
-    }
-
+    }//end testGetObjectServiceReturnsServiceWhenAvailable()
 
     public function testGetObjectServiceThrowsWhenNotAvailable(): void
     {
@@ -286,13 +279,11 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
 
         $this->service->getObjectService();
 
-    }
-
+    }//end testGetObjectServiceThrowsWhenNotAvailable()
 
     // ---------------------------------------------------------------
     // getRegisterMapper
     // ---------------------------------------------------------------
-
     public function testGetRegisterMapperReturnsMapperWhenAvailable(): void
     {
         $mockMapper = $this->createMock(RegisterMapper::class);
@@ -307,8 +298,7 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
         $result = $this->service->getRegisterMapper();
         $this->assertSame($mockMapper, $result);
 
-    }
-
+    }//end testGetRegisterMapperReturnsMapperWhenAvailable()
 
     public function testGetRegisterMapperThrowsWhenNotAvailable(): void
     {
@@ -320,13 +310,11 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
 
         $this->service->getRegisterMapper();
 
-    }
-
+    }//end testGetRegisterMapperThrowsWhenNotAvailable()
 
     // ---------------------------------------------------------------
     // getSchemaMapper
     // ---------------------------------------------------------------
-
     public function testGetSchemaMapperReturnsMapperWhenAvailable(): void
     {
         $mockMapper = $this->createMock(SchemaMapper::class);
@@ -341,8 +329,7 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
         $result = $this->service->getSchemaMapper();
         $this->assertSame($mockMapper, $result);
 
-    }
-
+    }//end testGetSchemaMapperReturnsMapperWhenAvailable()
 
     public function testGetSchemaMapperThrowsWhenNotAvailable(): void
     {
@@ -354,13 +341,11 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
 
         $this->service->getSchemaMapper();
 
-    }
-
+    }//end testGetSchemaMapperThrowsWhenNotAvailable()
 
     // ---------------------------------------------------------------
     // getConfigurationService
     // ---------------------------------------------------------------
-
     public function testGetConfigurationServiceReturnsServiceWhenAvailable(): void
     {
         $mockService = $this->createMock(ConfigurationService::class);
@@ -375,8 +360,7 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
         $result = $this->service->getConfigurationService();
         $this->assertSame($mockService, $result);
 
-    }
-
+    }//end testGetConfigurationServiceReturnsServiceWhenAvailable()
 
     public function testGetConfigurationServiceThrowsWhenNotAvailable(): void
     {
@@ -388,47 +372,55 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
 
         $this->service->getConfigurationService();
 
-    }
-
+    }//end testGetConfigurationServiceThrowsWhenNotAvailable()
 
     // ---------------------------------------------------------------
     // getSettings
     // ---------------------------------------------------------------
-
     public function testGetSettingsWithOpenRegisterAvailable(): void
     {
         $mockRegister = $this->createMock(Register::class);
         $mockRegister->method('jsonSerialize')
-            ->willReturn([
-                'id'      => 1,
-                'slug'    => 'publication',
-                'schemas' => [1, 2],
-            ]);
+            ->willReturn(
+                    [
+                        'id'      => 1,
+                        'slug'    => 'publication',
+                        'schemas' => [1, 2],
+                    ]
+                    );
 
         $mockRegisterMapper = $this->createRegisterMapperMock([$mockRegister]);
-        $mockSchemaMapper   = $this->createSchemaMapperMock([
-            1 => ['id' => 1, 'title' => 'Schema 1', 'slug' => 'schema-1'],
-            2 => ['id' => 2, 'title' => 'Schema 2', 'slug' => 'schema-2'],
-        ]);
+        $mockSchemaMapper   = $this->createSchemaMapperMock(
+                [
+                    1 => ['id' => 1, 'title' => 'Schema 1', 'slug' => 'schema-1'],
+                    2 => ['id' => 2, 'title' => 'Schema 2', 'slug' => 'schema-2'],
+                ]
+                );
 
         $this->appManager->method('getInstalledApps')
             ->willReturn(['openregister']);
 
         $this->container->method('get')
-            ->willReturnCallback(function (string $class) use ($mockRegisterMapper, $mockSchemaMapper) {
-                if ($class === 'OCA\OpenRegister\Db\RegisterMapper') {
-                    return $mockRegisterMapper;
-                }
-                if ($class === 'OCA\OpenRegister\Db\SchemaMapper') {
-                    return $mockSchemaMapper;
-                }
-                return null;
-            });
+            ->willReturnCallback(
+                    function (string $class) use ($mockRegisterMapper, $mockSchemaMapper) {
+                        if ($class === 'OCA\OpenRegister\Db\RegisterMapper') {
+                            return $mockRegisterMapper;
+                        }
+
+                        if ($class === 'OCA\OpenRegister\Db\SchemaMapper') {
+                            return $mockSchemaMapper;
+                        }
+
+                        return null;
+                    }
+                    );
 
         $this->config->method('getValueString')
-            ->willReturnCallback(function (string $app, string $key, string $default = '') {
-                return $default;
-            });
+            ->willReturnCallback(
+                    function (string $app, string $key, string $default='') {
+                        return $default;
+                    }
+                    );
 
         $result = $this->service->getSettings();
 
@@ -439,8 +431,7 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
         $this->assertContains('catalog', $result['objectTypes']);
         $this->assertContains('listing', $result['objectTypes']);
 
-    }
-
+    }//end testGetSettingsWithOpenRegisterAvailable()
 
     public function testGetSettingsWithoutOpenRegister(): void
     {
@@ -448,9 +439,11 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
             ->willReturn([]);
 
         $this->config->method('getValueString')
-            ->willReturnCallback(function (string $app, string $key, string $default = '') {
-                return $default;
-            });
+            ->willReturnCallback(
+                    function (string $app, string $key, string $default='') {
+                        return $default;
+                    }
+                    );
 
         $result = $this->service->getSettings();
 
@@ -459,8 +452,7 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
         $this->assertArrayHasKey('objectTypes', $result);
         $this->assertArrayHasKey('configuration', $result);
 
-    }
-
+    }//end testGetSettingsWithoutOpenRegister()
 
     public function testGetSettingsObjectTypesContainAllExpectedTypes(): void
     {
@@ -468,17 +460,18 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
             ->willReturn([]);
 
         $this->config->method('getValueString')
-            ->willReturnCallback(function (string $app, string $key, string $default = '') {
-                return $default;
-            });
+            ->willReturnCallback(
+                    function (string $app, string $key, string $default='') {
+                        return $default;
+                    }
+                    );
 
         $result = $this->service->getSettings();
 
         $expectedTypes = ['catalog', 'listing', 'organization', 'theme', 'page', 'menu', 'glossary'];
         $this->assertSame($expectedTypes, $result['objectTypes']);
 
-    }
-
+    }//end testGetSettingsObjectTypesContainAllExpectedTypes()
 
     public function testGetSettingsConfigurationContainsAllKeys(): void
     {
@@ -486,9 +479,11 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
             ->willReturn([]);
 
         $this->config->method('getValueString')
-            ->willReturnCallback(function (string $app, string $key, string $default = '') {
-                return $default;
-            });
+            ->willReturnCallback(
+                    function (string $app, string $key, string $default='') {
+                        return $default;
+                    }
+                    );
 
         $result = $this->service->getSettings();
 
@@ -503,8 +498,7 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
         $this->assertArrayHasKey('auto_publish_objects', $result['configuration']);
         $this->assertArrayHasKey('use_old_style_publishing_view', $result['configuration']);
 
-    }
-
+    }//end testGetSettingsConfigurationContainsAllKeys()
 
     public function testGetSettingsDefaultSourceIsOpenregister(): void
     {
@@ -512,9 +506,11 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
             ->willReturn([]);
 
         $this->config->method('getValueString')
-            ->willReturnCallback(function (string $app, string $key, string $default = '') {
-                return $default;
-            });
+            ->willReturnCallback(
+                    function (string $app, string $key, string $default='') {
+                        return $default;
+                    }
+                    );
 
         $result = $this->service->getSettings();
 
@@ -523,8 +519,7 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
             $this->assertSame('openregister', $result['configuration']["{$type}_source"]);
         }
 
-    }
-
+    }//end testGetSettingsDefaultSourceIsOpenregister()
 
     public function testGetSettingsThrowsOnConfigError(): void
     {
@@ -539,13 +534,11 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
 
         $this->service->getSettings();
 
-    }
-
+    }//end testGetSettingsThrowsOnConfigError()
 
     // ---------------------------------------------------------------
     // updateSettings
     // ---------------------------------------------------------------
-
     public function testUpdateSettingsSuccess(): void
     {
         $inputData = [
@@ -556,15 +549,19 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
 
         $this->config->expects($this->exactly(3))
             ->method('setValueString')
-            ->willReturnCallback(function (string $app, string $key, string $value) {
-                $this->assertSame('opencatalogi', $app);
-                return true;
-            });
+            ->willReturnCallback(
+                    function (string $app, string $key, string $value) {
+                        $this->assertSame('opencatalogi', $app);
+                        return true;
+                    }
+                    );
 
         $this->config->method('getValueString')
-            ->willReturnCallback(function (string $app, string $key) use ($inputData) {
-                return $inputData[$key] ?? '';
-            });
+            ->willReturnCallback(
+                    function (string $app, string $key) use ($inputData) {
+                        return $inputData[$key] ?? '';
+                    }
+                    );
 
         $result = $this->service->updateSettings($inputData);
 
@@ -572,34 +569,58 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('5', $result['catalog_schema']);
         $this->assertSame('1', $result['catalog_register']);
 
-    }
+    }//end testUpdateSettingsSuccess()
 
-
+    /**
+     * Throws RuntimeException when an allowlisted key causes a write failure.
+     *
+     * @return void
+     */
     public function testUpdateSettingsThrowsOnFailure(): void
     {
+        // Use a known allowlisted key so setValueString is actually called.
         $this->config->method('setValueString')
             ->willThrowException(new \Exception('Write error'));
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessageMatches('/Failed to update settings/');
 
-        $this->service->updateSettings(['key' => 'value']);
+        $this->service->updateSettings(['catalog_source' => 'openregister']);
 
-    }
+    }//end testUpdateSettingsThrowsOnFailure()
 
+    /**
+     * Silently drops unknown keys without touching config storage (C1 allowlist contract).
+     *
+     * @return void
+     */
+    public function testUpdateSettingsUnknownKeyIsSilentlyFiltered(): void
+    {
+        // Unknown keys must be dropped without touching config storage.
+        // This is the allowlist contract introduced in wave-3 (C1).
+        $this->config->expects($this->never())->method('setValueString');
 
+        $result = $this->service->updateSettings(['key' => 'value', 'unknown_setting' => 'bad']);
+
+        $this->assertSame([], $result);
+
+    }//end testUpdateSettingsUnknownKeyIsSilentlyFiltered()
+
+    /**
+     * Returns empty array when no settings are passed.
+     *
+     * @return void
+     */
     public function testUpdateSettingsEmptyArray(): void
     {
         $result = $this->service->updateSettings([]);
         $this->assertSame([], $result);
 
-    }
-
+    }//end testUpdateSettingsEmptyArray()
 
     // ---------------------------------------------------------------
     // getPublishingOptions
     // ---------------------------------------------------------------
-
     public function testGetPublishingOptionsAllFalse(): void
     {
         $this->config->method('getValueString')
@@ -611,8 +632,7 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
         $this->assertFalse($result['auto_publish_objects']);
         $this->assertFalse($result['use_old_style_publishing_view']);
 
-    }
-
+    }//end testGetPublishingOptionsAllFalse()
 
     public function testGetPublishingOptionsAllTrue(): void
     {
@@ -625,18 +645,20 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($result['auto_publish_objects']);
         $this->assertTrue($result['use_old_style_publishing_view']);
 
-    }
-
+    }//end testGetPublishingOptionsAllTrue()
 
     public function testGetPublishingOptionsMixed(): void
     {
         $this->config->method('getValueString')
-            ->willReturnCallback(function (string $app, string $key, string $default = 'false') {
-                if ($key === 'auto_publish_attachments') {
-                    return 'true';
-                }
-                return 'false';
-            });
+            ->willReturnCallback(
+                    function (string $app, string $key, string $default='false') {
+                        if ($key === 'auto_publish_attachments') {
+                            return 'true';
+                        }
+
+                        return 'false';
+                    }
+                    );
 
         $result = $this->service->getPublishingOptions();
 
@@ -644,8 +666,7 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
         $this->assertFalse($result['auto_publish_objects']);
         $this->assertFalse($result['use_old_style_publishing_view']);
 
-    }
-
+    }//end testGetPublishingOptionsMixed()
 
     public function testGetPublishingOptionsThrowsOnError(): void
     {
@@ -657,27 +678,26 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
 
         $this->service->getPublishingOptions();
 
-    }
-
+    }//end testGetPublishingOptionsThrowsOnError()
 
     // ---------------------------------------------------------------
     // updatePublishingOptions
     // ---------------------------------------------------------------
-
     public function testUpdatePublishingOptionsWithBooleanTrue(): void
     {
         $this->config->method('setValueString')->willReturn(true);
         $this->config->method('getValueString')
             ->willReturn('true');
 
-        $result = $this->service->updatePublishingOptions([
-            'auto_publish_attachments' => true,
-        ]);
+        $result = $this->service->updatePublishingOptions(
+                [
+                    'auto_publish_attachments' => true,
+                ]
+                );
 
         $this->assertTrue($result['auto_publish_attachments']);
 
-    }
-
+    }//end testUpdatePublishingOptionsWithBooleanTrue()
 
     public function testUpdatePublishingOptionsWithStringTrue(): void
     {
@@ -685,14 +705,15 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
         $this->config->method('getValueString')
             ->willReturn('true');
 
-        $result = $this->service->updatePublishingOptions([
-            'auto_publish_objects' => 'true',
-        ]);
+        $result = $this->service->updatePublishingOptions(
+                [
+                    'auto_publish_objects' => 'true',
+                ]
+                );
 
         $this->assertTrue($result['auto_publish_objects']);
 
-    }
-
+    }//end testUpdatePublishingOptionsWithStringTrue()
 
     public function testUpdatePublishingOptionsWithFalseValue(): void
     {
@@ -704,28 +725,30 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
         $this->config->method('getValueString')
             ->willReturn('false');
 
-        $result = $this->service->updatePublishingOptions([
-            'auto_publish_attachments' => false,
-        ]);
+        $result = $this->service->updatePublishingOptions(
+                [
+                    'auto_publish_attachments' => false,
+                ]
+                );
 
         $this->assertFalse($result['auto_publish_attachments']);
 
-    }
-
+    }//end testUpdatePublishingOptionsWithFalseValue()
 
     public function testUpdatePublishingOptionsIgnoresInvalidKeys(): void
     {
         $this->config->expects($this->never())
             ->method('setValueString')->willReturn(true);
 
-        $result = $this->service->updatePublishingOptions([
-            'invalid_option' => 'true',
-        ]);
+        $result = $this->service->updatePublishingOptions(
+                [
+                    'invalid_option' => 'true',
+                ]
+                );
 
         $this->assertEmpty($result);
 
-    }
-
+    }//end testUpdatePublishingOptionsIgnoresInvalidKeys()
 
     public function testUpdatePublishingOptionsMultipleOptions(): void
     {
@@ -735,19 +758,20 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
         $this->config->method('getValueString')
             ->willReturn('true');
 
-        $result = $this->service->updatePublishingOptions([
-            'auto_publish_attachments'      => true,
-            'auto_publish_objects'          => true,
-            'use_old_style_publishing_view' => true,
-        ]);
+        $result = $this->service->updatePublishingOptions(
+                [
+                    'auto_publish_attachments'      => true,
+                    'auto_publish_objects'          => true,
+                    'use_old_style_publishing_view' => true,
+                ]
+                );
 
         $this->assertCount(3, $result);
         $this->assertTrue($result['auto_publish_attachments']);
         $this->assertTrue($result['auto_publish_objects']);
         $this->assertTrue($result['use_old_style_publishing_view']);
 
-    }
-
+    }//end testUpdatePublishingOptionsMultipleOptions()
 
     public function testUpdatePublishingOptionsThrowsOnError(): void
     {
@@ -757,12 +781,13 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessageMatches('/Failed to update publishing options/');
 
-        $this->service->updatePublishingOptions([
-            'auto_publish_attachments' => true,
-        ]);
+        $this->service->updatePublishingOptions(
+                [
+                    'auto_publish_attachments' => true,
+                ]
+                );
 
-    }
-
+    }//end testUpdatePublishingOptionsThrowsOnError()
 
     public function testUpdatePublishingOptionsBooleanConversionForZero(): void
     {
@@ -774,14 +799,15 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
         $this->config->method('getValueString')
             ->willReturn('false');
 
-        $result = $this->service->updatePublishingOptions([
-            'auto_publish_attachments' => 0,
-        ]);
+        $result = $this->service->updatePublishingOptions(
+                [
+                    'auto_publish_attachments' => 0,
+                ]
+                );
 
         $this->assertFalse($result['auto_publish_attachments']);
 
-    }
-
+    }//end testUpdatePublishingOptionsBooleanConversionForZero()
 
     public function testUpdatePublishingOptionsEmptyInput(): void
     {
@@ -792,13 +818,11 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
 
         $this->assertEmpty($result);
 
-    }
-
+    }//end testUpdatePublishingOptionsEmptyInput()
 
     // ---------------------------------------------------------------
     // getVersionInfo
     // ---------------------------------------------------------------
-
     public function testGetVersionInfoVersionsMatch(): void
     {
         $mockConfigService = $this->createConfigServiceMock('2.0.0');
@@ -822,8 +846,7 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($result['versionsMatch']);
         $this->assertFalse($result['needsUpdate']);
 
-    }
-
+    }//end testGetVersionInfoVersionsMatch()
 
     public function testGetVersionInfoVersionsDontMatch(): void
     {
@@ -845,8 +868,7 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
         $this->assertFalse($result['versionsMatch']);
         $this->assertTrue($result['needsUpdate']);
 
-    }
-
+    }//end testGetVersionInfoVersionsDontMatch()
 
     public function testGetVersionInfoNoStoredVersion(): void
     {
@@ -869,8 +891,7 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($result['needsUpdate']);
         $this->assertNull($result['configuredVersion']);
 
-    }
-
+    }//end testGetVersionInfoNoStoredVersion()
 
     public function testGetVersionInfoThrowsOnError(): void
     {
@@ -885,8 +906,7 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
 
         $this->service->getVersionInfo();
 
-    }
-
+    }//end testGetVersionInfoThrowsOnError()
 
     public function testGetVersionInfoStoredVersionNewer(): void
     {
@@ -907,13 +927,11 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
         $this->assertFalse($result['versionsMatch']);
         $this->assertFalse($result['needsUpdate']);
 
-    }
-
+    }//end testGetVersionInfoStoredVersionNewer()
 
     // ---------------------------------------------------------------
     // manualImport
     // ---------------------------------------------------------------
-
     public function testManualImportVersionsMatchNoForce(): void
     {
         $mockConfigService = $this->createConfigServiceMock('2.0.0');
@@ -933,8 +951,7 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
         $this->assertStringContainsString('already up to date', $result['message']);
         $this->assertArrayHasKey('versionInfo', $result);
 
-    }
-
+    }//end testManualImportVersionsMatchNoForce()
 
     public function testManualImportForced(): void
     {
@@ -959,8 +976,7 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
         $this->assertFalse($result['success']);
         $this->assertArrayHasKey('error', $result);
 
-    }
-
+    }//end testManualImportForced()
 
     public function testManualImportNeedsUpdate(): void
     {
@@ -985,17 +1001,18 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
         $this->assertFalse($result['success']);
         $this->assertArrayHasKey('error', $result);
 
-    }
-
+    }//end testManualImportNeedsUpdate()
 
     public function testManualImportSuccessWithValidFile(): void
     {
-        $tmpDir = sys_get_temp_dir() . '/opencatalogi_test_' . uniqid();
-        mkdir($tmpDir . '/lib/Settings', 0777, true);
-        $jsonData = json_encode([
-            'x-openregister' => ['sourceUrl' => 'test', 'sourceType' => 'local'],
-        ]);
-        file_put_contents($tmpDir . '/lib/Settings/publication_register.json', $jsonData);
+        $tmpDir = sys_get_temp_dir().'/opencatalogi_test_'.uniqid();
+        mkdir($tmpDir.'/lib/Settings', 0777, true);
+        $jsonData = json_encode(
+                [
+                    'x-openregister' => ['sourceUrl' => 'test', 'sourceType' => 'local'],
+                ]
+                );
+        file_put_contents($tmpDir.'/lib/Settings/publication_register.json', $jsonData);
 
         $mockConfigService = $this->createMock(ConfigurationService::class);
         $mockConfigService->method('getConfiguredAppVersion')
@@ -1020,19 +1037,17 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
             $this->assertTrue($result['success']);
             $this->assertStringContainsString('successfully', $result['message']);
         } finally {
-            unlink($tmpDir . '/lib/Settings/publication_register.json');
-            rmdir($tmpDir . '/lib/Settings');
-            rmdir($tmpDir . '/lib');
+            unlink($tmpDir.'/lib/Settings/publication_register.json');
+            rmdir($tmpDir.'/lib/Settings');
+            rmdir($tmpDir.'/lib');
             rmdir($tmpDir);
         }
 
-    }
-
+    }//end testManualImportSuccessWithValidFile()
 
     // ---------------------------------------------------------------
     // loadSettings
     // ---------------------------------------------------------------
-
     public function testLoadSettingsFileNotFound(): void
     {
         $this->appManager->method('getAppPath')
@@ -1044,14 +1059,13 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
 
         $this->service->loadSettings();
 
-    }
-
+    }//end testLoadSettingsFileNotFound()
 
     public function testLoadSettingsInvalidJson(): void
     {
-        $tmpDir = sys_get_temp_dir() . '/opencatalogi_test_' . uniqid();
-        mkdir($tmpDir . '/lib/Settings', 0777, true);
-        file_put_contents($tmpDir . '/lib/Settings/publication_register.json', '{invalid json}');
+        $tmpDir = sys_get_temp_dir().'/opencatalogi_test_'.uniqid();
+        mkdir($tmpDir.'/lib/Settings', 0777, true);
+        file_put_contents($tmpDir.'/lib/Settings/publication_register.json', '{invalid json}');
 
         $this->appManager->method('getAppPath')
             ->with('opencatalogi')
@@ -1062,28 +1076,29 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
             $this->expectExceptionMessageMatches('/Failed to load settings/');
             $this->service->loadSettings();
         } finally {
-            unlink($tmpDir . '/lib/Settings/publication_register.json');
-            rmdir($tmpDir . '/lib/Settings');
-            rmdir($tmpDir . '/lib');
+            unlink($tmpDir.'/lib/Settings/publication_register.json');
+            rmdir($tmpDir.'/lib/Settings');
+            rmdir($tmpDir.'/lib');
             rmdir($tmpDir);
         }
 
-    }
-
+    }//end testLoadSettingsInvalidJson()
 
     public function testLoadSettingsValidJsonCallsImport(): void
     {
-        $tmpDir = sys_get_temp_dir() . '/opencatalogi_test_' . uniqid();
-        mkdir($tmpDir . '/lib/Settings', 0777, true);
-        $jsonData = json_encode([
-            'x-openregister' => [
-                'sourceUrl'  => 'test/path',
-                'sourceType' => 'local',
-            ],
-            'registers' => [],
-            'schemas'   => [],
-        ]);
-        file_put_contents($tmpDir . '/lib/Settings/publication_register.json', $jsonData);
+        $tmpDir = sys_get_temp_dir().'/opencatalogi_test_'.uniqid();
+        mkdir($tmpDir.'/lib/Settings', 0777, true);
+        $jsonData = json_encode(
+                [
+                    'x-openregister' => [
+                        'sourceUrl'  => 'test/path',
+                        'sourceType' => 'local',
+                    ],
+                    'registers'      => [],
+                    'schemas'        => [],
+                ]
+                );
+        file_put_contents($tmpDir.'/lib/Settings/publication_register.json', $jsonData);
 
         $mockConfigService = $this->createMock(ConfigurationService::class);
         $mockConfigService->method('importFromApp')
@@ -1110,21 +1125,20 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
             $this->assertArrayHasKey('registers', $result);
             $this->assertArrayHasKey('schemas', $result);
         } finally {
-            unlink($tmpDir . '/lib/Settings/publication_register.json');
-            rmdir($tmpDir . '/lib/Settings');
-            rmdir($tmpDir . '/lib');
+            unlink($tmpDir.'/lib/Settings/publication_register.json');
+            rmdir($tmpDir.'/lib/Settings');
+            rmdir($tmpDir.'/lib');
             rmdir($tmpDir);
         }
 
-    }
-
+    }//end testLoadSettingsValidJsonCallsImport()
 
     public function testLoadSettingsForceFlag(): void
     {
-        $tmpDir = sys_get_temp_dir() . '/opencatalogi_test_' . uniqid();
-        mkdir($tmpDir . '/lib/Settings', 0777, true);
+        $tmpDir = sys_get_temp_dir().'/opencatalogi_test_'.uniqid();
+        mkdir($tmpDir.'/lib/Settings', 0777, true);
         $jsonData = json_encode(['data' => 'test']);
-        file_put_contents($tmpDir . '/lib/Settings/publication_register.json', $jsonData);
+        file_put_contents($tmpDir.'/lib/Settings/publication_register.json', $jsonData);
 
         $mockConfigService = $this->createMock(ConfigurationService::class);
         $mockConfigService->expects($this->once())
@@ -1152,30 +1166,31 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
         try {
             $this->service->loadSettings(true);
         } finally {
-            unlink($tmpDir . '/lib/Settings/publication_register.json');
-            rmdir($tmpDir . '/lib/Settings');
-            rmdir($tmpDir . '/lib');
+            unlink($tmpDir.'/lib/Settings/publication_register.json');
+            rmdir($tmpDir.'/lib/Settings');
+            rmdir($tmpDir.'/lib');
             rmdir($tmpDir);
         }
 
-    }
-
+    }//end testLoadSettingsForceFlag()
 
     public function testLoadSettingsAddsOpenregisterMetadata(): void
     {
-        $tmpDir = sys_get_temp_dir() . '/opencatalogi_test_' . uniqid();
-        mkdir($tmpDir . '/lib/Settings', 0777, true);
+        $tmpDir = sys_get_temp_dir().'/opencatalogi_test_'.uniqid();
+        mkdir($tmpDir.'/lib/Settings', 0777, true);
         // JSON without x-openregister metadata.
         $jsonData = json_encode(['someKey' => 'someValue']);
-        file_put_contents($tmpDir . '/lib/Settings/publication_register.json', $jsonData);
+        file_put_contents($tmpDir.'/lib/Settings/publication_register.json', $jsonData);
 
-        $capturedData = null;
+        $capturedData      = null;
         $mockConfigService = $this->createMock(ConfigurationService::class);
         $mockConfigService->method('importFromApp')
-            ->willReturnCallback(function (string $appId, array $data, string $version, bool $force) use (&$capturedData) {
-                $capturedData = $data;
-                return ['registers' => [], 'schemas' => []];
-            });
+            ->willReturnCallback(
+                    function (string $appId, array $data, string $version, bool $force) use (&$capturedData) {
+                        $capturedData = $data;
+                        return ['registers' => [], 'schemas' => []];
+                    }
+                    );
 
         $this->appManager->method('getAppPath')
             ->willReturn($tmpDir);
@@ -1195,19 +1210,17 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
             $this->assertArrayHasKey('sourceUrl', $capturedData['x-openregister']);
             $this->assertSame('local', $capturedData['x-openregister']['sourceType']);
         } finally {
-            unlink($tmpDir . '/lib/Settings/publication_register.json');
-            rmdir($tmpDir . '/lib/Settings');
-            rmdir($tmpDir . '/lib');
+            unlink($tmpDir.'/lib/Settings/publication_register.json');
+            rmdir($tmpDir.'/lib/Settings');
+            rmdir($tmpDir.'/lib');
             rmdir($tmpDir);
         }
 
-    }
-
+    }//end testLoadSettingsAddsOpenregisterMetadata()
 
     // ---------------------------------------------------------------
     // autoConfigure
     // ---------------------------------------------------------------
-
     public function testAutoConfigureEmptyRegisters(): void
     {
         $mockMapper = $this->createRegisterMapperMock([]);
@@ -1222,21 +1235,22 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
 
         $this->assertSame([], $result);
 
-    }
-
+    }//end testAutoConfigureEmptyRegisters()
 
     public function testAutoConfigureWithMatchingRegister(): void
     {
-        $mockMapper = $this->createRegisterMapperMock([
-            [
-                'id'      => 1,
-                'slug'    => 'publication',
-                'schemas' => [
-                    ['id' => 10, 'title' => 'catalog'],
-                    ['id' => 11, 'title' => 'listing'],
-                ],
-            ],
-        ]);
+        $mockMapper = $this->createRegisterMapperMock(
+                [
+                    [
+                        'id'      => 1,
+                        'slug'    => 'publication',
+                        'schemas' => [
+                            ['id' => 10, 'title' => 'catalog'],
+                            ['id' => 11, 'title' => 'listing'],
+                        ],
+                    ],
+                ]
+                );
 
         $mockSchemaMapper = $this->createSchemaMapperMock();
 
@@ -1244,17 +1258,22 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
             ->willReturn(['openregister']);
 
         $this->container->method('get')
-            ->willReturnCallback(function (string $class) use ($mockMapper, $mockSchemaMapper) {
-                if ($class === 'OCA\OpenRegister\Db\SchemaMapper') {
-                    return $mockSchemaMapper;
-                }
-                return $mockMapper;
-            });
+            ->willReturnCallback(
+                    function (string $class) use ($mockMapper, $mockSchemaMapper) {
+                        if ($class === 'OCA\OpenRegister\Db\SchemaMapper') {
+                            return $mockSchemaMapper;
+                        }
+
+                        return $mockMapper;
+                    }
+                    );
 
         $this->config->method('getValueString')
-            ->willReturnCallback(function (string $app, string $key, string $default = '') {
-                return $default;
-            });
+            ->willReturnCallback(
+                    function (string $app, string $key, string $default='') {
+                        return $default;
+                    }
+                    );
 
         $result = $this->service->autoConfigure();
 
@@ -1265,57 +1284,64 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
         $this->assertArrayHasKey('listing_register', $result);
         $this->assertArrayHasKey('listing_schema', $result);
 
-    }
-
+    }//end testAutoConfigureWithMatchingRegister()
 
     public function testAutoConfigureWithRegisterObjectEntities(): void
     {
         $mockRegister = $this->createMock(Register::class);
         $mockRegister->method('jsonSerialize')
-            ->willReturn([
-                'id'      => 5,
-                'slug'    => 'my-publication-register',
-                'schemas' => [
-                    ['id' => 20, 'title' => 'organization'],
-                ],
-            ]);
+            ->willReturn(
+                    [
+                        'id'      => 5,
+                        'slug'    => 'my-publication-register',
+                        'schemas' => [
+                            ['id' => 20, 'title' => 'organization'],
+                        ],
+                    ]
+                    );
 
-        $mockMapper = $this->createRegisterMapperMock([$mockRegister]);
+        $mockMapper       = $this->createRegisterMapperMock([$mockRegister]);
         $mockSchemaMapper = $this->createSchemaMapperMock();
 
         $this->appManager->method('getInstalledApps')
             ->willReturn(['openregister']);
 
         $this->container->method('get')
-            ->willReturnCallback(function (string $class) use ($mockMapper, $mockSchemaMapper) {
-                if ($class === 'OCA\OpenRegister\Db\SchemaMapper') {
-                    return $mockSchemaMapper;
-                }
-                return $mockMapper;
-            });
+            ->willReturnCallback(
+                    function (string $class) use ($mockMapper, $mockSchemaMapper) {
+                        if ($class === 'OCA\OpenRegister\Db\SchemaMapper') {
+                            return $mockSchemaMapper;
+                        }
+
+                        return $mockMapper;
+                    }
+                    );
 
         $this->config->method('getValueString')
-            ->willReturnCallback(function (string $app, string $key, string $default = '') {
-                return $default;
-            });
+            ->willReturnCallback(
+                    function (string $app, string $key, string $default='') {
+                        return $default;
+                    }
+                    );
 
         $result = $this->service->autoConfigure();
 
         $this->assertArrayHasKey('organization_register', $result);
         $this->assertSame(5, $result['organization_register']);
 
-    }
-
+    }//end testAutoConfigureWithRegisterObjectEntities()
 
     public function testAutoConfigureNoMatchingRegister(): void
     {
-        $mockMapper = $this->createRegisterMapperMock([
-            [
-                'id'      => 1,
-                'slug'    => 'completely-different',
-                'schemas' => [],
-            ],
-        ]);
+        $mockMapper = $this->createRegisterMapperMock(
+                [
+                    [
+                        'id'      => 1,
+                        'slug'    => 'completely-different',
+                        'schemas' => [],
+                    ],
+                ]
+                );
 
         $mockSchemaMapper = $this->createSchemaMapperMock();
 
@@ -1323,24 +1349,28 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
             ->willReturn(['openregister']);
 
         $this->container->method('get')
-            ->willReturnCallback(function (string $class) use ($mockMapper, $mockSchemaMapper) {
-                if ($class === 'OCA\OpenRegister\Db\SchemaMapper') {
-                    return $mockSchemaMapper;
-                }
-                return $mockMapper;
-            });
+            ->willReturnCallback(
+                    function (string $class) use ($mockMapper, $mockSchemaMapper) {
+                        if ($class === 'OCA\OpenRegister\Db\SchemaMapper') {
+                            return $mockSchemaMapper;
+                        }
+
+                        return $mockMapper;
+                    }
+                    );
 
         $this->config->method('getValueString')
-            ->willReturnCallback(function (string $app, string $key, string $default = '') {
-                return $default;
-            });
+            ->willReturnCallback(
+                    function (string $app, string $key, string $default='') {
+                        return $default;
+                    }
+                    );
 
         $result = $this->service->autoConfigure();
 
         $this->assertEmpty($result);
 
-    }
-
+    }//end testAutoConfigureNoMatchingRegister()
 
     public function testAutoConfigureThrowsOnError(): void
     {
@@ -1352,18 +1382,19 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
 
         $this->service->autoConfigure();
 
-    }
-
+    }//end testAutoConfigureThrowsOnError()
 
     public function testAutoConfigureWithEmptySchemas(): void
     {
-        $mockMapper = $this->createRegisterMapperMock([
-            [
-                'id'      => 1,
-                'slug'    => 'publication',
-                'schemas' => [],
-            ],
-        ]);
+        $mockMapper = $this->createRegisterMapperMock(
+                [
+                    [
+                        'id'      => 1,
+                        'slug'    => 'publication',
+                        'schemas' => [],
+                    ],
+                ]
+                );
 
         $mockSchemaMapper = $this->createSchemaMapperMock();
 
@@ -1371,17 +1402,22 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
             ->willReturn(['openregister']);
 
         $this->container->method('get')
-            ->willReturnCallback(function (string $class) use ($mockMapper, $mockSchemaMapper) {
-                if ($class === 'OCA\OpenRegister\Db\SchemaMapper') {
-                    return $mockSchemaMapper;
-                }
-                return $mockMapper;
-            });
+            ->willReturnCallback(
+                    function (string $class) use ($mockMapper, $mockSchemaMapper) {
+                        if ($class === 'OCA\OpenRegister\Db\SchemaMapper') {
+                            return $mockSchemaMapper;
+                        }
+
+                        return $mockMapper;
+                    }
+                    );
 
         $this->config->method('getValueString')
-            ->willReturnCallback(function (string $app, string $key, string $default = '') {
-                return $default;
-            });
+            ->willReturnCallback(
+                    function (string $app, string $key, string $default='') {
+                        return $default;
+                    }
+                    );
 
         $result = $this->service->autoConfigure();
 
@@ -1389,18 +1425,19 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
         $this->assertArrayHasKey('catalog_register', $result);
         $this->assertArrayNotHasKey('catalog_schema', $result);
 
-    }
-
+    }//end testAutoConfigureWithEmptySchemas()
 
     public function testAutoConfigureSkipsNonArraySchemas(): void
     {
-        $mockMapper = $this->createRegisterMapperMock([
-            [
-                'id'      => 1,
-                'slug'    => 'publication',
-                'schemas' => ['not-an-array', 42],
-            ],
-        ]);
+        $mockMapper = $this->createRegisterMapperMock(
+                [
+                    [
+                        'id'      => 1,
+                        'slug'    => 'publication',
+                        'schemas' => ['not-an-array', 42],
+                    ],
+                ]
+                );
 
         $mockSchemaMapper = $this->createSchemaMapperMock();
 
@@ -1408,17 +1445,22 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
             ->willReturn(['openregister']);
 
         $this->container->method('get')
-            ->willReturnCallback(function (string $class) use ($mockMapper, $mockSchemaMapper) {
-                if ($class === 'OCA\OpenRegister\Db\SchemaMapper') {
-                    return $mockSchemaMapper;
-                }
-                return $mockMapper;
-            });
+            ->willReturnCallback(
+                    function (string $class) use ($mockMapper, $mockSchemaMapper) {
+                        if ($class === 'OCA\OpenRegister\Db\SchemaMapper') {
+                            return $mockSchemaMapper;
+                        }
+
+                        return $mockMapper;
+                    }
+                    );
 
         $this->config->method('getValueString')
-            ->willReturnCallback(function (string $app, string $key, string $default = '') {
-                return $default;
-            });
+            ->willReturnCallback(
+                    function (string $app, string $key, string $default='') {
+                        return $default;
+                    }
+                    );
 
         $result = $this->service->autoConfigure();
 
@@ -1426,25 +1468,26 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
         $this->assertArrayHasKey('catalog_register', $result);
         $this->assertArrayNotHasKey('catalog_schema', $result);
 
-    }
-
+    }//end testAutoConfigureSkipsNonArraySchemas()
 
     // ---------------------------------------------------------------
     // initialize
     // ---------------------------------------------------------------
-
     public function testInitializeSuccess(): void
     {
         $this->appManager->method('isInstalled')
             ->willReturn(true);
 
         $this->appManager->method('getAppVersion')
-            ->willReturnCallback(function (string $appId) {
-                if ($appId === 'openregister') {
-                    return '1.0.0';
-                }
-                return '2.0.0';
-            });
+            ->willReturnCallback(
+                    function (string $appId) {
+                        if ($appId === 'openregister') {
+                            return '1.0.0';
+                        }
+
+                        return '2.0.0';
+                    }
+                    );
 
         $mockRegisterMapper = $this->createRegisterMapperMock([]);
         $mockConfigService  = $this->createConfigServiceMock('2.0.0');
@@ -1453,20 +1496,26 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
             ->willReturn(['openregister']);
 
         $this->container->method('get')
-            ->willReturnCallback(function (string $class) use ($mockRegisterMapper, $mockConfigService) {
-                if ($class === 'OCA\OpenRegister\Db\RegisterMapper') {
-                    return $mockRegisterMapper;
-                }
-                if ($class === 'OCA\OpenRegister\Service\ConfigurationService') {
-                    return $mockConfigService;
-                }
-                return null;
-            });
+            ->willReturnCallback(
+                    function (string $class) use ($mockRegisterMapper, $mockConfigService) {
+                        if ($class === 'OCA\OpenRegister\Db\RegisterMapper') {
+                            return $mockRegisterMapper;
+                        }
+
+                        if ($class === 'OCA\OpenRegister\Service\ConfigurationService') {
+                            return $mockConfigService;
+                        }
+
+                        return null;
+                    }
+                    );
 
         $this->config->method('getValueString')
-            ->willReturnCallback(function (string $app, string $key, string $default = '') {
-                return $default;
-            });
+            ->willReturnCallback(
+                    function (string $app, string $key, string $default='') {
+                        return $default;
+                    }
+                    );
 
         $result = $this->service->initialize();
 
@@ -1474,15 +1523,13 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($result['settingsLoaded']);
         $this->assertEmpty($result['errors']);
 
-    }
-
+    }//end testInitializeSuccess()
 
     public function testInitializeWithPartialFailure(): void
     {
         $this->markTestSkipped('OC_App::installApp() is not available in unit test context');
 
-    }
-
+    }//end testInitializeWithPartialFailure()
 
     public function testInitializeAutoConfiguresWhenNotEmpty(): void
     {
@@ -1490,19 +1537,23 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
             ->willReturn(true);
 
         $this->appManager->method('getAppVersion')
-            ->willReturnCallback(function (string $appId) {
-                return '1.0.0';
-            });
+            ->willReturnCallback(
+                    function (string $appId) {
+                        return '1.0.0';
+                    }
+                    );
 
-        $mockRegisterMapper = $this->createRegisterMapperMock([
-            [
-                'id'      => 1,
-                'slug'    => 'publication',
-                'schemas' => [
-                    ['id' => 10, 'title' => 'catalog'],
-                ],
-            ],
-        ]);
+        $mockRegisterMapper = $this->createRegisterMapperMock(
+                [
+                    [
+                        'id'      => 1,
+                        'slug'    => 'publication',
+                        'schemas' => [
+                            ['id' => 10, 'title' => 'catalog'],
+                        ],
+                    ],
+                ]
+                );
 
         $mockConfigService = $this->createConfigServiceMock('1.0.0');
 
@@ -1510,20 +1561,26 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
             ->willReturn(['openregister']);
 
         $this->container->method('get')
-            ->willReturnCallback(function (string $class) use ($mockRegisterMapper, $mockConfigService) {
-                if ($class === 'OCA\OpenRegister\Db\RegisterMapper') {
-                    return $mockRegisterMapper;
-                }
-                if ($class === 'OCA\OpenRegister\Service\ConfigurationService') {
-                    return $mockConfigService;
-                }
-                return null;
-            });
+            ->willReturnCallback(
+                    function (string $class) use ($mockRegisterMapper, $mockConfigService) {
+                        if ($class === 'OCA\OpenRegister\Db\RegisterMapper') {
+                            return $mockRegisterMapper;
+                        }
+
+                        if ($class === 'OCA\OpenRegister\Service\ConfigurationService') {
+                            return $mockConfigService;
+                        }
+
+                        return null;
+                    }
+                    );
 
         $this->config->method('getValueString')
-            ->willReturnCallback(function (string $app, string $key, string $default = '') {
-                return $default;
-            });
+            ->willReturnCallback(
+                    function (string $app, string $key, string $default='') {
+                        return $default;
+                    }
+                    );
 
         $this->config->method('setValueString')->willReturn(true);
 
@@ -1532,13 +1589,11 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($result['openRegister']);
         $this->assertTrue($result['autoConfigured']);
 
-    }
-
+    }//end testInitializeAutoConfiguresWhenNotEmpty()
 
     // ---------------------------------------------------------------
     // Private: enrichRegistersWithSchemas
     // ---------------------------------------------------------------
-
     public function testEnrichRegistersWithSchemasEmptyArray(): void
     {
         $this->appManager->method('getInstalledApps')
@@ -1551,8 +1606,7 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
         $result = $this->invokePrivateMethod($this->service, 'enrichRegistersWithSchemas', [[]]);
         $this->assertSame([], $result);
 
-    }
-
+    }//end testEnrichRegistersWithSchemasEmptyArray()
 
     public function testEnrichRegistersWithSchemasNoSchemaMapper(): void
     {
@@ -1565,15 +1619,16 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
         // Falls back to returning registers as-is.
         $this->assertSame($registers, $result);
 
-    }
-
+    }//end testEnrichRegistersWithSchemasNoSchemaMapper()
 
     public function testEnrichRegistersWithSchemasReplacesIds(): void
     {
-        $mockSchemaMapper = $this->createSchemaMapperMock([
-            10 => ['id' => 10, 'title' => 'Schema 10'],
-            20 => ['id' => 20, 'title' => 'Schema 20'],
-        ]);
+        $mockSchemaMapper = $this->createSchemaMapperMock(
+                [
+                    10 => ['id' => 10, 'title' => 'Schema 10'],
+                    20 => ['id' => 20, 'title' => 'Schema 20'],
+                ]
+                );
 
         $this->appManager->method('getInstalledApps')
             ->willReturn(['openregister']);
@@ -1590,14 +1645,15 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
         $this->assertSame(10, $result[0]['schemas'][0]['id']);
         $this->assertSame(20, $result[0]['schemas'][1]['id']);
 
-    }
-
+    }//end testEnrichRegistersWithSchemasReplacesIds()
 
     public function testEnrichRegistersWithSchemasHandlesObjects(): void
     {
-        $mockSchemaMapper = $this->createSchemaMapperMock([
-            5 => ['id' => 5, 'title' => 'Schema 5'],
-        ]);
+        $mockSchemaMapper = $this->createSchemaMapperMock(
+                [
+                    5 => ['id' => 5, 'title' => 'Schema 5'],
+                ]
+                );
 
         $this->appManager->method('getInstalledApps')
             ->willReturn(['openregister']);
@@ -1614,8 +1670,7 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
         $this->assertCount(1, $result);
         $this->assertSame(5, $result[0]['schemas'][0]['id']);
 
-    }
-
+    }//end testEnrichRegistersWithSchemasHandlesObjects()
 
     public function testEnrichRegistersWithSchemasEmptySchemasArray(): void
     {
@@ -1633,8 +1688,7 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
         $this->assertCount(1, $result);
         $this->assertEmpty($result[0]['schemas']);
 
-    }
-
+    }//end testEnrichRegistersWithSchemasEmptySchemasArray()
 
     public function testEnrichRegistersWithSchemasSkipsNonNumericIds(): void
     {
@@ -1648,13 +1702,12 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
 
         $existingSchemaData = ['id' => 99, 'title' => 'Already resolved'];
         $registers          = [['id' => 1, 'slug' => 'test', 'schemas' => [$existingSchemaData]]];
-        $result             = $this->invokePrivateMethod($this->service, 'enrichRegistersWithSchemas', [$registers]);
+        $result = $this->invokePrivateMethod($this->service, 'enrichRegistersWithSchemas', [$registers]);
 
         $this->assertCount(1, $result);
         $this->assertSame($existingSchemaData, $result[0]['schemas'][0]);
 
-    }
-
+    }//end testEnrichRegistersWithSchemasSkipsNonNumericIds()
 
     public function testEnrichRegistersWithSchemasHandlesSchemaNotFound(): void
     {
@@ -1674,8 +1727,7 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
         $this->assertCount(1, $result);
         $this->assertEmpty($result[0]['schemas']);
 
-    }
-
+    }//end testEnrichRegistersWithSchemasHandlesSchemaNotFound()
 
     public function testEnrichRegistersWithSchemasNoSchemasKey(): void
     {
@@ -1692,13 +1744,11 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
 
         $this->assertCount(1, $result);
 
-    }
-
+    }//end testEnrichRegistersWithSchemasNoSchemasKey()
 
     // ---------------------------------------------------------------
     // Private: updateObjectTypeConfiguration
     // ---------------------------------------------------------------
-
     public function testUpdateObjectTypeConfigurationWithSchemaArrays(): void
     {
         $importResult = [
@@ -1713,10 +1763,12 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
 
         $storedValues = [];
         $this->config->method('setValueString')
-            ->willReturnCallback(function (string $app, string $key, string $value) use (&$storedValues) {
-                $storedValues[$key] = $value;
-                return true;
-            });
+            ->willReturnCallback(
+                    function (string $app, string $key, string $value) use (&$storedValues) {
+                        $storedValues[$key] = $value;
+                        return true;
+                    }
+                    );
 
         $this->invokePrivateMethod($this->service, 'updateObjectTypeConfiguration', [$importResult]);
 
@@ -1726,8 +1778,7 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('11', $storedValues['listing_schema']);
         $this->assertSame('1', $storedValues['listing_register']);
 
-    }
-
+    }//end testUpdateObjectTypeConfigurationWithSchemaArrays()
 
     public function testUpdateObjectTypeConfigurationWithSchemaObjects(): void
     {
@@ -1746,18 +1797,19 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
 
         $storedValues = [];
         $this->config->method('setValueString')
-            ->willReturnCallback(function (string $app, string $key, string $value) use (&$storedValues) {
-                $storedValues[$key] = $value;
-                return true;
-            });
+            ->willReturnCallback(
+                    function (string $app, string $key, string $value) use (&$storedValues) {
+                        $storedValues[$key] = $value;
+                        return true;
+                    }
+                    );
 
         $this->invokePrivateMethod($this->service, 'updateObjectTypeConfiguration', [$importResult]);
 
         $this->assertSame('30', $storedValues['theme_schema']);
         $this->assertSame('2', $storedValues['theme_register']);
 
-    }
-
+    }//end testUpdateObjectTypeConfigurationWithSchemaObjects()
 
     public function testUpdateObjectTypeConfigurationNoMatchingRegister(): void
     {
@@ -1772,10 +1824,12 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
 
         $storedValues = [];
         $this->config->method('setValueString')
-            ->willReturnCallback(function (string $app, string $key, string $value) use (&$storedValues) {
-                $storedValues[$key] = $value;
-                return true;
-            });
+            ->willReturnCallback(
+                    function (string $app, string $key, string $value) use (&$storedValues) {
+                        $storedValues[$key] = $value;
+                        return true;
+                    }
+                    );
 
         $this->invokePrivateMethod($this->service, 'updateObjectTypeConfiguration', [$importResult]);
 
@@ -1783,8 +1837,7 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('10', $storedValues['catalog_schema']);
         $this->assertArrayNotHasKey('catalog_register', $storedValues);
 
-    }
-
+    }//end testUpdateObjectTypeConfigurationNoMatchingRegister()
 
     public function testUpdateObjectTypeConfigurationEmptyResult(): void
     {
@@ -1795,10 +1848,12 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
 
         $storedValues = [];
         $this->config->method('setValueString')
-            ->willReturnCallback(function (string $app, string $key, string $value) use (&$storedValues) {
-                $storedValues[$key] = $value;
-                return true;
-            });
+            ->willReturnCallback(
+                    function (string $app, string $key, string $value) use (&$storedValues) {
+                        $storedValues[$key] = $value;
+                        return true;
+                    }
+                    );
 
         $this->invokePrivateMethod($this->service, 'updateObjectTypeConfiguration', [$importResult]);
 
@@ -1809,8 +1864,7 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
             $this->assertArrayNotHasKey("{$type}_register", $storedValues);
         }
 
-    }
-
+    }//end testUpdateObjectTypeConfigurationEmptyResult()
 
     public function testUpdateObjectTypeConfigurationWithUuidFallback(): void
     {
@@ -1825,18 +1879,19 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
 
         $storedValues = [];
         $this->config->method('setValueString')
-            ->willReturnCallback(function (string $app, string $key, string $value) use (&$storedValues) {
-                $storedValues[$key] = $value;
-                return true;
-            });
+            ->willReturnCallback(
+                    function (string $app, string $key, string $value) use (&$storedValues) {
+                        $storedValues[$key] = $value;
+                        return true;
+                    }
+                    );
 
         $this->invokePrivateMethod($this->service, 'updateObjectTypeConfiguration', [$importResult]);
 
         $this->assertSame('abc-123', $storedValues['page_schema']);
         $this->assertSame('reg-456', $storedValues['page_register']);
 
-    }
-
+    }//end testUpdateObjectTypeConfigurationWithUuidFallback()
 
     public function testUpdateObjectTypeConfigurationSetsAllObjectTypes(): void
     {
@@ -1847,10 +1902,12 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
 
         $storedValues = [];
         $this->config->method('setValueString')
-            ->willReturnCallback(function (string $app, string $key, string $value) use (&$storedValues) {
-                $storedValues[$key] = $value;
-                return true;
-            });
+            ->willReturnCallback(
+                    function (string $app, string $key, string $value) use (&$storedValues) {
+                        $storedValues[$key] = $value;
+                        return true;
+                    }
+                    );
 
         $this->invokePrivateMethod($this->service, 'updateObjectTypeConfiguration', [$importResult]);
 
@@ -1859,13 +1916,11 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
             $this->assertArrayHasKey("{$type}_source", $storedValues);
         }
 
-    }
-
+    }//end testUpdateObjectTypeConfigurationSetsAllObjectTypes()
 
     // ---------------------------------------------------------------
     // Private: shouldLoadSettings
     // ---------------------------------------------------------------
-
     public function testShouldLoadSettingsReturnsTrueNoStoredVersion(): void
     {
         $mockConfigService = $this->createConfigServiceMock(null);
@@ -1883,8 +1938,7 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
 
         $this->assertTrue($result);
 
-    }
-
+    }//end testShouldLoadSettingsReturnsTrueNoStoredVersion()
 
     public function testShouldLoadSettingsReturnsTrueWhenNewer(): void
     {
@@ -1904,8 +1958,7 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
 
         $this->assertTrue($result);
 
-    }
-
+    }//end testShouldLoadSettingsReturnsTrueWhenNewer()
 
     public function testShouldLoadSettingsReturnsFalseWhenSameVersion(): void
     {
@@ -1925,8 +1978,7 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
 
         $this->assertFalse($result);
 
-    }
-
+    }//end testShouldLoadSettingsReturnsFalseWhenSameVersion()
 
     public function testShouldLoadSettingsReturnsTrueOnException(): void
     {
@@ -1940,8 +1992,7 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
 
         $this->assertTrue($result);
 
-    }
-
+    }//end testShouldLoadSettingsReturnsTrueOnException()
 
     public function testShouldLoadSettingsReturnsFalseWhenOlderVersion(): void
     {
@@ -1961,7 +2012,5 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase
 
         $this->assertFalse($result);
 
-    }
-
-
-}
+    }//end testShouldLoadSettingsReturnsFalseWhenOlderVersion()
+}//end class


### PR DESCRIPTION
## Summary

- **R1 (DownloadServiceTest)**: Removed 4 failing test methods that called the deleted `createPublicationZip` method (wave-3 C5). Replaced with a single `testCreatePublicationZipMethodDoesNotExist` that asserts the method no longer exists, preventing regression.
- **R2 (SettingsServiceTest)**: Fixed `testUpdateSettingsThrowsOnFailure` to use a known allowlisted key (`catalog_source`) so `setValueString` is actually invoked and the exception path is exercised. Added `testUpdateSettingsUnknownKeyIsSilentlyFiltered` to explicitly document the C1 allowlist contract. Also auto-fixed 392 PHPCS style violations and added docblocks to 3 methods.
- **N1 (SettingsController)**: Removed `@NoCSRFRequired` from `updatePublishingOptions` (POST) and `manualImport` (POST). POST endpoints on admin-only controllers must require CSRF tokens — same attack surface as C1.
- **N2 (DirectoryService)**: Removed `_multitenancy: false` from both `searchObjects` call sites in `getDirectory()` (listings + catalogs). Per ADR-002 each tenant queries only its own data; bypassing multitenancy caused cross-tenant record leakage.

## Quality gates

- PHPStan: no errors on all 4 changed files
- PHPCS: DownloadServiceTest clean; SettingsServiceTest reduced from 517 to 125 non-auto-fixable errors (392 fixed by phpcbf)

## Test plan

- [ ] CI phpunit passes (DownloadServiceTest no longer has 4 undefined-method calls)
- [ ] CI phpstan passes on lib/Controller/SettingsController.php and lib/Service/DirectoryService.php
- [ ] Verify updatePublishingOptions and manualImport now require CSRF token
- [ ] Verify directory listing endpoint returns only the calling tenant own listings