### PR TITLE
ci(docs): add nightly journeydoc capture workflow

### DIFF
--- a/.github/workflows/docs-capture.yml
+++ b/.github/workflows/docs-capture.yml
@@ -1,0 +1,57 @@
+name: Docs capture
+
+# Nightly Playwright run that drives the OpenCatalogi UI through the
+# journeydoc tutorial flows and commits any refreshed screenshots back
+# to docs/static/screenshots/tutorials/{user,admin}/. Per ADR-030 and
+# hydra#279 stap 14.
+#
+# Uses the centralized journeydoc-capture job from
+# ConductionNL/.github/.github/workflows/quality.yml. All other quality
+# gates are disabled — this run is dedicated to screenshot refresh,
+# not regression testing.
+#
+# Manual trigger: Actions → "Docs capture" → Run workflow.
+
+on:
+  schedule:
+    # 03:27 UTC nightly (04:27 CET / 05:27 CEST — quiet hours).
+    # Off-the-hour minute to avoid GitHub's :00 scheduling cluster.
+    - cron: "27 3 * * *"
+  workflow_dispatch:
+
+jobs:
+  capture:
+    uses: ConductionNL/.github/.github/workflows/quality.yml@main
+    with:
+      app-name: opencatalogi
+      php-version: "8.3"
+      nextcloud-test-refs: '["stable32"]'
+      # OpenCatalogi reads from OpenRegister at runtime — without it,
+      # the tutorial flows can't render the lists/details that the
+      # capture spec navigates to.
+      additional-apps: '[{"repo":"ConductionNL/openregister","app":"openregister","ref":"development"}]'
+
+      # Activate the journeydoc capture + point its deploy at the
+      # existing documentation workflow (which deploys the docs to
+      # opencatalogi.conduction.nl).
+      enable-journeydoc-capture: true
+      journeydoc-deploy-workflow: documentation.yml
+
+      # Disable every other quality gate that has a toggle. The php-quality
+      # and security jobs always run (no toggle), but they're cheap (~2 min
+      # each) — acceptable overhead for the docs-capture cadence.
+      enable-frontend: false
+      enable-eslint: false
+      enable-license-check: false
+      enable-sbom: false
+      enable-features-extract: false
+      enable-coverage-guard: false
+      enable-phpunit: false
+      enable-newman: false
+      enable-playwright: false
+      enable-psalm: false
+      enable-phpstan: false
+      enable-phpmd: false
+      enable-phpcs: false
+      enable-phpmetrics: false
+    secrets: inherit

--- a/.github/workflows/docs-capture.yml
+++ b/.github/workflows/docs-capture.yml
@@ -6,7 +6,7 @@ name: Docs capture
 # hydra#279 stap 14.
 #
 # Uses the centralized journeydoc-capture job from
-# ConductionNL/.github/.github/workflows/quality.yml. All other quality
+# Conduction/.github/.github/workflows/quality.yml. All other quality
 # gates are disabled — this run is dedicated to screenshot refresh,
 # not regression testing.
 #
@@ -21,7 +21,7 @@ on:
 
 jobs:
   capture:
-    uses: ConductionNL/.github/.github/workflows/quality.yml@main
+    uses: Conduction/.github/.github/workflows/quality.yml@main
     with:
       app-name: opencatalogi
       php-version: "8.3"


### PR DESCRIPTION
## Summary

Per [hydra#279](https://github.com/ConductionNL/hydra/issues/279) stap 14 — nachtelijke screenshot refresh van de tutorial-pagina's onder `docs/static/screenshots/tutorials/`. Maakt OpenCatalogi de **eerste app in de fleet** die de gecentraliseerde journeydoc-capture job van [ConductionNL/.github#107](https://github.com/ConductionNL/.github/pull/107) gebruikt.

### Wat dit doet

Nieuwe workflow `.github/workflows/docs-capture.yml`:
- **Trigger**: cron `27 3 * * *` (nachtelijk 03:27 UTC = 04:27 CET / 05:27 CEST) + handmatige `workflow_dispatch`
- Roept `ConductionNL/.github/.github/workflows/quality.yml@main` aan met `enable-journeydoc-capture: true` en alle andere gates uit
- `additional-apps` wired voor OpenRegister (zelfde config als bestaande `code-quality.yml`) zodat OpenCatalogi's tutorial-flows volledig kunnen renderen
- `journeydoc-deploy-workflow: documentation.yml` — triggert de bestaande docs-deploy zodra screenshots wijzigen

Resultaat na merge: PR #559's tutorials + capture spec lopen elke nacht door, gewijzigde screenshots worden gecommit + de docs-site verdere zichzelf.

### Hoe werkt het uiteindelijk

```
[03:27 UTC]
  ↓
quality.yml @ ConductionNL/.github
  ↓  spint NC32 + Postgres + OpenCatalogi + OpenRegister
  ↓  npm run build (PWA bundle)
  ↓  npx playwright test --project docs-capture
  ↓  git diff docs/static/screenshots/tutorials/
  ↓  diff = leeg? → no-op, klaar
  ↓  diff = bestaat? → commit + push naar development + dispatch documentation.yml
                                       ↓
                              docs-site rebuildt
```

### Geen PATs nodig

Conduction post-"github has been hacked" beleid: alleen `GITHUB_TOKEN` (contents:write + actions:write op job-niveau, gescoped op deze repo).

### ⚠️ Afhankelijkheid

Deze PR is afhankelijk van [ConductionNL/.github#107](https://github.com/ConductionNL/.github/pull/107) — die voegt de `enable-journeydoc-capture` / `journeydoc-output-path` / `journeydoc-deploy-workflow` inputs toe aan de centrale `quality.yml`. **Eerst die mergen, dan deze.** Tot de .github-PR merged is, faalt deze workflow met "Unexpected input(s)" als-ie zou triggeren.

## Test plan

- [ ] Merge ConductionNL/.github#107 eerst
- [ ] Merge deze PR daarna
- [ ] Actions → "Docs capture" → "Run workflow" → handmatig triggeren als smoke-test
- [ ] Eerste run gaat waarschijnlijk falen op een race / firstrunwizard / selector — plan zegt "2-3 iteraties verwacht"
- [ ] Daarna nachtelijk groen → screenshots blijven actueel zonder handwerk

## Follow-up (out of scope)

Na succes op opencatalogi, dezelfde workflow file uitrollen naar de andere 6 apps met journeydoc-scaffold: mydash, openregister, openconnector, doriath, docudesk, pipelinq.

Refs hydra#279, [ADR-030](https://github.com/ConductionNL/hydra/blob/main/openspec/architecture/adr-030-journeydoc-pattern.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)