### PR TITLE
ci(l10n): fix the parity-gate container image (ci-node:22 → :20)

### DIFF
--- a/.forgejo/workflows/l10n-parity.yml
+++ b/.forgejo/workflows/l10n-parity.yml
@@ -17,7 +17,7 @@ jobs:
     name: l10n translation parity (nl/de/fr/es/it)
     runs-on: docker
     container:
-      image: code.forgejo.org/oci/ci-node:22
+      image: code.forgejo.org/oci/ci-node:20
     steps:
       - name: Checkout
         uses: https://code.forgejo.org/actions/checkout@v4


### PR DESCRIPTION
Heropend na de migratie van Codeberg naar GitHub (2026-07-14).
Origineel, met review-historie: https://codeberg.org/Conduction/opencatalogi/pulls/116