### PR TITLE
feat(fts): port WOO-506 + WOO-517 public FTS to main (stable/fts)

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -27,7 +27,7 @@ Create a [feature request](https://github.com/OpenCatalogi/.github/issues/new/ch
 
 **Support:** For support, contact support@conduction.nl. For a Service Level Agreement (SLA), contact sales@conduction.nl.
     ]]></description>
-	<version>0.7.34</version>
+	<version>0.7.55</version>
 	<licence>agpl</licence>
 	<author mail="info@conduction.nl" homepage="https://www.conduction.nl/">Conduction</author>
 	<author mail="info@acato.nl" homepage="https://acato.nl/">Acato</author>
@@ -56,7 +56,7 @@ Create a [feature request](https://github.com/OpenCatalogi/.github/issues/new/ch
         <lib>zip</lib>
 
         <owncloud max-version="0" min-version="0"/>
-		<nextcloud min-version="28" max-version="33"/>
+		<nextcloud min-version="28" max-version="34"/>
 	</dependencies>
 
 	<repair-steps>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -27,7 +27,7 @@ Create a [feature request](https://github.com/OpenCatalogi/.github/issues/new/ch
 
 **Support:** For support, contact support@conduction.nl. For a Service Level Agreement (SLA), contact sales@conduction.nl.
     ]]></description>
-	<version>0.7.55</version>
+	<version>0.7.56</version>
 	<licence>agpl</licence>
 	<author mail="info@conduction.nl" homepage="https://www.conduction.nl/">Conduction</author>
 	<author mail="info@acato.nl" homepage="https://acato.nl/">Acato</author>

--- a/lib/Controller/SearchController.php
+++ b/lib/Controller/SearchController.php
@@ -21,11 +21,17 @@ namespace OCA\OpenCatalogi\Controller;
 
 use OCP\AppFramework\Http\DataDownloadResponse;
 use OCA\OpenCatalogi\Service\PublicationService;
+use OCA\OpenCatalogi\Service\PublicationQueryService;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
+use OCP\IL10N;
 use OCP\IRequest;
 use Psr\Container\ContainerExceptionInterface;
+use Psr\Container\ContainerInterface;
 use Psr\Container\NotFoundExceptionInterface;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
 
 /**
  * Controller for handling internal search-related operations.
@@ -42,31 +48,111 @@ class SearchController extends Controller
     public function __construct(
         $appName,
         IRequest $request,
-        private readonly PublicationService $publicationService
+        private readonly PublicationService $publicationService,
+        private readonly ?PublicationQueryService $queryService=null,
+        private readonly ?ContainerInterface $container=null,
+        private readonly ?LoggerInterface $logger=null,
+        private readonly ?IL10N $l10n=null
     ) {
         parent::__construct(appName: $appName, request: $request);
 
     }//end __construct()
 
     /**
-     * Retrieve a list of publications based on all available catalogs.
+     * Search endpoint. Two behaviours behind the same route:
      *
-     * This is an internal endpoint for testing and administrative purposes.
+     *  - **WOO-506 / WOO-517 public full-text search** (fires when `_search` is present in
+     *    the query). Delegates to {@see PublicationQueryService::assemblePublicSearchResults()},
+     *    returns the flat mixed envelope with `@self.schema` discriminator. Respects the
+     *    opt-in `_content=true` for document body-text search (WOO-517 / OR PR #473).
+     *  - **Pre-WOO-506 internal listing** (fires when `_search` is absent). Preserves the
+     *    original main behaviour: delegates to `PublicationService::index($catalogId)` and
+     *    lists publications, optionally scoped by catalog. This branch is a defensive
+     *    backward-compat guard for any admin/testing tool that still hits `/api/search`
+     *    without a search term.
      *
-     * @param string|null $catalogId Optional ID of a specific catalog to filter by.
+     * @param string|null $catalogId Optional ID of a specific catalog to filter by
+     *                               (only honoured by the legacy internal listing branch).
      *
-     * @return JSONResponse JSON response containing the list of publications.
+     * @return JSONResponse JSON response — search-envelope or publication list.
      *
      * @throws ContainerExceptionInterface|NotFoundExceptionInterface
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+     * @PublicPage
      */
     public function index(?string $catalogId=null): JSONResponse
     {
+        // WOO-506 public FTS gate: opt-in when `_search` is supplied, OR when the caller
+        // wants facets (`_facetable=true` / `_facets[...]`) which are only usefully served
+        // by the FTS-envelope path. Absent → pre-WOO-506 internal-listing behaviour is
+        // preserved byte-for-byte below.
+        $searchTerm     = $this->request->getParam('_search');
+        $hasSearch      = ($searchTerm !== null && trim((string) $searchTerm) !== '');
+        $wantsFacetable = filter_var($this->request->getParam('_facetable', false), FILTER_VALIDATE_BOOLEAN) === true;
+        $wantsFacets    = is_array($this->request->getParam('_facets')) === true;
+        if (($hasSearch === true || $wantsFacetable === true || $wantsFacets === true) && $this->queryService !== null) {
+            try {
+                $objectService = $this->getObjectService();
+                $result = $this->queryService->assemblePublicSearchResults(
+                    queryParams: $this->request->getParams(),
+                    objectService: $objectService
+                );
+                return new JSONResponse(data: $result, statusCode: Http::STATUS_OK);
+            } catch (RuntimeException $e) {
+                if ($this->logger !== null) {
+                    $this->logger->warning(
+                        '[SearchController::index] OpenRegister not installed — public search unavailable',
+                        ['error' => $e->getMessage()]
+                    );
+                }
+                $errorMsg = $this->l10n !== null ? $this->l10n->t('Search backend is not available.') : 'Search backend is not available.';
+                return new JSONResponse(
+                    data: ['error' => $errorMsg],
+                    statusCode: Http::STATUS_SERVICE_UNAVAILABLE
+                );
+            } catch (\Exception $e) {
+                if ($this->logger !== null) {
+                    $this->logger->error(
+                        '[SearchController::index] Failed to execute public search',
+                        ['error' => $e->getMessage()]
+                    );
+                }
+                $errorMsg = $this->l10n !== null ? $this->l10n->t('Internal server error') : 'Internal server error';
+                return new JSONResponse(
+                    data: ['error' => $errorMsg],
+                    statusCode: Http::STATUS_INTERNAL_SERVER_ERROR
+                );
+            }
+        }
+
+        // Legacy pre-WOO-506 path: preserved unchanged.
         return $this->publicationService->index($catalogId);
 
     }//end index()
+
+    /**
+     * Resolve OpenRegister's ObjectService via the DI container. Kept as a method
+     * (not typehinted constructor arg) because a live openregister app may or may
+     * not be installed on any given deployment — the SearchController is loaded
+     * regardless, and the ObjectService resolve is only attempted on the FTS path.
+     *
+     * @return object The OpenRegister ObjectService instance.
+     *
+     * @throws RuntimeException When OpenRegister is not installed / DI cannot resolve it.
+     */
+    private function getObjectService(): object
+    {
+        if ($this->container === null) {
+            throw new RuntimeException('Container not available; SearchController FTS branch inactive.');
+        }
+        try {
+            return $this->container->get('OCA\\OpenRegister\\Service\\ObjectService');
+        } catch (\Throwable $e) {
+            throw new RuntimeException('OpenRegister ObjectService not available: '.$e->getMessage(), 0, $e);
+        }
+    }//end getObjectService()
 
     /**
      * Retrieve a specific publication by its ID.

--- a/lib/Controller/SearchController.php
+++ b/lib/Controller/SearchController.php
@@ -81,6 +81,7 @@ class SearchController extends Controller
      * @NoAdminRequired
      * @NoCSRFRequired
      * @PublicPage
+     * @BruteForceProtection(action=publicSearch)
      */
     public function index(?string $catalogId=null): JSONResponse
     {

--- a/lib/Controller/SearchController.php
+++ b/lib/Controller/SearchController.php
@@ -100,7 +100,17 @@ class SearchController extends Controller
                     queryParams: $this->request->getParams(),
                     objectService: $objectService
                 );
-                return new JSONResponse(data: $result, statusCode: Http::STATUS_OK);
+                $response = new JSONResponse(data: $result, statusCode: Http::STATUS_OK);
+                // Activate `@BruteForceProtection(action=publicSearch)` — the
+                // annotation only accrues delay when a controller calls
+                // `throttle()`; without this call the throttle was cosmetic
+                // and no rate limiting ever kicked in on the public path
+                // (review #147 🟡 unauthenticated DoS). Recording every
+                // public-FTS request meters legitimate use lightly and
+                // ramps up the delay only under sustained hammering, per
+                // Nextcloud's built-in brute-force machinery.
+                $response->throttle(['action' => 'publicSearch']);
+                return $response;
             } catch (RuntimeException $e) {
                 if ($this->logger !== null) {
                     $this->logger->warning(

--- a/lib/Service/PublicationQueryService.php
+++ b/lib/Service/PublicationQueryService.php
@@ -1,0 +1,909 @@
+<?php
+/**
+ * Service for publication query building and response shaping.
+ *
+ * Encapsulates the query-building, object-location, and response-shaping logic
+ * extracted from PublicationsController to keep the controller thin.
+ *
+ * @category Service
+ * @package  OCA\OpenCatalogi\Service
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2024 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://www.OpenCatalogi.nl
+ */
+
+namespace OCA\OpenCatalogi\Service;
+
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\IAppConfig;
+use OCP\IUserSession;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Query-building and response-shaping helpers for publications.
+ *
+ * All methods in this service are pure-logic helpers with no side-effects on
+ * routing, authentication, or HTTP response codes. They exist solely to reduce
+ * the size of PublicationsController.
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
+ */
+class PublicationQueryService
+{
+
+    /**
+     * Order fields that exist in every magic-mapper table.
+     *
+     * Used when filtering _order for multi-register searches.
+     *
+     * @var array<string>
+     */
+    private const UNIVERSAL_ORDER_FIELDS = [
+        '_uuid',
+        '_created',
+        '_updated',
+        '_name',
+        '_description',
+        '_summary',
+        '_relevance',
+    ];
+
+    /**
+     * Constructor.
+     *
+     * @param ContainerInterface   $container   DI container
+     * @param IUserSession|null    $userSession User session for anonymity checks (auto-wired at runtime)
+     * @param IAppConfig|null      $config      App config, resolves the publication/document register+schema ids
+     * @param LoggerInterface|null $logger      Logger — surfaces the fail-closed empty-envelope branch so silent
+     *                                          configuration drift is observable in production (SCH-PFTS-005).
+     */
+    public function __construct(
+        private readonly ContainerInterface $container,
+        private readonly ?IUserSession $userSession=null,
+        private readonly ?IAppConfig $config=null,
+        private readonly ?LoggerInterface $logger=null,
+    ) {
+
+    }//end __construct()
+
+    /**
+     * Determine whether the current request is made by an anonymous (logged-out) caller.
+     *
+     * Used by the published-predicate guard on the public per-catalog relation endpoints
+     * (PublicationsController::uses/used) so an anonymous caller cannot enumerate the
+     * relation graph of an unpublished object by guessing its UUID.
+     *
+     * @return boolean True when there is no authenticated user on the session.
+     *
+     * @spec exclude Visibility helper for the public-endpoint published-predicate guard.
+     */
+    public function isAnonymous(): bool
+    {
+        if ($this->userSession === null) {
+            // Fail closed: when the session is unavailable, treat the caller as anonymous
+            // so the published-predicate guard applies the stricter visibility rule.
+            return true;
+        }
+
+        return $this->userSession->getUser() === null;
+
+    }//end isAnonymous()
+
+    /**
+     * Determine whether an object is publicly visible (published and not depublished).
+     *
+     * Mirrors the live OpenRegister RBAC visibility model (APB-006), the same rule
+     * the public publications API and the frontend `publicationStatus` helpers use:
+     * an object is public when its own `publicatiedatum` field is set and is at or
+     * before "now", and either carries no `depublicatiedatum` or one still in the
+     * future. The removed object-level `@self.published` predicate is not consulted.
+     *
+     * @param array $objectData The serialized object data (own fields + `@self` envelope).
+     *
+     * @return boolean True when the object is currently published.
+     *
+     * @spec openspec/specs/auto-publishing/spec.md#APB-006
+     */
+    public function isObjectPublic(array $objectData): bool
+    {
+        $publicatiedatum   = ($objectData['publicatiedatum'] ?? null);
+        $depublicatiedatum = ($objectData['depublicatiedatum'] ?? null);
+
+        if ($publicatiedatum === null || $publicatiedatum === '') {
+            return false;
+        }
+
+        $now           = time();
+        $publishedTime = strtotime((string) $publicatiedatum);
+        if ($publishedTime === false || $publishedTime > $now) {
+            return false;
+        }
+
+        if ($depublicatiedatum === null || $depublicatiedatum === '') {
+            return true;
+        }
+
+        $depublishedTime = strtotime((string) $depublicatiedatum);
+        return ($depublishedTime === false || $depublishedTime > $now);
+
+    }//end isObjectPublic()
+
+    /**
+     * Assemble the public full-text search result envelope (SCH-PFTS-002/006/007).
+     *
+     * Delegates entirely to OR's zoeken-filteren (`ObjectService::searchObjectsPaginated`)
+     * across the `publication` and `document` schemas of the publication register, merges
+     * the candidate rows into a single flat array discriminated by `@self.schema`
+     * (SCH-PFTS-002), embeds the linked publication summary on every document row
+     * (SCH-PFTS-003), and applies the anonymous visibility filter AFTER scoring/merge
+     * (SCH-PFTS-004) so ranking is computed on the full candidate set before visibility
+     * is enforced. Authenticated callers are not filtered — this endpoint absorbs the
+     * previous admin-only search and authenticated callers keep seeing every match
+     * (SCH-OR-003).
+     *
+     * The scope (register + schemas) is fixed by this method and never taken from the
+     * caller-supplied query parameters, so a caller cannot widen the search beyond the
+     * publication/document schemas by passing its own `_register`/`_schema(s)` (mirrors
+     * the constrained-scope discipline in {@see findObjectLocation()}).
+     *
+     * Dual-path (design.md "Dual-path design"): this ships Path B — matches are
+     * driven by OR's `zoeken-filteren` against schema properties and `@self` metadata.
+     * Path A (document-content matching, WOO-517) is layered on top via the opt-in
+     * `_content` query parameter: when set, the OR-side `_content_search` flag
+     * (shipped in `openregister:expose-content-search-in-object-service`, PR #473) is
+     * forwarded on `searchObjectsPaginated()`'s query array, widening the candidate
+     * set to documents whose OR-extracted body text matches the query. OpenCatalogi
+     * does not run its own text-extraction pipeline — OR's TextExtractionService +
+     * ChunkMapper own that entirely (SCH-PFTS-CONTENT-001).
+     *
+     * @param array  $queryParams   Raw request query parameters from IRequest::getParams().
+     *                              Recognised keys include the opt-in `_content` boolean
+     *                              (SCH-PFTS-CONTENT-001) — when true, forwarded to OR as
+     *                              `_content_search` to widen matching to document body text.
+     * @param object $objectService OpenRegister ObjectService instance (already resolved from container).
+     *
+     * @return array{results: array<int, array>, total: int} Flat mixed-type result envelope.
+     *
+     * @spec openspec/changes/add-public-fulltext-search/tasks.md#task-5
+     * @spec openspec/changes/add-document-content-search/tasks.md#task-3
+     *
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+     * @SuppressWarnings(PHPMD.NPathComplexity)
+     */
+    public function assemblePublicSearchResults(array $queryParams, object $objectService): array
+    {
+        $registerId          = $this->resolveConfiguredId('publication_register');
+        $publicationSchemaId = $this->resolveConfiguredId('publication_schema');
+        $documentSchemaId    = $this->resolveConfiguredId('document_schema');
+
+        if ($registerId === null || $publicationSchemaId === null || $documentSchemaId === null) {
+            // Configuration not (yet) loaded — fail closed to an empty envelope rather
+            // than falling back to an unscoped, platform-wide search. Emit a warning so
+            // the failure is observable in production (silent empty is indistinguishable
+            // from "no matches" in the response envelope; operators need a signal that
+            // the deploy is misconfigured).
+            $registerStatus          = 'set';
+            $publicationSchemaStatus = 'set';
+            $documentSchemaStatus    = 'set';
+            if ($registerId === null) {
+                $registerStatus = 'MISSING';
+            }
+
+            if ($publicationSchemaId === null) {
+                $publicationSchemaStatus = 'MISSING';
+            }
+
+            if ($documentSchemaId === null) {
+                $documentSchemaStatus = 'MISSING';
+            }
+
+            $this->logger?->warning(
+                'PublicationQueryService::assemblePublicSearchResults returning empty envelope — register/schema config unresolved',
+                [
+                    'publication_register' => $registerStatus,
+                    'publication_schema'   => $publicationSchemaStatus,
+                    'document_schema'      => $documentSchemaStatus,
+                ]
+            );
+            return [
+                'results' => [],
+                'total'   => 0,
+            ];
+        }//end if
+
+        $schemaSlugById = [
+            $publicationSchemaId => 'publication',
+            $documentSchemaId    => 'document',
+        ];
+
+        // Opt-in content-search (SCH-PFTS-CONTENT-001): widen matching to include
+        // OR-extracted document body text. Default false — omitted/false is
+        // byte-identical to the WOO-506 baseline, so existing consumers see zero
+        // drift. Read before buildSearchQuery() so the raw `_content` key can be
+        // stripped from the forwarded query below (it is OC's own flag name, not
+        // OR's — OR's equivalent is `_content_search`).
+        $contentSearchRequested = filter_var(
+            value: ($queryParams['_content'] ?? false),
+            filter: FILTER_VALIDATE_BOOLEAN
+        );
+
+        $searchQuery = $objectService->buildSearchQuery($queryParams);
+        // The scope is fixed above — strip any caller-supplied scope keys so a request
+        // parameter can never widen the search outside the publication/document schemas.
+        unset($searchQuery['_schema'], $searchQuery['_registers'], $searchQuery['catalogSlug'], $searchQuery['fq']);
+        unset($searchQuery['_content']);
+        $searchQuery['_register']       = $registerId;
+        $searchQuery['_schemas']        = [$publicationSchemaId, $documentSchemaId];
+        $searchQuery['_includeDeleted'] = false;
+
+        if ($contentSearchRequested === true) {
+            // Forward to OR's opt-in chunk-search fan-out (expose-content-search-in
+            // -object-service, PR #473). OR already dedupes its own metadata-match +
+            // chunk-match union on object id before returning; the `@self.id` dedup
+            // below is an additional guarantee at the OC assembly layer per
+            // SCH-PFTS-CONTENT-002 / MODIFIED SCH-PFTS-002.
+            $searchQuery['_content_search'] = true;
+        }
+
+        // _rbac: false — visibility is enforced below via isObjectPublic() AFTER
+        // scoring/merge (SCH-PFTS-004); folding it into the OR query would bias ranking
+        // against rows the corpus considers relevant.
+        $candidateResult = $objectService->searchObjectsPaginated(
+            query: $searchQuery,
+            _rbac: false,
+            _multitenancy: false
+        );
+
+        // Visibility filter runs unconditionally — the endpoint is public per
+        // SCH-PFTS-001, so it MUST NOT surface draft/depublished content to ANY
+        // caller (anonymous, authenticated non-admin, or admin). The prior
+        // `$isAnonymous === true &&` guard let any logged-in user enumerate the
+        // whole register because `_rbac: false` disables OR's schema authorization —
+        // classic broken-authorisation (OWASP A01:2021). Admins who need to see
+        // drafts use the admin `/publications` endpoint, not this public surface.
+        $publicationCache = [];
+        $seenObjectIds    = [];
+        $rows = [];
+
+        foreach (($candidateResult['results'] ?? []) as $candidate) {
+            $rowArray = $candidate;
+            if (is_array($rowArray) === false) {
+                $rowArray = $rowArray->jsonSerialize();
+            }
+
+            // Dedup on @self.id (SCH-PFTS-CONTENT-002 / MODIFIED SCH-PFTS-002): a
+            // document matching on BOTH metadata and body text must appear exactly
+            // once. Rows without a resolvable id (defensive — should not occur) are
+            // never deduped against each other. Marker is stamped AFTER all per-row
+            // validation (schema known + publication summary resolved + isObjectPublic
+            // check) so a first candidate that fails validation cannot silently
+            // suppress a later same-id candidate that would have passed — the metadata
+            // arm and the chunk arm can carry differently-stale denormalised
+            // `publication` fields, and only the emit-ready row should claim the seen
+            // slot.
+            $objectId = ($rowArray['@self']['id'] ?? ($rowArray['id'] ?? null));
+            if ($objectId !== null && isset($seenObjectIds[$objectId]) === true) {
+                continue;
+            }
+
+            $schemaId   = $this->extractSchemaId($rowArray);
+            $schemaSlug = ($schemaSlugById[$schemaId] ?? null);
+            if ($schemaSlug === null) {
+                continue;
+            }
+
+            $rowArray['@self']['schema'] = $schemaSlug;
+
+            // Strip any raw chunk-search fields OR might have attached to the row
+            // (SCH-PFTS-CONTENT-002 — the public response returns documents, never
+            // chunks). Defence-in-depth: OR already resolves each chunk hit to its
+            // owning ObjectEntity, so these fields should never be present; strip
+            // regardless so any future regression cannot leak them to the anonymous
+            // surface. Mirrors the scope-strip pattern used on the delegated query
+            // above.
+            unset(
+                $rowArray['_snippet'],
+                $rowArray['snippet'],
+                $rowArray['chunk'],
+                $rowArray['chunk_id'],
+                $rowArray['chunkId'],
+                $rowArray['score'],
+                $rowArray['_score']
+            );
+
+            if ($schemaSlug === 'document') {
+                $publicationSummary = $this->resolveDocumentPublicationSummary(
+                    documentRow: $rowArray,
+                    objectService: $objectService,
+                    registerId: $registerId,
+                    publicationSchemaId: $publicationSchemaId,
+                    cache: $publicationCache
+                );
+
+                if ($publicationSummary === null) {
+                    // No linked publication — MUST NOT appear (SCH-PFTS-003).
+                    continue;
+                }
+
+                if ($publicationSummary['public'] !== true) {
+                    // Transitive visibility (SCH-PFTS-004): linked publication is not
+                    // public — drop the document row regardless of caller identity.
+                    continue;
+                }
+
+                $rowArray['publication'] = $publicationSummary['summary'];
+            }//end if
+
+            if ($this->isObjectPublic($rowArray) === false) {
+                continue;
+            }
+
+            if ($objectId !== null) {
+                $seenObjectIds[$objectId] = true;
+            }
+
+            $rows[] = $rowArray;
+        }//end foreach
+
+        // Propagate the facets + facetable blocks from OR's response so consumers can
+        // build faceted-search UIs on this endpoint (docs claim, endpoint 2). OR only
+        // populates these when the caller asked for them (`_facetable=true` +
+        // `_facets[...]`); when absent, the keys are simply omitted from the response.
+        // The facet counts reflect OR's pre-filter view of the candidate set — visibility
+        // filtering below happens per-row in application code and does not adjust facets.
+        $envelope = [
+            'results' => $rows,
+            'total'   => count($rows),
+        ];
+        if (isset($candidateResult['facets']) === true) {
+            $envelope['facets'] = $candidateResult['facets'];
+        }
+        if (isset($candidateResult['facetable']) === true) {
+            $envelope['facetable'] = $candidateResult['facetable'];
+        }
+        return $envelope;
+
+    }//end assemblePublicSearchResults()
+
+    /**
+     * Resolve a configured register/schema id from app config.
+     *
+     * @param string $configKey The app-config key (e.g. `publication_register`).
+     *
+     * @return integer|null The configured id, or null when unconfigured/non-numeric.
+     *
+     * @spec exclude Configuration-lookup plumbing; no domain behavior of its own.
+     */
+    private function resolveConfiguredId(string $configKey): ?int
+    {
+        if ($this->config === null) {
+            return null;
+        }
+
+        $value = $this->config->getValueString('opencatalogi', $configKey, '');
+        if ($value === '' || is_numeric($value) === false) {
+            return null;
+        }
+
+        return (int) $value;
+
+    }//end resolveConfiguredId()
+
+    /**
+     * Extract the numeric schema id from a serialized object row's `@self.schema`.
+     *
+     * @param array $rowArray The serialized object row.
+     *
+     * @return integer|null The schema id, or null when absent/non-numeric.
+     *
+     * @spec exclude Row-shape plumbing; no domain behavior of its own.
+     */
+    private function extractSchemaId(array $rowArray): ?int
+    {
+        $schema = ($rowArray['@self']['schema'] ?? ($rowArray['schema'] ?? null));
+        if (is_array($schema) === true) {
+            $schema = ($schema['id'] ?? null);
+        }
+
+        if ($schema === null || is_numeric($schema) === false) {
+            return null;
+        }
+
+        return (int) $schema;
+
+    }//end extractSchemaId()
+
+    /**
+     * Resolve the linked publication's `{id, slug, title}` summary for a document row.
+     *
+     * Looks the linked publication up by slug (denormalised on the document's own
+     * `publication.slug` property) so the response can carry the publication's real
+     * UUID even though the authored document payload only carries `slug` + `title`
+     * (design.md "Seed publications" — the UUID does not exist until import). Results
+     * are cached per request so a page of documents linking the same publication only
+     * issues one lookup per unique slug.
+     *
+     * @param array               $documentRow         The document row (post `@self.schema` rewrite).
+     * @param object              $objectService       OpenRegister ObjectService instance.
+     * @param integer             $registerId          The publication register id.
+     * @param integer             $publicationSchemaId The publication schema id.
+     * @param array<string,mixed> $cache               Per-request slug → summary cache (by
+     *                                                 reference).
+     *
+     * @return array{summary: array{id:string,slug:string,title:string}, public: bool}|null
+     *
+     * @spec openspec/changes/add-public-fulltext-search/tasks.md#task-6
+     */
+    private function resolveDocumentPublicationSummary(
+        array $documentRow,
+        object $objectService,
+        int $registerId,
+        int $publicationSchemaId,
+        array &$cache
+    ): ?array {
+        $linked = ($documentRow['publication'] ?? null);
+        $slug   = null;
+        if (is_array($linked) === true) {
+            $slug = ($linked['slug'] ?? null);
+        } else if (is_string($linked) === true && $linked !== '') {
+            $slug = $linked;
+        }
+
+        if ($slug === null || $slug === '') {
+            return null;
+        }
+
+        if (array_key_exists($slug, $cache) === true) {
+            return $cache[$slug];
+        }
+
+        // Slug lives on the magic metadata column `_slug` and is addressed via
+        // the nested `@self` block (equivalent to `@self.slug` in URL query form).
+        // A bare `slug` key becomes a schema-property filter — publications have
+        // no `slug` property, so the search matches nothing and every document
+        // row is silently dropped by the assembler with a null publication
+        // summary.
+        $matches = $objectService->searchObjects(
+            query: [
+                '_register' => $registerId,
+                '_schema'   => $publicationSchemaId,
+                '@self'     => ['slug' => $slug],
+                '_limit'    => 1,
+            ],
+            _rbac: false,
+            _multitenancy: false
+        );
+
+        if (empty($matches) === true) {
+            $cache[$slug] = null;
+            return null;
+        }
+
+        $publication = $matches[0];
+        if (is_array($publication) === false) {
+            $publication = $publication->jsonSerialize();
+        }
+
+        $summary = [
+            'summary' => [
+                'id'    => (string) ($publication['id'] ?? ''),
+                'slug'  => (string) ($publication['@self']['slug'] ?? $slug),
+                'title' => (string) ($publication['title'] ?? ''),
+            ],
+            'public'  => $this->isObjectPublic($publication),
+        ];
+
+        $cache[$slug] = $summary;
+        return $summary;
+
+    }//end resolveDocumentPublicationSummary()
+
+    /**
+     * Find the register and schema IDs for an object UUID within a constrained scope.
+     *
+     * Locates which OpenRegister (register × schema) pair holds a given UUID, always
+     * scoped to the caller-supplied register/schema lists. The lookup goes through
+     * OpenRegister's `ObjectService` (ADR-022: consume OR abstractions) rather than
+     * issuing raw SQL against OR's internal per-register/per-schema storage tables or
+     * probing the DBMS catalog for their existence. OR remains free to change its
+     * physical storage layout without breaking opencatalogi.
+     *
+     * The legacy platform-wide search across every magic table is gone (#734) — it was
+     * an anonymous-reachable DoS vector and also leaked cross-catalog objects (#733).
+     * Callers MUST pass non-empty $allowedRegisters and $allowedSchemas; otherwise the
+     * method returns null without touching OpenRegister.
+     *
+     * @param string                 $uuid             The UUID of the object to find.
+     * @param array<int|string>|null $allowedRegisters Register IDs the search may touch.
+     * @param array<int|string>|null $allowedSchemas   Schema IDs the search may touch.
+     *
+     * @return array{register: int, schema: int}|null The register/schema IDs, or null.
+     *
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+     *
+     * @spec openspec/specs/opencatalogi-adopt-or-abstractions/spec.md
+     */
+    public function findObjectLocation(
+        string $uuid,
+        ?array $allowedRegisters=null,
+        ?array $allowedSchemas=null
+    ): ?array {
+        if (empty($allowedRegisters) === true || empty($allowedSchemas) === true) {
+            // Fail closed — without an explicit constraint we will NOT do a
+            // platform-wide scan. This is the post-#734 behaviour.
+            return null;
+        }
+
+        $objectService = $this->getObjectService();
+        if ($objectService === null) {
+            return null;
+        }
+
+        // Locate the object by asking OpenRegister to resolve it within each
+        // constrained (register × schema) pair. The location lookup is visibility-
+        // agnostic (_rbac: false) — it mirrors the previous behaviour of locating an
+        // object's home pair; callers re-apply their own RBAC/visibility filter on the
+        // subsequent read. No raw SQL and no knowledge of OR's table layout.
+        foreach ($allowedRegisters as $register) {
+            if (is_numeric($register) === false) {
+                continue;
+            }
+
+            $registerId = (int) $register;
+            foreach ($allowedSchemas as $schema) {
+                if (is_numeric($schema) === false) {
+                    continue;
+                }
+
+                $schemaId = (int) $schema;
+                try {
+                    $object = $objectService->find(
+                        id: $uuid,
+                        _extend: [],
+                        files: false,
+                        register: $registerId,
+                        schema: $schemaId,
+                        _rbac: false,
+                        _multitenancy: false
+                    );
+                } catch (DoesNotExistException $e) {
+                    continue;
+                } catch (\Exception $e) {
+                    continue;
+                }
+
+                if ($object !== null) {
+                    return [
+                        'register' => $registerId,
+                        'schema'   => $schemaId,
+                    ];
+                }
+            }//end foreach
+        }//end foreach
+
+        return null;
+
+    }//end findObjectLocation()
+
+    /**
+     * Resolve the OpenRegister ObjectService from the container.
+     *
+     * @return object|null The OpenRegister ObjectService, or null when OR is unavailable.
+     *
+     * @spec exclude Lazy dependency-injection accessor for the OR ObjectService; pure
+     *       framework plumbing, no domain behavior.
+     */
+    private function getObjectService(): ?object
+    {
+        try {
+            return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+        } catch (\Throwable $e) {
+            return null;
+        }
+
+    }//end getObjectService()
+
+    /**
+     * Build the ObjectService search query for a catalog index request.
+     *
+     * Merges the incoming request parameters with catalog-level schema/register filters,
+     * handles multi-schema and multi-register cases, and strips non-universal _order fields
+     * when searching across multiple registers.
+     *
+     * @param array  $catalog       Catalog data array (keys: schemas, registers).
+     * @param array  $queryParams   Raw request query parameters from IRequest::getParams().
+     * @param object $objectService ObjectService instance (already resolved from container).
+     *
+     * @return array The merged and sanitised search query ready for searchObjectsPaginated().
+     *
+     * @spec exclude Query-assembly plumbing extracted from PublicationsController; translates
+     *       request params into an ObjectService search query, no domain behavior of its own.
+     *
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+     * @SuppressWarnings(PHPMD.NPathComplexity)
+     */
+    public function buildCatalogSearchQuery(array $catalog, array $queryParams, object $objectService): array
+    {
+        // Use ObjectService centralized query builder which handles dot-to-underscore conversion.
+        $searchQuery = array_merge(
+            $objectService->buildSearchQuery($queryParams),
+            ['_includeDeleted' => false]
+        );
+
+        // Clean up catalog-specific parameters.
+        unset($searchQuery['catalogSlug'], $searchQuery['fq']);
+
+        // Handle catalog filtering using _schemas for multi-schema search.
+        if (empty($catalog['schemas']) === false) {
+            $schemas = $catalog['schemas'];
+            // Parse JSON string if needed.
+            if (is_string($schemas) === true) {
+                $schemas = json_decode($schemas, true) ?? [];
+            }
+
+            $schemas = array_map('intval', $schemas);
+            // Pass all schemas for both search and faceting.
+            $searchQuery['_schemas'] = $schemas;
+            // Only set _schema for single-schema catalogs for magic mapper optimization.
+            // Explicitly unset _schema for multi-schema search to prevent auto-setting.
+            unset($searchQuery['_schema']);
+            if (count($schemas) === 1) {
+                $searchQuery['_schema'] = $schemas[0];
+            }
+        }//end if
+
+        if (empty($catalog['registers']) === false) {
+            $registers = $catalog['registers'];
+            // Parse JSON string if needed.
+            if (is_string($registers) === true) {
+                $registers = json_decode($registers, true) ?? [];
+            }
+
+            $registers = array_map('intval', $registers);
+            if (count($registers) === 1) {
+                // Single register: use magic mapper optimization.
+                $searchQuery['_register'] = $registers[0];
+                return $searchQuery;
+            }
+
+            // Multi-register: pass all register IDs and prevent auto-setting.
+            $searchQuery['_registers'] = $registers;
+            $searchQuery['_register']  = null;
+
+            // Multi-register search: strip _order on non-universal fields
+            // since schemas may have different property names (e.g., 'name' vs 'naam').
+            // Only allow metadata fields that exist in all magic mapper tables.
+            if (empty($searchQuery['_order']) === false && is_array($searchQuery['_order']) === true) {
+                foreach (array_keys($searchQuery['_order']) as $orderField) {
+                    if (in_array($orderField, self::UNIVERSAL_ORDER_FIELDS, true) === false) {
+                        unset($searchQuery['_order'][$orderField]);
+                    }
+                }
+
+                if (empty($searchQuery['_order']) === true) {
+                    unset($searchQuery['_order']);
+                }
+            }
+        }//end if
+
+        return $searchQuery;
+
+    }//end buildCatalogSearchQuery()
+
+    /**
+     * Resolve schema and register objects from OpenRegister mappers for catalog enrichment.
+     *
+     * Returns an array with keys 'schemas' (id → {id, slug, title}) and
+     * 'registers' (id → {id, slug, title}). Missing entries are silently skipped.
+     *
+     * @param array $catalog Catalog data array (keys: schemas, registers).
+     *
+     * @return array{schemas: array<int|string, array>, registers: array<int|string, array>}
+     *
+     * @spec exclude Metadata-resolution plumbing extracted from PublicationsController; looks up
+     *       schema/register labels via OR mappers for response enrichment, no domain behavior.
+     */
+    public function resolveSchemaAndRegisterObjects(array $catalog): array
+    {
+        $resolvedSchemas   = [];
+        $resolvedRegisters = [];
+
+        try {
+            $schemaMapper   = $this->container->get('OCA\OpenRegister\Db\SchemaMapper');
+            $registerMapper = $this->container->get('OCA\OpenRegister\Db\RegisterMapper');
+
+            $schemaIds = $catalog['schemas'] ?? [];
+            if (is_string($schemaIds) === true) {
+                $schemaIds = json_decode($schemaIds, true) ?? [];
+            }
+
+            foreach ($schemaIds as $schemaId) {
+                try {
+                    $schema = $schemaMapper->find((int) $schemaId);
+                    $resolvedSchemas[$schemaId] = [
+                        'id'    => $schema->getId(),
+                        'slug'  => $schema->getSlug(),
+                        'title' => $schema->getTitle(),
+                    ];
+                } catch (\Exception $e) {
+                    // Schema not found, skip.
+                }
+            }
+
+            $registerIds = $catalog['registers'] ?? [];
+            if (is_string($registerIds) === true) {
+                $registerIds = json_decode($registerIds, true) ?? [];
+            }
+
+            foreach ($registerIds as $registerId) {
+                try {
+                    $register = $registerMapper->find((int) $registerId);
+                    $resolvedRegisters[$registerId] = [
+                        'id'    => $register->getId(),
+                        'slug'  => $register->getSlug(),
+                        'title' => $register->getTitle(),
+                    ];
+                } catch (\Exception $e) {
+                    // Register not found, skip.
+                }
+            }
+        } catch (\Exception $e) {
+            // OpenRegister not available, return empty sets.
+        }//end try
+
+        return [
+            'schemas'   => $resolvedSchemas,
+            'registers' => $resolvedRegisters,
+        ];
+
+    }//end resolveSchemaAndRegisterObjects()
+
+    /**
+     * Find an object within a catalog's registers/schemas using ObjectService.
+     *
+     * Iterates over each (register, schema) combination in the catalog.
+     * Returns the first matching object entity, or null if not found.
+     *
+     * @param array  $catalog       Catalog data array (keys: schemas, registers).
+     * @param string $id            The UUID of the object to find.
+     * @param object $objectService ObjectService instance (already resolved from container).
+     *
+     * @return object|null The found object entity, or null.
+     *
+     * @spec exclude Lookup plumbing extracted from PublicationsController; iterates a catalog's
+     *       (register, schema) pairs and delegates the actual read to ObjectService::find().
+     */
+    public function findObjectInCatalog(array $catalog, string $id, object $objectService): ?object
+    {
+        $catalogRegisters = $catalog['registers'] ?? [];
+        $catalogSchemas   = $catalog['schemas'] ?? [];
+
+        // Parse JSON string if needed (catalog fields may be JSON-encoded).
+        if (is_string($catalogRegisters) === true) {
+            $catalogRegisters = json_decode($catalogRegisters, true) ?? [];
+        }
+
+        if (is_string($catalogSchemas) === true) {
+            $catalogSchemas = json_decode($catalogSchemas, true) ?? [];
+        }
+
+        // WF4 / wave-12: iterate ALL (register × schema) pairs, not just $catalogRegisters[0].
+        // Previously the code only tried the first register in the list, so objects in
+        // register #2+ were unreachable via this path and returned spurious 404s.
+        if (empty($catalogRegisters) === false) {
+            $registersToTry = array_map('intval', $catalogRegisters);
+        } else {
+            $registersToTry = [null];
+        }
+
+        $schemasToTry = array_map('intval', $catalogSchemas);
+
+        foreach ($registersToTry as $register) {
+            foreach ($schemasToTry as $schemaId) {
+                try {
+                    $object = $objectService->find(
+                        id: $id,
+                        _extend: [],
+                        files: false,
+                        register: $register,
+                        schema: $schemaId,
+                        _rbac: true,
+                        _multitenancy: false
+                    );
+                    if ($object !== null) {
+                        return $object;
+                    }
+                } catch (DoesNotExistException $e) {
+                    // Object not found in this (register, schema) pair — try next.
+                    continue;
+                }
+            }//end foreach
+        }//end foreach
+
+        return null;
+
+    }//end findObjectInCatalog()
+
+    /**
+     * Recursively strips empty values (null, empty string, empty array) from an array.
+     *
+     * Used to reduce API response payload by omitting properties that have no value.
+     * Values of 0, false, and "0" are preserved as they are meaningful.
+     *
+     * @param array $data The data array to strip empty values from.
+     *
+     * @return array The data with empty values removed.
+     *
+     * @spec exclude Response-shaping plumbing extracted from PublicationsController; recursively
+     *       prunes empty values to slim the payload, no domain behavior.
+     *
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+     */
+    public function stripEmptyValues(array $data): array
+    {
+        $result = [];
+        foreach ($data as $key => $value) {
+            if (is_array($value) === true) {
+                $this->processArrayValue(result: $result, key: $key, value: $value);
+                continue;
+            }//end if
+
+            if ($value === null || $value === '') {
+                continue;
+            }
+
+            $result[$key] = $value;
+        }//end foreach
+
+        return $result;
+
+    }//end stripEmptyValues()
+
+    /**
+     * Process a single array value during empty-value stripping.
+     *
+     * Handles both sequential (list) and associative arrays, recursing into nested arrays.
+     *
+     * @param array      $result Reference to the result array being built.
+     * @param int|string $key    The key for this value.
+     * @param array      $value  The array value to process.
+     *
+     * @return void
+     */
+    private function processArrayValue(array &$result, int|string $key, array $value): void
+    {
+        if (array_is_list($value) === true) {
+            $stripped = [];
+            foreach ($value as $item) {
+                if (is_array($item) === false) {
+                    $stripped[] = $item;
+                    continue;
+                }
+
+                $stripped[] = $this->stripEmptyValues(data: $item);
+            }
+
+            if (empty($stripped) === false) {
+                $result[$key] = $stripped;
+            }
+
+            return;
+        }
+
+        $stripped = $this->stripEmptyValues(data: $value);
+        if (empty($stripped) === false) {
+            $result[$key] = $stripped;
+        }
+
+    }//end processArrayValue()
+}//end class

--- a/lib/Service/PublicationQueryService.php
+++ b/lib/Service/PublicationQueryService.php
@@ -104,9 +104,11 @@ class PublicationQueryService
      *
      * Mirrors the live OpenRegister RBAC visibility model (APB-006), the same rule
      * the public publications API and the frontend `publicationStatus` helpers use:
-     * an object is public when its own `publicatiedatum` field is set and is at or
-     * before "now", and either carries no `depublicatiedatum` or one still in the
-     * future. The removed object-level `@self.published` predicate is not consulted.
+     * an object is public when its `status` is not a terminal-hidden state (e.g.
+     * `archived`, RET-006), its own `publicatiedatum` field is set and is at or
+     * before "now", and it either carries no `depublicatiedatum` or one still in
+     * the future. The removed object-level `@self.published` predicate is not
+     * consulted.
      *
      * @param array $objectData The serialized object data (own fields + `@self` envelope).
      *
@@ -116,6 +118,13 @@ class PublicationQueryService
      */
     public function isObjectPublic(array $objectData): bool
     {
+        // RET-006: `archived` is a terminal-hidden state that must never appear
+        // on a public surface, regardless of publish/depublish dates. Enforced
+        // here as belt-and-braces alongside the OR schema authorization contract.
+        if (($objectData['status'] ?? null) === 'archived') {
+            return false;
+        }
+
         $publicatiedatum   = ($objectData['publicatiedatum'] ?? null);
         $depublicatiedatum = ($objectData['depublicatiedatum'] ?? null);
 
@@ -355,21 +364,39 @@ class PublicationQueryService
             $rows[] = $rowArray;
         }//end foreach
 
+        // Forward OR's pre-filter `total` so client-side pagination sees an
+        // accurate (or slightly-over) dataset size, not the current-page-post-filter
+        // count. OR now filters drafts via publication.authorization; the remaining
+        // gap between OR total and post-filter count is archived rows removed by
+        // `isObjectPublic()` — an upper-bound total is acceptable for pagination.
+        $envelope = [
+            'results' => $rows,
+            'total'   => (int) ($candidateResult['total'] ?? count($rows)),
+        ];
+
         // Propagate the facets + facetable blocks from OR's response so consumers can
         // build faceted-search UIs on this endpoint (docs claim, endpoint 2). OR only
         // populates these when the caller asked for them (`_facetable=true` +
         // `_facets[...]`); when absent, the keys are simply omitted from the response.
-        // The facet counts reflect OR's pre-filter view of the candidate set — visibility
-        // filtering below happens per-row in application code and does not adjust facets.
-        $envelope = [
-            'results' => $rows,
-            'total'   => count($rows),
-        ];
+        //
+        // Facet counts on public surfaces MUST NOT leak lifecycle-state population
+        // to anonymous callers: `status` is app-level filtered (RET-006 archived
+        // removal happens in `isObjectPublic()`, not in OR), so the raw OR facet
+        // counts for the `status` bucket would enumerate archived + any future
+        // hidden-state populations. Strip that bucket before forwarding.
         if (isset($candidateResult['facets']) === true) {
-            $envelope['facets'] = $candidateResult['facets'];
+            $facets = $candidateResult['facets'];
+            if (is_array($facets) === true && $this->isAnonymous() === true) {
+                unset($facets['status'], $facets['@self']['status']);
+            }
+            $envelope['facets'] = $facets;
         }
         if (isset($candidateResult['facetable']) === true) {
-            $envelope['facetable'] = $candidateResult['facetable'];
+            $facetable = $candidateResult['facetable'];
+            if (is_array($facetable) === true && $this->isAnonymous() === true) {
+                unset($facetable['status'], $facetable['@self']['status']);
+            }
+            $envelope['facetable'] = $facetable;
         }
         return $envelope;
 

--- a/lib/Service/PublicationQueryService.php
+++ b/lib/Service/PublicationQueryService.php
@@ -59,6 +59,19 @@ class PublicationQueryService
     ];
 
     /**
+     * Hard cap on `_limit` for the anonymous public FTS surface.
+     *
+     * Review #147 🟡 (unauthenticated DoS): without a cap, an anonymous
+     * `?_limit=1000000&_content=true` fanned out unbounded into OR's
+     * chunk-search path, giving a public CPU/memory amplifier. 100 rows
+     * per page matches typical faceted-search UI needs; callers with a
+     * legitimate higher-throughput need MUST paginate.
+     *
+     * @var integer
+     */
+    public const PUBLIC_LIMIT_MAX = 100;
+
+    /**
      * Constructor.
      *
      * @param ContainerInterface   $container   DI container
@@ -142,8 +155,17 @@ class PublicationQueryService
             return true;
         }
 
+        // Fail closed on an unparseable `depublicatiedatum` — a withdrawn object
+        // whose depublish date does not round-trip through strtotime() MUST NOT
+        // stay publicly visible on the strength of a parse failure (review #147
+        // 🟡 fail-open). Return false instead of the previous
+        // `false || > now` shape.
         $depublishedTime = strtotime((string) $depublicatiedatum);
-        return ($depublishedTime === false || $depublishedTime > $now);
+        if ($depublishedTime === false) {
+            return false;
+        }
+
+        return ($depublishedTime > $now);
 
     }//end isObjectPublic()
 
@@ -255,6 +277,18 @@ class PublicationQueryService
         $searchQuery['_schemas']        = [$publicationSchemaId, $documentSchemaId];
         $searchQuery['_includeDeleted'] = false;
 
+        // Clamp `_limit` to a hard maximum (review #147 🟡 unauthenticated DoS —
+        // no cap allowed anonymous `?_limit=1000000&_content=true` to fan out
+        // unbounded into OR's chunk-search path). The cap is enforced HERE, not
+        // in the controller, so every entry point that reaches this assembler
+        // is covered (`SearchController::index()` is the only one today, but
+        // any future entrypoint automatically inherits the cap). 100 mirrors
+        // typical faceted-search page sizes; callers wanting more MUST paginate.
+        $requestedLimit = ($searchQuery['_limit'] ?? null);
+        if (is_numeric($requestedLimit) === true && (int) $requestedLimit > self::PUBLIC_LIMIT_MAX) {
+            $searchQuery['_limit'] = self::PUBLIC_LIMIT_MAX;
+        }
+
         if ($contentSearchRequested === true) {
             // Forward to OR's opt-in chunk-search fan-out (expose-content-search-in
             // -object-service, PR #473). OR already dedupes its own metadata-match +
@@ -364,14 +398,27 @@ class PublicationQueryService
             $rows[] = $rowArray;
         }//end foreach
 
-        // Forward OR's pre-filter `total` so client-side pagination sees an
-        // accurate (or slightly-over) dataset size, not the current-page-post-filter
-        // count. OR now filters drafts via publication.authorization; the remaining
-        // gap between OR total and post-filter count is archived rows removed by
-        // `isObjectPublic()` — an upper-bound total is acceptable for pagination.
+        // `total` on an anonymous surface MUST NOT expose the pre-filter count
+        // (review #147 🔴 total leak): the OR candidate query runs `_rbac: false`
+        // and OC applies `isObjectPublic()` only to the emitted rows, so OR's
+        // `total` still counts drafts, future-dated, depublished AND archived
+        // objects. Polling that number over time would let a caller infer
+        // publication/withdrawal activity before it is public. Anonymous callers
+        // therefore see the exact post-filter row count for THIS PAGE — a
+        // per-page under-count that never reveals hidden lifecycle state.
+        // Authenticated callers keep OR's pre-filter total so their client-side
+        // pagination continues to work against the full accessible corpus
+        // (they can see the same rows through the admin surface anyway).
+        $isAnonymous = $this->isAnonymous();
+        if ($isAnonymous === true) {
+            $envelopeTotal = count($rows);
+        } else {
+            $envelopeTotal = (int) ($candidateResult['total'] ?? count($rows));
+        }
+
         $envelope = [
             'results' => $rows,
-            'total'   => (int) ($candidateResult['total'] ?? count($rows)),
+            'total'   => $envelopeTotal,
         ];
 
         // Propagate the facets + facetable blocks from OR's response so consumers can
@@ -379,24 +426,24 @@ class PublicationQueryService
         // populates these when the caller asked for them (`_facetable=true` +
         // `_facets[...]`); when absent, the keys are simply omitted from the response.
         //
-        // Facet counts on public surfaces MUST NOT leak lifecycle-state population
-        // to anonymous callers: `status` is app-level filtered (RET-006 archived
-        // removal happens in `isObjectPublic()`, not in OR), so the raw OR facet
-        // counts for the `status` bucket would enumerate archived + any future
-        // hidden-state populations. Strip that bucket before forwarding.
-        if (isset($candidateResult['facets']) === true) {
-            $facets = $candidateResult['facets'];
-            if (is_array($facets) === true && $this->isAnonymous() === true) {
-                unset($facets['status'], $facets['@self']['status']);
-            }
-            $envelope['facets'] = $facets;
+        // On an anonymous surface EVERY OR facet/facetable bucket is unsafe
+        // (review #147 🔴 facet leak): the OR candidate query runs `_rbac: false`
+        // and OC applies its public-predicate only to result ROWS, so every
+        // bucket — `publicatiedatum`, `organization`, `themes`, `mimeType`, …
+        // — aggregates counts over drafts / future-dated / depublished /
+        // archived objects. A `publicatiedatum` range facet would even reveal
+        // dates of not-yet-published objects. The previous "strip `status` only"
+        // fix was incomplete; drop the entire facets/facetable envelopes for
+        // anonymous callers rather than post-stripping individual buckets. A
+        // future OR API that returns authorization-filtered facet aggregations
+        // can be forwarded through here once available.
+        // Authenticated callers keep the full OR facets — they can already
+        // see the underlying rows through admin surfaces.
+        if (isset($candidateResult['facets']) === true && $isAnonymous === false) {
+            $envelope['facets'] = $candidateResult['facets'];
         }
-        if (isset($candidateResult['facetable']) === true) {
-            $facetable = $candidateResult['facetable'];
-            if (is_array($facetable) === true && $this->isAnonymous() === true) {
-                unset($facetable['status'], $facetable['@self']['status']);
-            }
-            $envelope['facetable'] = $facetable;
+        if (isset($candidateResult['facetable']) === true && $isAnonymous === false) {
+            $envelope['facetable'] = $candidateResult['facetable'];
         }
         return $envelope;
 

--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -359,6 +359,12 @@ class SettingsService
             'page',
             'menu',
             'glossary',
+            // WOO-506/517 FTS: publication + document included so autoConfigure()
+            // populates `publication_register`/`publication_schema`/`document_schema`
+            // config keys — required by PublicationQueryService for the /api/search
+            // FTS endpoint. Fails-closed (empty envelope + warn) when unset.
+            'publication',
+            'document',
         ];
         $data['openRegisters']      = false;
         $data['availableRegisters'] = [];
@@ -712,6 +718,12 @@ class SettingsService
             'page',
             'menu',
             'glossary',
+            // WOO-506/517 FTS: publication + document included so the config
+            // keys `publication_register`/`publication_schema`/`document_schema`
+            // get persisted from loadSettings (which imports the JSON register
+            // schema). Required by PublicationQueryService for /api/search FTS.
+            'publication',
+            'document',
         ];
 
         // Build a map of schema slugs to schema IDs.

--- a/lib/Settings/publication_register.json
+++ b/lib/Settings/publication_register.json
@@ -163,7 +163,15 @@
         "searchable": true,
         "authorization": {
           "read": [
-            "public"
+            {
+              "group": "public",
+              "match": {
+                "publicatiedatum": {
+                  "$lte": "$now"
+                }
+              }
+            },
+            "authenticated"
           ]
         }
       },

--- a/lib/Settings/publication_register.json
+++ b/lib/Settings/publication_register.json
@@ -130,6 +130,30 @@
             },
             "description": "List of themes associated with this publication",
             "facetable": true
+          },
+          "publicatiedatum": {
+            "type": "string",
+            "description": "Publication date (WOO/DIWOO) — when set to a date in the past, this publication is live and publicly accessible",
+            "format": "date-time",
+            "facetable": true,
+            "title": "Publication Date"
+          },
+          "depublicatiedatum": {
+            "type": "string",
+            "description": "Depublication date (WOO/DIWOO) — when set and in the past, this publication is withdrawn from public access. A future value schedules automatic depublication via the OpenRegister published-predicate.",
+            "format": "date-time",
+            "facetable": true,
+            "title": "Depublication Date"
+          },
+          "status": {
+            "type": "string",
+            "description": "Lifecycle status of the publication; the archived state retains the object internally while removing it from every public surface (RET-006).",
+            "enum": [
+              "published",
+              "archived"
+            ],
+            "facetable": true,
+            "title": "Status"
           }
         },
         "configuration": {
@@ -140,6 +164,118 @@
         "authorization": {
           "read": [
             "public"
+          ]
+        }
+      },
+      "document": {
+        "slug": "document",
+        "title": "Document",
+        "version": "0.1.0",
+        "published": "2026-07-03T00:00:00+00:00",
+        "summary": "A document attached to a publication, discoverable via the public full-text search endpoint",
+        "description": "A document represents a file (e.g. PDF, DOCX) attached to a publication. Documents are schema-discoverable so the public full-text search endpoint (SCH-PFTS-005) can surface them alongside publications, discriminated by @self.schema.",
+        "icon": null,
+        "required": [
+          "title",
+          "publication"
+        ],
+        "properties": {
+          "title": {
+            "type": "string",
+            "description": "The title of the document",
+            "maxLength": 255,
+            "minLength": 1,
+            "facetable": true,
+            "title": "Title"
+          },
+          "filename": {
+            "type": "string",
+            "description": "The original filename of the document",
+            "maxLength": 255,
+            "facetable": false,
+            "title": "Filename"
+          },
+          "mimeType": {
+            "type": "string",
+            "description": "The MIME type of the document",
+            "maxLength": 255,
+            "facetable": true,
+            "title": "MIME Type"
+          },
+          "summary": {
+            "type": "string",
+            "description": "Brief description of the document",
+            "maxLength": 255,
+            "facetable": false,
+            "title": "Summary"
+          },
+          "description": {
+            "type": "string",
+            "description": "Detailed description of the document",
+            "maxLength": 2555,
+            "facetable": false,
+            "title": "Description"
+          },
+          "publication": {
+            "type": "object",
+            "description": "Summary of the publication this document is attached to",
+            "facetable": false,
+            "title": "Publication",
+            "properties": {
+              "id": {
+                "type": "string",
+                "description": "The UUID of the linked publication",
+                "title": "Publication ID"
+              },
+              "slug": {
+                "type": "string",
+                "description": "The slug of the linked publication",
+                "title": "Publication Slug"
+              },
+              "title": {
+                "type": "string",
+                "description": "The title of the linked publication",
+                "title": "Publication Title"
+              }
+            }
+          },
+          "organization": {
+            "type": "string",
+            "description": "Reference to the organization that owns this document",
+            "facetable": true,
+            "title": "Organization"
+          },
+          "publicatiedatum": {
+            "type": "string",
+            "description": "Publication date (WOO/DIWOO) — when set to a date in the past, this document is live and publicly accessible",
+            "format": "date-time",
+            "facetable": true,
+            "title": "Publication Date"
+          },
+          "depublicatiedatum": {
+            "type": "string",
+            "description": "Depublication date (WOO/DIWOO) — when set and in the past, this document is withdrawn from public access",
+            "format": "date-time",
+            "facetable": true,
+            "title": "Depublication Date"
+          }
+        },
+        "configuration": {
+          "autoPublish": false
+        },
+        "hardValidation": false,
+        "searchable": true,
+        "authorization": {
+          "read": [
+            {
+              "group": "public",
+              "match": {
+                "publicatiedatum": {
+                  "$lte": "$now"
+                }
+              }
+            },
+            "authenticated"
           ]
         }
       },

--- a/lib/Settings/publication_register.json
+++ b/lib/Settings/publication_register.json
@@ -34,7 +34,8 @@
           "theme",
           "page",
           "menu",
-          "glossary"
+          "glossary",
+          "document"
         ],
         "tablePrefix": "",
         "folder": "Open Registers/Publication Register",
@@ -47,7 +48,12 @@
               "autoCreateTable": true,
               "comment": "High-volume content schema - main content type with frequent queries for search, filtering, and display"
             },
-            "catalog": {
+"document": {
+              "magicMapping": true,
+              "autoCreateTable": true,
+              "comment": "FTS content-search target (WOO-517) — chunk-store attaches to objects here"
+            },
+                        "catalog": {
               "magicMapping": true,
               "autoCreateTable": true,
               "comment": "Frequently queried for navigation and organization - benefits from SQL indexing and joins"


### PR DESCRIPTION
Mirror of Codeberg PR #147: https://codeberg.org/Conduction/opencatalogi/pulls/147

Port the WOO-506 public full-text search + WOO-517 opt-in document body-text search from `development` onto `main` via the `stable/fts` branch.

**Note**: GitHub `main` currently diverges from Codeberg `main` (GH main advanced separately post-migratie). Review the diff carefully — the intent mirrors Codeberg but the base may differ.

Jira: WOO-506, WOO-517