### PR TITLE
docs(openspec): market-wave 2026-07-23 — three research-backed ff changes

### DIFF
--- a/openspec/changes/authenticated-read-parity/design.md
+++ b/openspec/changes/authenticated-read-parity/design.md
@@ -1,0 +1,31 @@
+# Design: authenticated-read-parity
+
+## Approach
+Inject `IUserSession` into the assembler(s) that apply the anonymous strip
+list; branch once per request (not per object) on `getUser() !== null`.
+
+## Decisions
+
+### D1 — Session check, not permission re-derivation
+OR RBAC already decided the caller may read the object (`_rbac: true` on the
+delegated search). Re-deriving per-property permissions in the leaf would
+duplicate OR's authority (ADR-022). All-or-nothing on session is the whole
+design.
+
+### D2 — Single strip-list source
+The `$unwantedProperties` list is extracted to one private constant reused by
+every public-read assembler that strips (`CatalogiService`; plus
+`PublicationService`/`PublicationQueryService` if apply confirms they carry a
+duplicate list), so the anonymous envelope cannot fork between endpoints.
+
+### D3 — Byte-parity guard for anonymous
+A golden-fixture PHPUnit test freezes the anonymous envelope. This is a
+public, CORS-consumed API: the anonymous shape is a compatibility contract
+(portal frontends, harvester consumers), so the test exists to prove this
+change ships zero anonymous drift.
+
+## Security note
+This widens metadata exposure ONLY to sessions OR RBAC already trusts to read
+the object; `validation`/`retention`/`owner` are not secrets to a caller who
+can already open the object in OpenRegister. Gate `security-change-has-tests`
+applies (session-dependent response shaping) — tests ship in the same PR.

--- a/openspec/changes/authenticated-read-parity/hydra.json
+++ b/openspec/changes/authenticated-read-parity/hydra.json
@@ -1,0 +1,8 @@
+{
+  "spec_slug": "authenticated-read-parity",
+  "title": "Session-aware @self metadata on public reads (closes the logged-in-as-anonymous todo)",
+  "app": "opencatalogi",
+  "repo": "https://github.com/ConductionNL/opencatalogi",
+  "depends_on": [],
+  "issue": null
+}

--- a/openspec/changes/authenticated-read-parity/proposal.md
+++ b/openspec/changes/authenticated-read-parity/proposal.md
@@ -1,0 +1,47 @@
+---
+kind: code
+depends_on: []
+---
+
+# Proposal: authenticated-read-parity
+
+## Summary
+Stop treating logged-in users as anonymous on OpenCatalogi's public read
+endpoints. Today `CatalogiService` strips a fixed list of `@self` metadata
+properties from every response regardless of session (the code carries the
+`@todo: a logged-in user should be able to see the full object` at
+`lib/Service/CatalogiService.php`). This change makes the stripping
+session-aware: anonymous callers keep today's minimal envelope byte-identical;
+authenticated callers receive the full `@self` metadata for objects OpenRegister
+RBAC already lets them read.
+
+## Motivation
+Editors and administrators browsing catalogs through the same public endpoints
+the portal uses cannot see ownership, lock state, retention or validation
+metadata on their own objects — they must detour through the OpenRegister UI.
+The visibility decision (may this caller read this object at all?) already
+lives in OR RBAC (`_rbac: true` on the delegated search, per ADR-022 and the
+catalogs spec); the leaf-side stripping is a *presentation* rule for the
+anonymous public web, wrongly applied to everyone. Rights-aware UI is also a
+recurring user wish in the 2026-07-23 research (issues #535/#569/#635 cluster:
+users see surfaces they cannot act on and vice versa).
+
+## Scope
+- `CatalogiService` (and any sibling public-read assembler applying the same
+  `$unwantedProperties` strip — PublicationService/PublicationQueryService to
+  be confirmed during apply) consults `IUserSession`: strip for anonymous,
+  pass-through full `@self` for authenticated callers.
+- No change to which OBJECTS are returned — OR RBAC continues to govern
+  visibility for both audiences; this only changes envelope metadata richness.
+- PHPUnit coverage proving: anonymous envelope byte-identical to baseline;
+  authenticated envelope carries the previously stripped keys; object-set
+  parity between the two audiences given identical RBAC context.
+
+## Out of scope
+- Group/role-differentiated partial metadata (all-or-nothing on session).
+- Any write-surface change.
+
+## Impact
+- Touched: `lib/Service/CatalogiService.php` (+ sibling assemblers if they
+  duplicate the strip list), unit tests.
+- Specs: delta on `catalogs` (ADDED CAT-AUTH-001, MODIFIED none).

--- a/openspec/changes/authenticated-read-parity/specs/catalogs/spec.md
+++ b/openspec/changes/authenticated-read-parity/specs/catalogs/spec.md
@@ -1,0 +1,41 @@
+## ADDED Requirements
+
+### Requirement: Authenticated callers receive full object metadata on public reads (CAT-AUTH-001)
+
+Public read endpoints that assemble catalog/publication envelopes MUST make
+the `@self` metadata stripping session-aware. For requests with no
+authenticated Nextcloud session, the response MUST remain byte-identical to
+the current anonymous envelope (the fixed strip list: `schemaVersion`,
+`relations`, `locked`, `owner`, `folder`, `application`, `validation`,
+`retention`, `size`, `deleted`). For requests carrying an authenticated
+session, the full `@self` metadata MUST be passed through unmodified for every
+object the caller may read. Which objects are returned MUST NOT differ between
+the two audiences beyond what OpenRegister RBAC (`_rbac: true`) already
+decides — this requirement changes envelope richness only, never visibility.
+
+#### Scenario: anonymous envelope is unchanged
+
+- GIVEN a published catalog readable anonymously,
+- WHEN an unauthenticated caller lists it via the public API,
+- THEN each object's `@self` MUST omit the stripped properties,
+- AND the envelope MUST be byte-identical to the pre-change baseline.
+
+> @e2e exclude Backend envelope contract; anonymous baseline byte-parity is asserted by PHPUnit against a golden fixture, no distinct UI surface.
+
+#### Scenario: authenticated caller sees full metadata
+
+- GIVEN the same catalog and an authenticated user whom OR RBAC allows to read it,
+- WHEN that user lists it via the same public API route,
+- THEN each object's `@self` MUST include `owner`, `locked`, `retention` and
+  the other previously stripped properties as provided by OpenRegister.
+
+> @e2e exclude Backend envelope contract; covered by PHPUnit with a mocked IUserSession; no rendering change ships in this change.
+
+#### Scenario: session changes metadata richness, never the object set
+
+- GIVEN an identical OR RBAC context for an anonymous and an authenticated request,
+- WHEN both list the same catalog,
+- THEN both responses MUST contain the same object ids in the same order,
+- AND only the `@self` richness may differ.
+
+> @e2e exclude Backend parity contract; PHPUnit.

--- a/openspec/changes/authenticated-read-parity/tasks.md
+++ b/openspec/changes/authenticated-read-parity/tasks.md
@@ -1,0 +1,12 @@
+# Tasks: authenticated-read-parity
+
+- [ ] Freeze delta spec `specs/catalogs/spec.md` (ADDED CAT-AUTH-001); `openspec validate authenticated-read-parity` green
+- [ ] Extract the `$unwantedProperties` strip list to a single private constant; audit `PublicationService`/`PublicationQueryService`/controllers for duplicate strip lists and route them through it
+  - Spec ref: CAT-AUTH-001
+  - Acceptance: grep shows exactly one definition of the strip list in lib/
+- [ ] Inject `IUserSession` into `CatalogiService` (+ confirmed siblings); strip only when `getUser() === null`
+  - Spec ref: CAT-AUTH-001
+  - Acceptance: PHPUnit: authenticated envelope carries owner/locked/retention; anonymous envelope byte-identical to golden fixture
+- [ ] Object-set parity test: same ids/order for both audiences under identical mocked RBAC context
+  - Spec ref: CAT-AUTH-001 scenario 3
+- [ ] Remove the `@todo` comment at the strip site; `@spec` tags on changed methods; hydra gates green locally (spec-coverage, security-change-has-tests — tests/ touched in same PR)

--- a/openspec/changes/public-api-openapi-document/design.md
+++ b/openspec/changes/public-api-openapi-document/design.md
@@ -1,0 +1,36 @@
+# Design: public-api-openapi-document
+
+## Approach
+Static, hand-maintained OpenAPI 3.1 document + a bidirectional parity test.
+Static beats runtime generation here: the public envelopes are stable and
+deliberately versioned, PHP attribute-driven generators would add a dependency
+and still miss response shapes, and the parity test provides the anti-rot
+guarantee that is the actual point.
+
+## Decisions
+
+### D1 — Parity is route-name based with an allowlist
+The test parses `appinfo/routes.php` (it returns a plain array — include it,
+no regex), filters to controller methods carrying PublicPage, converts NC
+route patterns (`{catalogSlug}`) to OpenAPI path templates, and diffs against
+`openapi.json` paths. Allowlist entries need a reason string; the wildcard
+publication routes get one canonical documented form.
+
+### D2 — Serve-time version substitution
+`GET /api/openapi.json` reads the static file once, overwrites
+`info.version` with `IAppManager::getAppVersion('opencatalogi')`, and returns
+JSONResponse with the standard CORS decoration. The shipped file's version is
+kept in sync by the parity test comparing it to `appinfo/info.xml` — serve-time
+substitution covers installed-but-not-rebuilt instances.
+
+### D3 — Response schemas at envelope granularity
+Document the envelope contracts (results/total/page/pages/facets, `@self`
+metadata object, error shape) with `additionalProperties: true` for
+schema-driven publication payloads — publication properties are
+register-defined per instance and MUST NOT be frozen in the static document.
+
+## Alternatives considered
+- **zircote/swagger-php attribute generation** — new composer dep, needs
+  attributes on 13 controllers, still hand-writes response schemas. Rejected.
+- **Documenting admin surface too** — doubles the work, procurement value is
+  in the public surface. Follow-up change.

--- a/openspec/changes/public-api-openapi-document/hydra.json
+++ b/openspec/changes/public-api-openapi-document/hydra.json
@@ -1,0 +1,8 @@
+{
+  "spec_slug": "public-api-openapi-document",
+  "title": "Accurate public OpenAPI document + anti-rot parity test",
+  "app": "opencatalogi",
+  "repo": "https://github.com/ConductionNL/opencatalogi",
+  "depends_on": [],
+  "issue": null
+}

--- a/openspec/changes/public-api-openapi-document/proposal.md
+++ b/openspec/changes/public-api-openapi-document/proposal.md
@@ -1,0 +1,56 @@
+---
+kind: code
+depends_on: []
+---
+
+# Proposal: public-api-openapi-document
+
+## Summary
+Replace the dead `openapi.json` stub with an accurate, maintained OpenAPI 3.1
+document describing OpenCatalogi's public API surface, serve it from a public
+CORS-enabled endpoint (`GET /api/openapi.json`), and add a parity test that
+fails whenever a public route in `appinfo/routes.php` is missing from the
+document (or vice versa) so the document cannot rot again.
+
+## Motivation
+The repo's `openapi.json` is a leftover template from another app entirely:
+version `0.0.1`, license `agpl`, and its only path is
+`/ocs/v2.php/apps/dsonextcloud/api`. Meanwhile the real public API is large
+and deliberately public: search, catalog-scoped publications, attachments and
+downloads, DCAT feeds with content negotiation, DIWOO sitemaps, federation
+endpoints, and the CMS read APIs (pages/menus/themes/glossary) — all
+CORS-enabled. Market research (2026-07-23) makes accurate API documentation a
+procurement credential: developer.overheid.nl's API-register auto-validates
+registered OpenAPI documents and generates client collections, and the NL API
+Strategy (Common Ground) expects a published, accurate spec. A misleading
+spec is worse than none — it actively fails vendor assessments. This is also
+the cheapest fix in the wave's "positioning drift" risk cluster (logged as a
+spectr insight alongside the AGPL/EUPL doc inconsistency).
+
+## Scope
+- Author `openapi.json` (OpenAPI 3.1) covering every `@PublicPage` route in
+  `appinfo/routes.php`: search (incl. `_content`), catalogi, publications
+  wildcard surface (`/api/{catalogSlug}`, `/{id}`, `/uses`, `/used`,
+  `/attachments`, `/download`), DCAT (`/api/dcat`,
+  `/api/catalogs/{slug}/dcat` with content-negotiation documented),
+  sitemaps/robots, federation, directory, pages/menus/themes/glossary,
+  schema.org endpoints. Correct metadata: title OpenCatalogi, EUPL-1.2
+  license, version sourced from `appinfo/info.xml`.
+- New public route `GET /api/openapi.json` serving the document with CORS
+  headers, version field substituted from the installed app version.
+- PHPUnit parity test: the set of public GET routes in `appinfo/routes.php`
+  must equal the documented paths (modulo an explicit allowlist with
+  reasons), so drift breaks the build.
+- Remove the `dsonextcloud` stub content entirely.
+
+## Out of scope
+- Documenting admin-gated endpoints (retention, settings, WOO batch, setup)
+  — follow-up; the public surface is the procurement-critical one.
+- Registration with developer.overheid.nl (manual organisational step).
+- Runtime OpenAPI generation from attributes (heavier; static + parity test
+  gives the same guarantee at lower complexity).
+
+## Impact
+- Replaced: `openapi.json`. New: route + controller method (or `UiController`
+  addition), `tests/unit/OpenApiParityTest.php`.
+- Specs: new capability `api-documentation` (API-DOC-001..003).

--- a/openspec/changes/public-api-openapi-document/specs/api-documentation/spec.md
+++ b/openspec/changes/public-api-openapi-document/specs/api-documentation/spec.md
@@ -1,0 +1,56 @@
+## ADDED Requirements
+
+### Requirement: Accurate OpenAPI 3.1 document describes the public API (API-DOC-001)
+
+The repository MUST ship an OpenAPI 3.1 document (`openapi.json`) that
+describes OpenCatalogi's actual public API surface: every route registered in
+`appinfo/routes.php` whose controller method is annotated `@PublicPage` /
+`#[PublicPage]` MUST appear as a documented path, with request parameters
+(including pagination, `_extend`, facet and `_content` query parameters where
+supported) and response schemas that match the served envelopes. The document
+MUST carry the app's real metadata: title "OpenCatalogi", license EUPL-1.2,
+and a version equal to the `<version>` in `appinfo/info.xml`. Content stemming
+from other applications MUST NOT be present.
+
+#### Scenario: stale foreign stub is gone
+
+- GIVEN the shipped `openapi.json`,
+- WHEN its paths are inspected,
+- THEN no path may reference `dsonextcloud` or any non-OpenCatalogi app,
+- AND `info.license` MUST identify EUPL-1.2,
+- AND `info.version` MUST equal the version in `appinfo/info.xml`.
+
+> @e2e exclude Static document contract; covered by PHPUnit parity test.
+
+### Requirement: Public routes and documented paths cannot drift (API-DOC-002)
+
+A PHPUnit test MUST compare the set of public routes parsed from
+`appinfo/routes.php` against the paths documented in `openapi.json` in both
+directions. A public route absent from the document, or a documented path
+with no corresponding route, MUST fail the test unless listed in an explicit
+in-test allowlist entry carrying a reason string.
+
+#### Scenario: adding an undocumented public route breaks the build
+
+- GIVEN a new `@PublicPage` route added to `appinfo/routes.php`,
+- AND no corresponding path added to `openapi.json` nor allowlist entry,
+- WHEN the unit test suite runs,
+- THEN the parity test MUST fail naming the missing path.
+
+> @e2e exclude Build-time guard, no runtime surface; PHPUnit.
+
+### Requirement: The document is served publicly with CORS (API-DOC-003)
+
+The system MUST serve the OpenAPI document at `GET /api/openapi.json` as a
+public, CORS-enabled endpoint (same cross-origin posture as the rest of the
+public API per the cross-origin-api-access spec), with `info.version`
+substituted at serve time from the installed app version.
+
+#### Scenario: anonymous client fetches the document cross-origin
+
+- GIVEN an anonymous request with an `Origin` header,
+- WHEN `GET /apps/opencatalogi/api/openapi.json` is requested,
+- THEN the response MUST be HTTP 200 JSON with CORS headers,
+- AND `info.version` MUST equal the installed app version.
+
+@e2e tests/e2e/spec-coverage/openapi-document.spec.ts

--- a/openspec/changes/public-api-openapi-document/tasks.md
+++ b/openspec/changes/public-api-openapi-document/tasks.md
@@ -1,0 +1,15 @@
+# Tasks: public-api-openapi-document
+
+- [ ] Freeze delta spec `specs/api-documentation/spec.md` (ADDED API-DOC-001..003); `openspec validate public-api-openapi-document` green
+- [ ] Author `openapi.json` (OpenAPI 3.1): all `@PublicPage` routes from `appinfo/routes.php` — search (+`_content`), catalogi, publications wildcard surface, DCAT (+content negotiation), sitemaps/robots, federation, directory, pages/menus/themes/glossary, schema.org; envelope-granularity response schemas; EUPL-1.2; version = info.xml
+  - Spec ref: API-DOC-001
+  - Acceptance: `python3 -c "import json; json.load(open('openapi.json'))"` parses; no dsonextcloud content remains
+- [ ] PHPUnit bidirectional parity test `tests/unit/OpenApiParityTest.php` (routes ↔ documented paths, allowlist with reasons, version-sync assertion vs info.xml)
+  - Spec ref: API-DOC-002
+  - Acceptance: test fails when a public route is removed from the document (prove once by mutation, then restore)
+- [ ] Public `GET /api/openapi.json` endpoint: route in `appinfo/routes.php`, controller method with `#[PublicPage]` + CORS decoration, serve-time `info.version` substitution
+  - Spec ref: API-DOC-003
+  - Acceptance: anonymous curl with Origin header returns 200 + CORS headers + installed version
+- [ ] E2E `tests/e2e/spec-coverage/openapi-document.spec.ts`: anonymous fetch asserts 200, JSON, version, one known path present
+  - Spec ref: API-DOC-003
+- [ ] `@spec` tags; hydra gates green locally (route-auth on the new public method, spec-coverage, e2e-coverage)

--- a/openspec/changes/woo-index-harvester-readiness/design.md
+++ b/openspec/changes/woo-index-harvester-readiness/design.md
@@ -1,0 +1,42 @@
+# Design: woo-index-harvester-readiness
+
+## Approach
+Outside-in validation: the service fetches its *own* public URLs (base URL from
+`overwrite.cli.url` / configured public base) through the existing
+SSRF-hardened outbound guard (`DirectoryService::assertSafeOutboundUrl()`
+extracted or reused), so the report reflects what the KOOP harvester would
+actually see — not what the router can render internally.
+
+## Decisions
+
+### D1 — Reuse the existing DIWOO validation, don't duplicate it
+`SitemapService` already ships admin DIWOO validation against the bundled XSD.
+`WooReadinessService` calls that validation on the *fetched* sitemap bytes
+(fetched over HTTP from the public URL), not on internally rendered output.
+No second XSD path.
+
+### D2 — Report persistence in appconfig JSON
+One JSON blob under app config key `woo_readiness_report` (per-check results,
+verdict, timestamp, baseUrl). Atomic replace on each run. No new register
+schema: this is instance-operational state, not domain data (consistent with
+how setup wizard state is stored, ADR-042).
+
+### D3 — Registration status is config, not a register object
+`woo_index_registration` config object (status/registeredUrl/registeredAt),
+edited via the existing settings save endpoint. It describes *this instance's*
+relationship to a national registry — operational config, not a publication.
+
+### D4 — Fail-closed posture (gate: security-config-fail-mode)
+Empty/missing WOO configuration → HTTP 409 `not-configured`, zero outbound
+requests. A readiness endpoint that silently "passes" on an unconfigured
+instance would be exactly the silent-defense-off pattern gate 51 exists for.
+
+### D5 — Checks are sampled, bounded, and time-limited
+Per catalog: 1 sitemapindex + up to 3 category sitemaps + 1 publication URL
+sample; every request with a 10s timeout and a hard cap of 25 outbound
+requests per run (bounded-work, ADR-058 spirit). The report notes sampling.
+
+## Alternatives considered
+- **Cron-driven continuous monitoring + notifications** — deferred; would ride
+  the ADR-031 notification dialect and needs a decision on alert fatigue.
+- **Automatic Woo-index registration** — no public API exists; out of scope.

--- a/openspec/changes/woo-index-harvester-readiness/hydra.json
+++ b/openspec/changes/woo-index-harvester-readiness/hydra.json
@@ -1,0 +1,8 @@
+{
+  "spec_slug": "woo-index-harvester-readiness",
+  "title": "Woo-index harvester-readiness self-check + registration tracking",
+  "app": "opencatalogi",
+  "repo": "https://github.com/ConductionNL/opencatalogi",
+  "depends_on": [],
+  "issue": null
+}

--- a/openspec/changes/woo-index-harvester-readiness/proposal.md
+++ b/openspec/changes/woo-index-harvester-readiness/proposal.md
@@ -1,0 +1,62 @@
+---
+kind: code
+depends_on: []
+---
+
+# Proposal: woo-index-harvester-readiness
+
+## Summary
+Add a Woo-index **harvester-readiness self-check** and registration-status
+tracking to OpenCatalogi. A new admin endpoint validates, from the outside in,
+everything the KOOP Woo-harvester needs to actually ingest this instance:
+public reachability of `robots.txt`, the DIWOO sitemapindex and per-category
+sitemaps, XML validity against the DIWOO XSD, and stable public publication
+URLs. The result is a persisted, per-check readiness report surfaced in the
+admin settings UI, together with a tracked Woo-index registration status
+(registered URL, date, state) so an organisation can *prove* harvestability
+instead of assuming it.
+
+## Motivation
+Market research (2026-07-23 deep-dive, logged in the spectr register) shows
+708 of 971 Woo-plichtige organisations are registered in the Woo-index but
+**only 3 are actually connected to the daily Woo-harvester** (Rijkswaterstaat,
+provincies Zeeland and Gelderland — od-online, "Woo-index na 1 jaar").
+Demonstrable harvestability is therefore a concrete procurement differentiator:
+competitor CARE markets exactly this ("working Woo-index harvesting
+integration"), and OpenGDC advertises automatic national-portal registration.
+OpenCatalogi already ships the hard part — DIWOO sitemaps per catalog per
+informatiecategorie (WOO-001..010), TOOI binding, robots.txt — but nothing
+verifies the *deployed* instance is externally reachable, valid, and
+registered. Sitemaps that render locally but 404 publicly, an overriding
+root `robots.txt`, or an expired XSD conformance are silent failures the
+harvester never reports back. The self-check closes the loop the way the
+delayed Generieke Woo-voorziening (≥9 months, Kamerbrief 2026-02-16) cannot:
+municipalities need to self-serve proof now.
+
+## Scope
+- New `WooReadinessService` performing the outside-in checks against the
+  instance's own public base URL (reusing the existing SSRF-hardened outbound
+  URL guard for any fetch it performs).
+- New admin endpoints under `/api/woo/readiness` (run check, get last report)
+  gated with `#[AuthorizedAdminSetting]`, fail-closed when the WOO
+  configuration (woo-enabled catalogs) is absent.
+- Persisted readiness report (appconfig JSON) with per-check status +
+  timestamps; re-run on demand from the settings UI.
+- Woo-index registration status tracking: `wooIndexRegistration` config object
+  (status: not_registered | requested | registered; registered URL; date),
+  editable in admin settings, included in the readiness report.
+- Settings UI panel (Woo section) rendering the report with per-check
+  pass/fail and remediation hints, plus the registration status editor.
+
+## Out of scope
+- Automatic registration with the Woo-index itself (no public API exists;
+  registration runs through the Register van Overheidsorganisaties process).
+- Any change to sitemap/robots generation (WOO-001..010 unchanged).
+- Notifications on readiness regression (future; would ride ADR-031 dialect).
+
+## Impact
+- New: `lib/Service/WooReadinessService.php`, `lib/Controller/WooReadinessController.php`
+  (or extension of `WooController`), settings UI panel component.
+- Touched: `appinfo/routes.php` (2 admin routes), `lib/Settings` config keys,
+  `src/views/settings` Woo panel.
+- Specs: delta on `woo-compliance` (ADDED WOO-HR-001..004).

--- a/openspec/changes/woo-index-harvester-readiness/specs/woo-compliance/spec.md
+++ b/openspec/changes/woo-index-harvester-readiness/specs/woo-compliance/spec.md
@@ -1,0 +1,101 @@
+## ADDED Requirements
+
+### Requirement: Harvester-readiness self-check validates the deployed public WOO surface (WOO-HR-001)
+
+The system MUST provide an admin-triggered harvester-readiness self-check that
+validates, using outbound HTTP requests against the instance's own public base
+URL, every precondition for KOOP Woo-harvester ingestion:
+
+1. `robots.txt` is publicly reachable (HTTP 200) and references the DIWOO
+   sitemapindex location(s) rendered by `RobotsController`;
+2. every WOO-enabled catalog's sitemapindex is publicly reachable and is
+   well-formed XML;
+3. each per-informatiecategorie sitemap referenced by a sitemapindex is
+   publicly reachable, well-formed, and carries the `diwoo:` metadata
+   extension elements;
+4. the DIWOO metadata in a sampled sitemap validates against the bundled
+   DIWOO XSD (same schema version used by the existing admin DIWOO
+   validation endpoint);
+5. a sampled publication URL from a sitemap resolves publicly with HTTP 200.
+
+Each check MUST produce an individual `pass` / `fail` result with a
+machine-readable reason on failure. A check that cannot run because its
+prerequisite failed MUST report `skipped`, not `pass`. Outbound requests MUST
+go through the existing SSRF-hardened outbound URL guard.
+
+#### Scenario: fully harvestable instance reports all checks passing
+
+- GIVEN an instance with at least one WOO-enabled catalog whose robots.txt,
+  sitemapindex, category sitemaps and publication URLs are publicly reachable
+  and DIWOO-valid,
+- WHEN an admin runs the readiness self-check,
+- THEN the report MUST list every check with status `pass`,
+- AND the overall verdict MUST be `ready`.
+
+> @e2e exclude Backend outbound-validation contract against the instance's own public surface; requires a publicly-resolvable deployment topology not present in the e2e harness; covered by PHPUnit tests with a mocked HTTP client.
+
+#### Scenario: publicly unreachable sitemapindex fails the check with a reason
+
+- GIVEN a WOO-enabled catalog whose sitemapindex URL returns HTTP 404 from
+  the public base URL,
+- WHEN an admin runs the readiness self-check,
+- THEN the sitemapindex check MUST report `fail` with reason `http-404`,
+- AND dependent per-category sitemap checks MUST report `skipped`,
+- AND the overall verdict MUST be `not-ready`.
+
+> @e2e exclude Same backend contract as above; PHPUnit with mocked HTTP client.
+
+### Requirement: Readiness report is persisted and retrievable (WOO-HR-002)
+
+The system MUST persist the most recent readiness report (per-check results,
+overall verdict, run timestamp, checked base URL) and expose it via an
+admin-gated endpoint so the settings UI can render the last-known state
+without re-running the checks. Running a new self-check MUST replace the
+persisted report atomically.
+
+#### Scenario: last report is returned without re-running checks
+
+- GIVEN a readiness self-check completed at time T,
+- WHEN an admin requests the readiness report,
+- THEN the persisted report from time T MUST be returned,
+- AND no outbound validation requests may be made by that read.
+
+> @e2e exclude Backend persistence contract; covered by PHPUnit.
+
+### Requirement: Woo-index registration status is tracked in configuration (WOO-HR-003)
+
+The system MUST track the organisation's Woo-index registration state as an
+admin-editable configuration object with fields `status`
+(`not_registered` | `requested` | `registered`), `registeredUrl` (the public
+base URL registered in the Woo-index / Register van Overheidsorganisaties)
+and `registeredAt` (date). The readiness report MUST include this
+registration object, and when `status=registered` the self-check MUST verify
+that `registeredUrl` matches the public base URL the checks ran against,
+reporting a `url-mismatch` failure otherwise.
+
+#### Scenario: registered URL mismatch is surfaced
+
+- GIVEN registration status `registered` with `registeredUrl`
+  `https://old.example.org`,
+- AND the instance's configured public base URL is `https://new.example.org`,
+- WHEN an admin runs the readiness self-check,
+- THEN the registration check MUST report `fail` with reason `url-mismatch`.
+
+> @e2e exclude Backend config contract; covered by PHPUnit.
+
+### Requirement: Readiness endpoints are admin-gated and fail closed (WOO-HR-004)
+
+The readiness run and report endpoints MUST be gated with
+`#[AuthorizedAdminSetting]`. When the WOO configuration is absent or no
+WOO-enabled catalog exists, the run endpoint MUST fail closed with an
+explicit `not-configured` error (HTTP 409) rather than reporting `ready`,
+and MUST NOT perform any outbound request.
+
+#### Scenario: unconfigured instance refuses the check instead of passing
+
+- GIVEN an instance with no WOO-enabled catalog,
+- WHEN an admin runs the readiness self-check,
+- THEN the endpoint MUST respond HTTP 409 with error `not-configured`,
+- AND no outbound HTTP request may be made.
+
+> @e2e exclude Backend auth/fail-mode contract; covered by PHPUnit.

--- a/openspec/changes/woo-index-harvester-readiness/tasks.md
+++ b/openspec/changes/woo-index-harvester-readiness/tasks.md
@@ -1,0 +1,20 @@
+# Tasks: woo-index-harvester-readiness
+
+- [ ] Freeze delta spec `specs/woo-compliance/spec.md` (ADDED WOO-HR-001..004); `openspec validate woo-index-harvester-readiness` green
+  - Acceptance: validator reports valid; existing WOO-001..010 untouched
+- [ ] `lib/Service/WooReadinessService.php`: outside-in checks (robots.txt, sitemapindex per WOO catalog, category sitemaps, DIWOO XSD validation on fetched bytes, sampled publication URL), SSRF guard on every fetch, per-check pass/fail/skipped with machine-readable reasons, bounded to ≤25 requests / 10s timeout each
+  - Spec ref: WOO-HR-001
+  - Acceptance: PHPUnit with mocked HTTP client covers pass, 404→fail+skipped-dependents, invalid-XML fail, XSD fail, SSRF-guard rejection
+- [ ] Persist report atomically in appconfig `woo_readiness_report`; expose `GET /api/woo/readiness` (last report, no side effects) and `POST /api/woo/readiness/run`
+  - Spec ref: WOO-HR-002
+  - Acceptance: PHPUnit proves GET performs zero outbound requests and returns the persisted report
+- [ ] `woo_index_registration` config object (status/registeredUrl/registeredAt) editable via settings; include in report; `url-mismatch` check when status=registered
+  - Spec ref: WOO-HR-003
+  - Acceptance: PHPUnit mismatch scenario green
+- [ ] Gate both endpoints with `#[AuthorizedAdminSetting]`; fail closed HTTP 409 `not-configured` when no WOO-enabled catalog; register routes in `appinfo/routes.php`
+  - Spec ref: WOO-HR-004
+  - Acceptance: PHPUnit: unconfigured→409+zero outbound; route-auth + semantic-auth gates green
+- [ ] Settings UI: Woo panel section rendering per-check status with remediation hints + registration status editor (NcSelect with inputLabel; modal-free inline panel)
+  - Spec ref: WOO-HR-002/003
+  - Acceptance: vitest component test; nc-input-labels gate green
+- [ ] `@spec` tags on all new/changed methods; hydra gates (spdx, route-auth, spec-coverage, security-change-has-tests — new outbound-fetch code touches tests/) green locally


### PR DESCRIPTION
Deep-dive market research (competitors, standards, user wishes, ecosystem placement — logged to the spectr register as `deepdive-2026-07-23-app-opencatalogi`: 19 competitors, 24 scored capabilities, 16 insights) surfaced three gaps not covered by the 43 canonical specs or 33 pending changes:

- **woo-index-harvester-readiness** — outside-in self-check + Woo-index registration tracking proving KOOP Woo-harvester ingestibility. Only 3/971 Woo-plichtige orgs are connected to the national harvester; competitors CARE and OpenGDC market exactly this capability.
- **public-api-openapi-document** — replace the dead `dsonextcloud` openapi.json stub with an accurate served OpenAPI 3.1 document + bidirectional route↔document parity test (developer.overheid.nl API-register + procurement credibility).
- **authenticated-read-parity** — session-aware `@self` stripping on public reads, closing the `@todo` (logged-in users treated as anonymous) in CatalogiService.

Specs only — implementation follows per change on wip/ branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)