### PR TITLE
docs(openspec): fix-woo-capability-provisioning — provision the orphaned WOO storage

### DIFF
--- a/openspec/changes/fix-woo-capability-provisioning/design.md
+++ b/openspec/changes/fix-woo-capability-provisioning/design.md
@@ -1,0 +1,59 @@
+# Design: fix-woo-capability-provisioning
+
+## Approach
+Provision, don't rewrite. `WooService` is correct code that was never given
+storage; the fix is three small, surgical additions plus one generic guard.
+
+## Decisions
+
+### D1 — Schemas join the SHARED publication register, not a new one
+`SettingsService`'s import pipeline creates exactly one register
+(`publication`); the OOAPI change already documented that a genuinely separate
+register is not achievable without rearchitecting `SettingsService`. `WooService`
+also treats the register as shared (`getRegister()` backs both batch and
+assessment objects). So `wooBatch`/`wooAssessment` are added to
+`publication_register.json` and `woo_register` resolves to that same register id.
+
+### D2 — Explicit key map, mirroring `$ooapiTypeMap`
+The WOO keys break the `type === slug` convention twice: the prefix differs
+(`woo_` vs `wooBatch`) and `woo_register` is a *register* key with no matching
+schema slug. The existing `$ooapiTypeMap` is the established precedent for
+exactly this; reuse the pattern rather than bending the slug convention.
+`woo_register` is set from the resolved publication register id directly.
+
+### D3 — Field inventory is derived from the service, not invented
+Every property comes from reading `WooService`'s writes:
+`createBatch()` (`caseReference`, `status`, `deckBoardId`, `deckAvailable`,
+`documents`, `besluit`, `inventarislijst`, `createdAt`, `updatedAt`,
+`createdBy`), the assessment literal (`documentReference`, `fileName`,
+`fileType`, `assessment`, `weigeringsgronden`, `redactionInstructions`,
+`anonymizedDocument`, `caseReference`, `assessedBy`, `assessedAt`), and the
+later `$batch[...]` assignments (`documentSummary`, `publishedAt`,
+`publishedCount`, `wooPublication`). Enum values likewise come from the
+service's own literals. A test pins this correspondence so the schema cannot
+drift from the writer.
+
+### D4 — The parity test is the real fix
+Adding three keys to a hand-maintained list fixes today's page; it does not
+stop the next one from breaking the same way. The listener's own docblock
+already claims the list is "kept in sync with the object types OpenCatalogi's
+frontend registers" — it drifted anyway, silently, and the only symptom was a
+404 in a console nobody reads. The parity test converts that silent runtime
+failure into a loud build failure, and is the same anti-rot pattern shipped
+for `openapi.json` in `public-api-openapi-document`.
+
+Implementation: parse the effective manifest the way `src/main.js` does (base
+`src/manifest.json` + `src/manifest.d/*.json` + `src/menu-layout.json`),
+regex every `@resolve:([a-z][a-z0-9_-]*)` string, reflect
+`MANIFEST_CONFIG_KEYS` off the listener class, and assert the sentinel set is
+a subset. Reflection (not a duplicated literal list) keeps one source of truth.
+
+### D5 — Idempotent, non-destructive configuration
+Follow the existing loop's shape: only write a key when the corresponding
+schema was actually found in the import result. Never write an empty string
+over a value an operator set by hand.
+
+## Verification
+Beyond unit tests, the change is live-verified on the dev instance: run the
+repair/auto-configure path, confirm `occ config:list opencatalogi` now shows
+the three WOO keys, and confirm `/woo` no longer emits `@resolve:` 404s.

--- a/openspec/changes/fix-woo-capability-provisioning/hydra.json
+++ b/openspec/changes/fix-woo-capability-provisioning/hydra.json
@@ -1,0 +1,8 @@
+{
+  "spec_slug": "fix-woo-capability-provisioning",
+  "title": "Provision WOO batch/assessment storage + kill the @resolve sentinel 404s",
+  "app": "opencatalogi",
+  "repo": "https://github.com/ConductionNL/opencatalogi",
+  "depends_on": [],
+  "issue": null
+}

--- a/openspec/changes/fix-woo-capability-provisioning/proposal.md
+++ b/openspec/changes/fix-woo-capability-provisioning/proposal.md
@@ -1,0 +1,90 @@
+---
+kind: code
+depends_on: []
+---
+
+# Proposal: fix-woo-capability-provisioning
+
+## Summary
+Provision the storage the WOO transparency capability has always needed but
+never got. Today the entire WOO workflow is **orphaned**: `WooService` (993
+lines), `WooController`, `WooBatchDetail.vue` and `WooRedactionView.vue` all
+ship and the `woo-transparency` spec is marked done, but the OpenRegister
+schemas those objects live in do not exist, the config keys pointing at them
+are never populated, and the frontend's `@resolve:` sentinels for those keys
+are never substituted. The visible symptom is the `/woo` view rendering
+"No items found" while the console logs two 404s. This change ships the two
+missing schemas, auto-configures the three WOO config keys, surfaces them as
+initial state, and adds a parity test that prevents the whole defect class
+from recurring.
+
+## Motivation
+Observed live on the dev instance (2026-07-23 UX audit): opening `/woo` fires
+
+```
+GET /apps/openregister/api/schemas/@resolve:woo_batch_schema            → 404
+GET /apps/openregister/api/objects/@resolve:woo_register/@resolve:woo_batch_schema → 404
+```
+
+The literal sentinel strings reach the network because nothing resolved them.
+Tracing back, three coupled defects stack up:
+
+1. **No storage schemas.** `lib/Settings/publication_register.json` declares 10
+   schemas (`publication`, `document`, `catalog`, `listing`, `organization`,
+   `page`, `theme`, `menu`, `glossary`, `usageCounter`). There is no
+   `wooBatch` and no `wooAssessment` schema anywhere in the repo, so
+   `woo_register` / `woo_batch_schema` / `woo_assessment_schema` have nothing
+   to point at.
+2. **No auto-configuration.** `SettingsService::updateObjectTypeConfiguration()`
+   populates `{slug}_register` / `{slug}_schema` for nine object types whose
+   config-key prefix equals the schema slug, plus an explicit `$ooapiTypeMap`
+   for the OOAPI keys whose prefix deliberately differs. The WOO keys match
+   neither convention (prefix `woo_`, schema slugs `wooBatch` /
+   `wooAssessment`, and a *shared* `woo_register`), so no code path ever sets
+   them. `occ config:list opencatalogi` on a provisioned instance confirms all
+   three keys are absent.
+3. **Sentinels never resolve.** `ProvideManifestConfigStateListener::MANIFEST_CONFIG_KEYS`
+   lists 16 keys and omits the WOO ones, so `resolveManifestSentinelsSync()` in
+   `src/main.js` finds no initial state, leaves `@resolve:woo_register`
+   untouched by design ("unknown / unset keys are left untouched"), and the
+   manifest page requests a literal sentinel as a register id.
+
+This is the fleet's ORPHANED CAPABILITY defect class: spec-says-done ≠ feature
+runs. `WooService::createBatch()` throws `RuntimeException('OpenRegister WOO
+register/schema unavailable or unconfigured')` on the very first call, so no
+municipality has ever been able to run a Woo-verzoek batch on a stock install
+— which matters directly given the Woo procurement window this app is chasing.
+
+## Scope
+- Add `wooBatch` and `wooAssessment` schemas to the shared publication
+  register (`lib/Settings/publication_register.json`), modelled exactly on the
+  object shapes `WooService` reads and writes today — no new fields invented,
+  no field the service writes omitted.
+- Extend `SettingsService::updateObjectTypeConfiguration()` with an explicit
+  WOO key map (mirroring the existing `$ooapiTypeMap` precedent) so
+  `woo_register` (the shared publication register id), `woo_batch_schema` and
+  `woo_assessment_schema` are populated on install/repair.
+- Add the three WOO keys to `ProvideManifestConfigStateListener::MANIFEST_CONFIG_KEYS`.
+- **Anti-drift guard**: a unit test asserting that every `@resolve:<key>`
+  sentinel appearing anywhere in the effective manifest (base + `manifest.d`
+  fragments + menu layout) is present in `MANIFEST_CONFIG_KEYS`. This is the
+  generic fix — the same drift silently broke this page and would break the
+  next one added.
+
+## Out of scope
+- Any change to the WOO workflow logic itself (assessment, weigeringsgronden,
+  inventarislijst, approval chain, Deck integration) — that code is correct,
+  it simply had nowhere to store objects.
+- `WooService::resolveStackId()` (returns 0; Deck stack mapping) and the
+  silent degradation when the Deck leaf is absent — tracked separately.
+- Retro-configuring already-installed instances beyond what the existing
+  repair-step/`autoConfigure` path does on upgrade.
+
+## Impact
+- Touched: `lib/Settings/publication_register.json` (+2 schemas),
+  `lib/Service/SettingsService.php` (WOO key map),
+  `lib/Listener/ProvideManifestConfigStateListener.php` (+3 keys), unit tests.
+- Specs: delta on `woo-transparency` (ADDED WOO-PROV-001..003).
+- Behavioural: `/woo` renders a real (empty-but-live) batch list instead of a
+  404-backed dead table; `WooService::createBatch()` stops throwing
+  "unconfigured" on a stock install.

--- a/openspec/changes/fix-woo-capability-provisioning/specs/woo-transparency/spec.md
+++ b/openspec/changes/fix-woo-capability-provisioning/specs/woo-transparency/spec.md
@@ -1,0 +1,92 @@
+## ADDED Requirements
+
+### Requirement: WOO batch and assessment objects have shipped storage schemas (WOO-PROV-001)
+
+The app MUST ship `wooBatch` and `wooAssessment` schemas in the bundled
+publication register so the WOO transparency workflow has storage on a stock
+install. The schemas MUST cover exactly the object shapes `WooService`
+persists:
+
+- `wooBatch`: `caseReference`, `status` (enum `in_progress` |
+  `ready_for_review` | `published`), `deckBoardId`, `deckAvailable`,
+  `documents` (array of assessment object references), `besluit`,
+  `inventarislijst`, `documentSummary`, `publishedAt`, `publishedCount`,
+  `wooPublication`, `createdAt`, `updatedAt`, `createdBy`.
+- `wooAssessment`: `documentReference`, `fileName`, `fileType`, `assessment`
+  (enum `te_beoordelen` | `openbaar` | `niet_openbaar` | `deels_openbaar`),
+  `weigeringsgronden` (array), `redactionInstructions`,
+  `anonymizedDocument`, `caseReference`, `assessedBy`, `assessedAt`.
+
+Every property MUST carry a human-friendly English `title` and `description`.
+No property that `WooService` writes may be absent from its schema, and the
+schemas MUST NOT introduce properties the service never writes.
+
+#### Scenario: a stock install exposes both WOO schemas
+
+- GIVEN a fresh install whose register import has completed,
+- WHEN the bundled publication register's schemas are listed,
+- THEN a `wooBatch` schema and a `wooAssessment` schema MUST be present,
+- AND every field `WooService` persists MUST exist as a property on the
+  matching schema.
+
+> @e2e exclude Bundled register-definition contract; asserted by a PHPUnit test that cross-checks the shipped register JSON against the field inventory, no browser-observable surface of its own.
+
+### Requirement: WOO config keys are auto-configured on install and repair (WOO-PROV-002)
+
+The register-import configuration step MUST populate `woo_register` (the
+shared publication register id), `woo_batch_schema` (the `wooBatch` schema id)
+and `woo_assessment_schema` (the `wooAssessment` schema id), using an explicit
+key map because the WOO config-key prefixes deliberately differ from their
+schema slugs — the same mechanism the OOAPI keys already use. Re-running the
+import MUST be idempotent and MUST NOT clear an operator's existing values
+with empty ones.
+
+#### Scenario: install populates all three WOO keys
+
+- GIVEN a register import whose result contains the `wooBatch` and
+  `wooAssessment` schemas and the `publication` register,
+- WHEN the object-type configuration step runs,
+- THEN `woo_register` MUST equal the publication register id,
+- AND `woo_batch_schema` MUST equal the `wooBatch` schema id,
+- AND `woo_assessment_schema` MUST equal the `wooAssessment` schema id.
+
+> @e2e exclude Backend configuration contract; covered by PHPUnit against a mocked import result.
+
+#### Scenario: a missing schema in the import result leaves the key untouched
+
+- GIVEN an import result that does not contain a `wooAssessment` schema,
+- WHEN the object-type configuration step runs,
+- THEN `woo_assessment_schema` MUST NOT be overwritten with an empty value.
+
+> @e2e exclude Same backend contract; PHPUnit.
+
+### Requirement: Every manifest resolve-sentinel is backed by provided initial state (WOO-PROV-003)
+
+The system MUST guarantee that every resolve-sentinel appearing anywhere in
+the app's effective manifest (base manifest plus manifest.d fragments plus
+menu layout) has its config key listed in the initial-state provider's
+manifest-config key set, so the frontend can substitute it before first paint.
+A sentinel whose key is absent from that set MUST fail the build, because at
+runtime it silently reaches the network as a literal register or schema
+identifier and returns HTTP 404.
+
+The WOO keys `woo_register`, `woo_batch_schema` and `woo_assessment_schema`
+MUST be members of that key set.
+
+#### Scenario: an unbacked sentinel fails the build
+
+- GIVEN a manifest page whose `config` references `@resolve:some_new_key`,
+- AND `some_new_key` is absent from the initial-state provider's key set,
+- WHEN the unit test suite runs,
+- THEN the parity test MUST fail naming `some_new_key`.
+
+> @e2e exclude Build-time drift guard with no runtime surface; PHPUnit.
+
+#### Scenario: the WOO page resolves to real ids
+
+- GIVEN an install where the WOO config keys are populated,
+- WHEN the SPA renders the WOO page,
+- THEN the page's register/schema config MUST contain the configured numeric
+  ids and MUST NOT contain any literal `@resolve:` string.
+
+> @e2e exclude Frontend substitution is covered by the parity test plus the existing initial-state provision; a live-instance check is recorded in the change's tasks rather than as an automated e2e (the WOO surface needs a provisioned Deck leaf to be meaningfully driven).

--- a/openspec/changes/fix-woo-capability-provisioning/tasks.md
+++ b/openspec/changes/fix-woo-capability-provisioning/tasks.md
@@ -1,0 +1,17 @@
+# Tasks: fix-woo-capability-provisioning
+
+- [ ] Freeze delta spec `specs/woo-transparency/spec.md` (ADDED WOO-PROV-001..003); `openspec validate fix-woo-capability-provisioning` green
+- [ ] Add `wooBatch` + `wooAssessment` schemas to `lib/Settings/publication_register.json`, field-for-field from `WooService`'s writes (D3); English `title`+`description` on every property; enums exactly as the service uses them
+  - Spec ref: WOO-PROV-001
+  - Acceptance: PHPUnit cross-checks the shipped register JSON against the field inventory; schema-property-titles + relation-dialect gates green
+- [ ] Extend `SettingsService::updateObjectTypeConfiguration()` with the explicit WOO key map (`woo_register` ← publication register id, `woo_batch_schema` ← `wooBatch`, `woo_assessment_schema` ← `wooAssessment`), idempotent + never overwrite with empty
+  - Spec ref: WOO-PROV-002
+  - Acceptance: PHPUnit — all three keys set from a mocked import result; missing-schema case leaves the key untouched
+- [ ] Add `woo_register`, `woo_batch_schema`, `woo_assessment_schema` to `ProvideManifestConfigStateListener::MANIFEST_CONFIG_KEYS`
+  - Spec ref: WOO-PROV-003
+- [ ] Anti-drift parity test: every `@resolve:<key>` in the effective manifest (base + `manifest.d/*` + `menu-layout.json`) must be in `MANIFEST_CONFIG_KEYS`, read via reflection (single source of truth); prove by mutation that removing a key fails the test, then restore
+  - Spec ref: WOO-PROV-003
+  - Acceptance: test fails naming the offending key when a sentinel is unbacked
+- [ ] Live-verify on the dev instance: run the auto-configure/repair path, `occ config:list opencatalogi` shows the three WOO keys, and `/woo` loads with no `@resolve:` 404 in the console
+  - Spec ref: WOO-PROV-002, WOO-PROV-003
+- [ ] `@spec` tags on changed methods; SPDX headers intact; full unit suite shows no new failures vs the documented baseline (SetupControllerTest ×2, DirectoryServiceTest ×1)


### PR DESCRIPTION
Specs the fix for the `/woo` green-but-dead bug found in the 2026-07-23 UX audit.

## Root cause
Opening `/woo` fires two 404s with literal sentinels in the URL:
```
GET /apps/openregister/api/schemas/@resolve:woo_batch_schema → 404
GET /apps/openregister/api/objects/@resolve:woo_register/@resolve:woo_batch_schema → 404
```
Three coupled defects leave the entire WOO transparency capability **orphaned** (spec-says-done ≠ feature runs):
1. **No storage schemas** — `publication_register.json` has 10 schemas; `wooBatch`/`wooAssessment` exist nowhere, so the config keys have nothing to point at.
2. **No auto-configuration** — `SettingsService::updateObjectTypeConfiguration()` handles `{slug}_register`/`{slug}_schema` plus an explicit OOAPI map; the WOO keys match neither convention, so nothing sets them (`occ config:list opencatalogi` confirms all three absent).
3. **Sentinels never resolve** — `ProvideManifestConfigStateListener::MANIFEST_CONFIG_KEYS` omits the WOO keys, so `resolveManifestSentinelsSync()` leaves them literal by design.

Consequence: `WooService::createBatch()` throws "unconfigured" on the first call — no municipality can run a Woo-verzoek batch on a stock install.

## Spec (WOO-PROV-001..003)
Ship the two schemas (field-for-field from what `WooService` actually writes), auto-configure the three keys via an explicit map mirroring the OOAPI precedent, add them to the initial-state list, and add an **anti-drift parity test** asserting every manifest resolve-sentinel is backed by a provided key — turning this silent runtime 404 class into a build failure.

Specs only — implementation follows on the same branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)