### PR TITLE
fix(e2e): catalog-detail nav — expand CatalogueGroup, drop stale settings foldout

### DIFF
--- a/tests/e2e/spec-coverage/catalog-detail-page.spec.ts
+++ b/tests/e2e/spec-coverage/catalog-detail-page.spec.ts
@@ -39,7 +39,25 @@ test.describe('catalog-detail-page', () => {
 			const errors = trackPageErrors(page)
 
 			await bootApp(page)
-			await navTo(page, 'CatalogsMenu', true)
+
+			// CatalogsMenu is a child of the collapsible `CatalogueGroup`
+			// (the nav-IA `settings-foldout + admin-IA hygiene` refactor moved
+			// Catalogs/Glossary/Themes/Pages/Menus/WooBatches under it). The
+			// group renders collapsed (aria-expanded=false) so its children are
+			// hidden until it is opened — exactly as woo-batches-page.spec.ts
+			// handles WooBatchesMenu. The stale `settings=true` here opened the
+			// settings gear foldout (where CatalogsMenu does NOT live), leaving
+			// the entry hidden and the click never landing. Expand the group
+			// first, then use the normal nav click.
+			const group = page.locator('[data-testid="cn-nav-entry-CatalogueGroup"]').first()
+			await expect(group).toBeVisible({ timeout: 10000 })
+			const catalogsEntry = page.locator('[data-testid="cn-nav-entry-CatalogsMenu"]').first()
+			if (!(await catalogsEntry.isVisible().catch(() => false))) {
+				await group.locator('a, button').first().click()
+				await expect(catalogsEntry).toBeVisible({ timeout: 10000 })
+			}
+
+			await navTo(page, 'CatalogsMenu')
 			await expect(page.locator('[data-testid="cn-index-page"]').first())
 				.toBeVisible({ timeout: 15000 })
 


### PR DESCRIPTION
## Problem
`catalog-detail-page.spec.ts` failed on every run: `cn-nav-entry-CatalogsMenu` present in DOM but `hidden`. Not a product regression — a stale nav assumption.

The `settings-foldout + admin-IA hygiene` nav-IA refactor moved `CatalogsMenu` under the collapsible **`CatalogueGroup`** (with Glossary/Themes/Pages/Menus/WooBatches). Only `SettingsMenu` lives in the settings gear foldout. But the spec navigated via `navTo('CatalogsMenu', settings=true)`, which opens the gear foldout — where CatalogsMenu isn't — and never expands `CatalogueGroup`. The group renders collapsed (verified live: `aria-expanded=false`, all children `w=0 h=0`), so the entry stayed hidden.

## Fix
Expand `CatalogueGroup` first, then `navTo('CatalogsMenu')` without the settings flag — the identical pattern `woo-batches-page.spec.ts` (a sibling under the same group, added by the woo-e2e-regression-guard) already uses and which passes.

**Verified live against 8080: `1 passed (1.5m)`.** The other spec-coverage specs covering the WOO/OpenAPI work (`woo-batches-page`, `search-page`, `openapi-document`) were already green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)