### PR TITLE
docs(icons): tie the ContentBlocks icon set to ADR-077 and its published contract

### DIFF
--- a/src/modals/pageContents/PageContentForm.vue
+++ b/src/modals/pageContents/PageContentForm.vue
@@ -331,6 +331,21 @@ export default {
 			typeOptions: {
 				options: ['text', 'RichText', 'Image', 'Faq', 'Quote', 'ContentBlocks'],
 			},
+			// The ContentBlocks icon set — the SECOND legal icon dialect under
+			// ADR-077, and the only place it is authored. These lowercase names
+			// are stored in page/register data and drawn by the PUBLIC
+			// Softwarecatalogus website with its own glyphs, not by CnIcon, which
+			// is why they are not MDI PascalCase names.
+			//
+			// This list is a published contract: it is documented for end users in
+			// Softwarecatalogus `website/docs/Handleidingen/pagina-beheer.md`, so
+			// renaming an entry breaks the public site AND the documentation.
+			//
+			// Hydra's gate-60 validates every lowercase icon value against a
+			// mirror of this list (`contentBlockIcons` in
+			// scripts/schemas/semantic-icons.json). Adding a name here means
+			// updating that mirror, the user documentation, and the public site's
+			// glyph mapping — all three, deliberately.
 			iconOptions: {
 				options: ['search', 'cubes', 'cube', 'users', 'building', 'document', 'gear', 'link', 'world', 'truck', 'scroll', 'themes', 'house'],
 			},


### PR DESCRIPTION
The 13 lowercase names in this picker are the **second legal icon dialect** under ADR-077, and this is the only place they are authored. Nothing in the code said so, so they read like drift from the MDI vocabulary rather than a deliberate, separate set.

They are deliberate: the values are stored in page/register data and drawn by the **public Softwarecatalogus website** with its own glyphs — not by CnIcon — and they are documented for end users in that site's page-management handleiding. Renaming one breaks the public site *and* the documentation, which is why they are governed where they are rather than migrated to MDI.

Records that hydra's gate-60 now validates every lowercase icon value against a mirror of this list (ConductionNL/hydra#421), so adding a name here means updating the mirror, the user documentation and the public site's glyph mapping together.

Comment only — no behaviour change.