### PR TITLE
fix(search): clear-search button called a method that does not exist

### DIFF
--- a/src/components/SearchResults.vue
+++ b/src/components/SearchResults.vue
@@ -92,7 +92,7 @@ onMounted(() => {
 				:trailing-button-label="t('opencatalogi', 'Clear search')"
 				:show-trailing-button="objectStore.getSearchTerm('search') !== ''"
 				@update:model-value="(value) => objectStore.setSearchTerm('search', value)"
-				@trailing-button-click="objectStore.clearSearch('search')">
+				@trailing-button-click="objectStore.clearSearchTerm('search')">
 				<template #icon>
 					<MagnifyIcon />
 				</template>

--- a/src/views/publications/PublicationList.vue
+++ b/src/views/publications/PublicationList.vue
@@ -12,7 +12,7 @@ import { navigationStore, objectStore, catalogStore } from '../../store/store.js
 					trailing-button-icon="close"
 					:show-trailing-button="objectStore.getSearchTerm('publication') !== ''"
 					@update:model-value="objectStore.setSearchTerm('publication', $event)"
-					@trailing-button-click="objectStore.clearSearch('publication')">
+					@trailing-button-click="objectStore.clearSearchTerm('publication')">
 					<Magnify :size="20" />
 				</NcTextField>
 				<NcActions>


### PR DESCRIPTION
## Problem

`PublicationList.vue:15` and `SearchResults.vue:95` both call `objectStore.clearSearch(type)`.

The **object** store defines `clearSearchTerm(type)`. `clearSearch()` exists only on the **search** store and takes no argument. So `objectStore.clearSearch` resolves to `undefined` and the clear (×) button throws on click — in the publication list and in search results.

## Fix

Two call sites: `clearSearch(type)` → `clearSearchTerm(type)`.

The sibling bindings on the very same components already use the typed API (`getSearchTerm(type)`, `setSearchTerm(type, value)`), so `clearSearchTerm(type)` is unambiguously the intended method. `clearSearchTerm` also clears the debounce timer and refetches the collection, which is the desired behaviour.

## Verification

- Positive control: `clearSearchTerm(type)` **is** defined in `object.js:1543` (1 hit).
- Negative control: no `clearSearch()` definition in the object store (0 hits).
- Remaining bad callers: **0**. Fixed callers: **2**.
- `eslint` on both changed files: rc=0.

## Scope

Pre-existing on `development` — **not** introduced by the Vue 3 migration. Found during the migration sweep and deliberately kept out of that PR to avoid widening its diff.