### PR TITLE
ci: re-run Code Quality when a PR is pushed to

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -4,7 +4,20 @@ on:
   push:
     branches: [main, beta, development, feature/**, bugfix/**, hotfix/**]
   pull_request:
-    types: [opened, reopened]
+    # `synchronize` — a push to an open PR — was missing. Without it the quality
+    # suite runs ONCE, when the PR is opened, and every commit after that is
+    # merged unchecked while the PR still shows the first run's green tick. A
+    # green check here described code that no longer existed.
+    #
+    # The branch list on `push:` does not cover the gap: it names `feature/**`
+    # while the convention in practice is also `feat/**` and `fix/**`.
+    #
+    # Cost is bounded by the `concurrency` block below — a new push cancels the
+    # in-flight run for the same head ref rather than queueing beside it.
+    #
+    # openregister fixed the identical defect on its own copy of this workflow;
+    # this matches that.
+    types: [opened, reopened, synchronize]
     branches: [main, beta, development]
   workflow_dispatch:
 


### PR DESCRIPTION
`pull_request: types: [opened, reopened]` meant the Code Quality suite ran
**once**, when the PR was opened. Every commit pushed after that merged
unchecked while the PR still displayed the first run's green tick — a check
describing code that no longer existed.

Added `synchronize`. Cost is bounded by the existing `concurrency` block: a new
push cancels the in-flight run for the same head ref rather than queueing beside
it. openregister fixed the identical defect on its own copy of this workflow.

## What this does NOT fix — and why they must not be conflated

The recent incident where merging #782 to `development` produced **zero**
workflow runs has a different cause, now established:

The squashed merge commit body carries **`[skip ci]`**, inherited from an
auto-generated `github-actions[bot]` commit inside the PR
(`ci: regenerate docs/features.json from openspec/specs/ [skip ci]`). GitHub
honours a skip token anywhere in the head commit message and suppresses every
push- and `pull_request`-triggered run — so there is no run at all, no
check-runs, and nothing in `gh run list`.

Evidence, with a positive control:

- Every earlier push to `development` created **3 runs** each (Code Quality,
  Release, Sync to Beta) — `feat(icons)` #776, `fix(objects)` #777,
  `docs(icons)` #778 all show them.
- The #782 merge created **0**.
- Of the last 12 commits on `development`, 3827d0ec is the **only** one carrying
  a skip token.

So this is merge hygiene, not workflow configuration — no `on:` trigger can
override a skip token. It is worth knowing that any PR containing the
auto-generated `features.json` commit will silently suppress CI on merge if it
is squash-merged.
