### PR TITLE
chore(quality): make check:strict a real gate

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,18 +38,24 @@
 		"phpcs:fix": "./vendor/bin/phpcbf --standard=phpcs.xml",
 		"phpcs:output": "./vendor/bin/phpcs --standard=phpcs.xml --report=json lib/ 2>/dev/null | tail -1 > phpcs-output.json",
 		"phpcs:named-params": "./vendor/bin/phpcs --standard=phpcs.xml --sniffs=CustomSniffs.Functions.NamedParameters lib/",
-		"phpmd": "phpmd lib text phpmd.xml || echo 'PHPMD not installed, skipping...'",
+		"phpmd": "./vendor/bin/phpmd lib text phpmd.xml --baseline-file phpmd.baseline.xml",
 		"phpmetrics": "./vendor/bin/phpmetrics --report-html=phpmetrics lib/",
 		"phpmetrics:violations": "./vendor/bin/phpmetrics --violations-xml=phpmetrics/violations.xml lib/",
-		"psalm": "./vendor/bin/psalm --threads=1 --no-cache || echo 'Psalm not installed, skipping...'",
-		"phpstan": "./vendor/bin/phpstan analyse --memory-limit=1G || echo 'PHPStan not installed, skipping...'",
+		"psalm": "./vendor/bin/psalm --threads=1 --no-cache",
+		"phpstan": "./vendor/bin/phpstan analyse --memory-limit=1G",
 		"test:unit": "phpunit tests -c phpunit.xml --colors=always --fail-on-warning --fail-on-risky",
 		"test:all": "./vendor/bin/phpunit --colors=always || echo 'Tests require Nextcloud environment, skipping...'",
 		"openapi": "generate-spec",
 		"phpqa": "./vendor/bin/phpqa --report --analyzedDirs lib --buildDir phpqa",
 		"phpqa:full": "./vendor/bin/phpqa --report --analyzedDirs lib --buildDir phpqa --tools phpcs:0,phpmd:0,phploc:0,phpmetrics,phpcpd:0,parallel-lint:0",
 		"phpqa:ci": "./vendor/bin/phpqa --report --analyzedDirs lib --buildDir phpqa --tools phpcs,phpmd,phploc,phpmetrics,phpcpd,parallel-lint",
-		"check:strict": "@lint && @cs:check && @phpmd && @psalm && @phpstan",
+		"check:strict": [
+			"@lint",
+			"@cs:check",
+			"@phpmd",
+			"@psalm",
+			"@phpstan"
+		],
 		"qa:check": [
 			"@phpqa"
 		],

--- a/lib/Service/WooReadinessService.php
+++ b/lib/Service/WooReadinessService.php
@@ -427,7 +427,7 @@ class WooReadinessService
             return;
         }
 
-        if (($report['valid'] ?? false) === true) {
+        if ($report['valid'] === true) {
             $checks[] = $this->buildCheck(id: $checkId, status: 'pass', catalogSlug: $slug);
             return;
         }

--- a/phpmd.baseline.xml
+++ b/phpmd.baseline.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0"?>
+<phpmd-baseline>
+  <violation rule="PHPMD\Rule\Design\LongMethod" file="lib/AppInfo/Application.php" method="register"/>
+  <violation rule="PHPMD\Rule\CleanCode\MissingImport" file="lib/Controller/ApiDocumentationController.php"/>
+  <violation rule="PHPMD\Rule\Design\CouplingBetweenObjects" file="lib/Controller/GlossaryController.php"/>
+  <violation rule="PHPMD\Rule\Design\WeightedMethodCount" file="lib/Controller/ListingsController.php"/>
+  <violation rule="PHPMD\Rule\CleanCode\ElseExpression" file="lib/Controller/ListingsController.php"/>
+  <violation rule="PHPMD\Rule\Design\CouplingBetweenObjects" file="lib/Controller/MenusController.php"/>
+  <violation rule="PHPMD\Rule\CleanCode\ElseExpression" file="lib/Controller/PublicationsController.php"/>
+  <violation rule="PHPMD\Rule\CleanCode\MissingImport" file="lib/Controller/ResolvesRegisterConfiguration.php"/>
+  <violation rule="PHPMD\Rule\Design\WeightedMethodCount" file="lib/Controller/SetupController.php"/>
+  <violation rule="PHPMD\Rule\Design\LongParameterList" file="lib/Controller/SetupController.php" method="__construct"/>
+  <violation rule="PHPMD\Rule\CleanCode\ElseExpression" file="lib/Controller/SetupController.php"/>
+  <violation rule="PHPMD\Rule\UnusedFormalParameter" file="lib/Controller/WooController.php"/>
+  <violation rule="PHPMD\Rule\CleanCode\StaticAccess" file="lib/Observability/OpenCatalogiMetricsProvider.php"/>
+  <violation rule="PHPMD\Rule\CleanCode\ElseExpression" file="lib/Service/CatalogiService.php"/>
+  <violation rule="PHPMD\Rule\CleanCode\ElseExpression" file="lib/Service/DcatMappingService.php"/>
+  <violation rule="PHPMD\Rule\CyclomaticComplexity" file="lib/Service/DcatMappingService.php" method="resolveHvdCategory"/>
+  <violation rule="PHPMD\Rule\CyclomaticComplexity" file="lib/Service/DirectoryService.php" method="isSelfInstance"/>
+  <violation rule="PHPMD\Rule\CleanCode\MissingImport" file="lib/Service/EventService.php"/>
+  <violation rule="PHPMD\Rule\UnusedFormalParameter" file="lib/Service/OoapiService.php"/>
+  <violation rule="PHPMD\Rule\Design\LongMethod" file="lib/Service/PublicationQueryService.php" method="assemblePublicSearchResults"/>
+  <violation rule="PHPMD\Rule\Naming\LongVariable" file="lib/Service/PublicationQueryService.php"/>
+  <violation rule="PHPMD\Rule\CleanCode\ElseExpression" file="lib/Service/PublicationQueryService.php"/>
+  <violation rule="PHPMD\Rule\CyclomaticComplexity" file="lib/Service/PublicationService.php" method="getCatalogFilters"/>
+  <violation rule="PHPMD\Rule\CleanCode\ElseExpression" file="lib/Service/QualityService.php"/>
+  <violation rule="PHPMD\Rule\Design\WeightedMethodCount" file="lib/Service/RetentionService.php"/>
+  <violation rule="PHPMD\Rule\CleanCode\MissingImport" file="lib/Service/RetentionService.php"/>
+  <violation rule="PHPMD\Rule\CyclomaticComplexity" file="lib/Service/RetentionService.php" method="applyDefaults"/>
+  <violation rule="PHPMD\Rule\Design\NpathComplexity" file="lib/Service/RetentionService.php" method="applyDefaults"/>
+  <violation rule="PHPMD\Rule\CyclomaticComplexity" file="lib/Service/RetentionService.php" method="evaluate"/>
+  <violation rule="PHPMD\Rule\Design\NpathComplexity" file="lib/Service/RetentionService.php" method="evaluate"/>
+  <violation rule="PHPMD\Rule\CyclomaticComplexity" file="lib/Service/RetentionService.php" method="getQueueSummary"/>
+  <violation rule="PHPMD\Rule\Design\NpathComplexity" file="lib/Service/RetentionService.php" method="getQueueSummary"/>
+  <violation rule="PHPMD\Rule\CyclomaticComplexity" file="lib/Service/RetentionService.php" method="recordHumanDecision"/>
+  <violation rule="PHPMD\Rule\CyclomaticComplexity" file="lib/Service/RetentionService.php" method="buildReport"/>
+  <violation rule="PHPMD\Rule\Design\NpathComplexity" file="lib/Service/RetentionService.php" method="buildReport"/>
+  <violation rule="PHPMD\Rule\Design\LongClass" file="lib/Service/SettingsService.php"/>
+  <violation rule="PHPMD\Rule\Design\LongMethod" file="lib/Service/SettingsService.php" method="loadSettings"/>
+  <violation rule="PHPMD\Rule\CleanCode\ElseExpression" file="lib/Service/SettingsService.php"/>
+  <violation rule="PHPMD\Rule\Design\LongMethod" file="lib/Service/SettingsService.php" method="updateObjectTypeConfiguration"/>
+  <violation rule="PHPMD\Rule\CyclomaticComplexity" file="lib/Service/SettingsService.php" method="backfillCatalogScopes"/>
+  <violation rule="PHPMD\Rule\Design\LongMethod" file="lib/Service/SettingsService.php" method="backfillCatalogScopes"/>
+  <violation rule="PHPMD\Rule\CleanCode\ElseExpression" file="lib/Service/SitemapService.php"/>
+  <violation rule="PHPMD\Rule\Design\WeightedMethodCount" file="lib/Service/UsageCounterService.php"/>
+  <violation rule="PHPMD\Rule\CleanCode\MissingImport" file="lib/Service/UsageCounterService.php"/>
+  <violation rule="PHPMD\Rule\CleanCode\MissingImport" file="lib/Service/WooReadinessService.php"/>
+  <violation rule="PHPMD\Rule\CleanCode\ErrorControlOperator" file="lib/Service/WooReadinessService.php" method="isWellFormedXml"/>
+  <violation rule="PHPMD\Rule\CleanCode\ErrorControlOperator" file="lib/Service/WooReadinessService.php" method="extractLocs"/>
+  <violation rule="PHPMD\Rule\Design\WeightedMethodCount" file="lib/Service/WooService.php"/>
+  <violation rule="PHPMD\Rule\CyclomaticComplexity" file="lib/Service/WooService.php" method="createBatch"/>
+  <violation rule="PHPMD\Rule\Design\NpathComplexity" file="lib/Service/WooService.php" method="createBatch"/>
+  <violation rule="PHPMD\Rule\Design\LongMethod" file="lib/Service/WooService.php" method="createBatch"/>
+  <violation rule="PHPMD\Rule\CleanCode\MissingImport" file="lib/Service/WooService.php"/>
+  <violation rule="PHPMD\Rule\UnusedFormalParameter" file="lib/Service/WooService.php"/>
+  <violation rule="PHPMD\Rule\CyclomaticComplexity" file="lib/Service/WooService.php" method="updateAssessment"/>
+  <violation rule="PHPMD\Rule\Design\NpathComplexity" file="lib/Service/WooService.php" method="updateAssessment"/>
+  <violation rule="PHPMD\Rule\CleanCode\ElseExpression" file="lib/Service/WooService.php"/>
+</phpmd-baseline>

--- a/psalm.xml
+++ b/psalm.xml
@@ -79,6 +79,10 @@
                 <referencedClass name="OCA\OpenRegister\Service\RegisterService"/>
                 <referencedClass name="OCA\OpenRegister\Service\FileService"/>
                 <referencedClass name="OCA\OpenRegister\Service\CalendarEventService"/>
+                <!-- Thrown by ResolvesRegisterConfiguration when the register/schema
+                     configuration is absent. Same cross-app runtime-only situation as the
+                     entries above: OpenRegister is not on the analysis path. -->
+                <referencedClass name="OCA\OpenRegister\Service\Resolver\Exception\MissingConfigException"/>
                 <!-- OpenRegister AppHost classes (AppHost escape hatch — loaded via DI) -->
                 <referencedClass name="OCA\OpenRegister\AppHost\IMetricsProvider"/>
                 <referencedClass name="OCA\OpenRegister\AppHost\Controller\GenericHealthController"/>
@@ -113,6 +117,15 @@
         <!-- JSONResponse uses @template T which Psalm cannot resolve through addHeader() chaining.
              The pattern is fleet-wide and correct at runtime. -->
         <InvalidTemplateParam errorLevel="suppress"/>
+        <!-- MissingConfigException is an OpenRegister exception that is only present at
+             runtime, so Psalm cannot see that it extends \Exception and reports the throw
+             as InvalidThrow. Scoped to the single call site rather than suppressed
+             globally. PHPStan carries the equivalent ignore for its @throws variant. -->
+        <InvalidThrow>
+            <errorLevel type="suppress">
+                <referencedClass name="OCA\OpenRegister\Service\Resolver\Exception\MissingConfigException"/>
+            </errorLevel>
+        </InvalidThrow>
         <UndefinedMagicMethod errorLevel="suppress"/>
         <UnusedClass errorLevel="suppress"/>
         <PossiblyUnusedMethod errorLevel="suppress"/>


### PR DESCRIPTION
## Why

`composer check:strict` was dead **twice over** on opencatalogi.

**1. The `&&` chain never ran anything.** `check:strict` was the *string*
script `"@lint && @cs:check && @phpmd && @psalm && @phpstan"`. A string
Composer script is not a shell command line — Composer expands the first
`@script` and passes the rest through as **literal arguments**. Running it on
`development` produces:

```
Could not open input file: @psalm
Could not open input file: &&
Could not open input file: @phpstan
... returned with error code 123
```

`php -l` was being handed `&&`, `@cs:check`, `@phpmd`, `@psalm`, `@phpstan` as
filenames. **cs:check, phpmd, psalm and phpstan never executed at all.**

**2. Each analyser swallowed its own exit code** via `|| echo '... skipping ...'`.

Verified end-to-end — `composer phpmd` on `development`:

```
/app/lib/Service/WooService.php:905  MissingImport  Missing class import ...
PHPMD not installed, skipping...
COMPOSER_PHPMD_EXIT=0
```

It found 99 violations, printed **"PHPMD not installed, skipping..."**, and
exited 0. Note the message is a *lie*: the bare `phpmd` binary resolves fine,
because Composer prepends `vendor/bin` to `PATH` for scripts. The `|| echo` was
not protecting against a missing tool — it was hiding real findings.

## Analysis-path verification

Counts from an unverified path are worthless, so:

- **Container:** `nextcloud:32-apache`, **PHP 8.3.32** — matches CI, which pins
  `php-version: "8.3"`. Host PHP 8.2 is too old; `nextcloud:34` ships PHP 8.5,
  on which Psalm 5.26.1 crashes in its own `MethodCallAnalyzer`.
- **`imagick` present** (confirmed via `php -m`) — its absence alone has shifted
  a psalm count by 13 elsewhere in the fleet.
- **OCP stubs were broken and had to be repaired.** In the shared checkout
  `vendor/nextcloud/ocp/OCP` is a **symlink to `/var/www/html/lib/public`**,
  which does not resolve on the host — 0 PHP files. The real stubs (931 files)
  sit in `OCP.bak`. Restored in the analysis tree.
- **Positive control, per path.** `interface_exists("OCP\IRequest")` is *not* a
  valid probe here: `nextcloud/ocp` ships `autoload: null`, so OCP is never on
  the composer autoloader — phpstan resolves it via `scanDirectories`, psalm via
  `<extraFiles>`. So the control was to **break it and confirm the count moves**:

  | `lib/Controller/CatalogiController.php` | errors |
  |---|---|
  | stubs present (931 files) | **0** |
  | stubs emptied | **36** |

  Stub resolution is load-bearing and working. Without this control, "1 error" is
  indistinguishable from "the analyser resolved nothing".
- **Vendor tree verified in sync with `composer.lock`** — 127 packages locked,
  127 installed, zero drift. No `composer install` was needed or run here.

## Measured before repair

| step | result | exit | verdict |
|---|---|---|---|
| lint | 0 | 0 | pass |
| cs:check (phpcs) | 0 errors / 110 warnings | 0 | pass (warnings non-fatal by ruleset) |
| phpmd | **99** | 2 | **fail** |
| psalm | **1** | 2 | **fail** |
| phpstan | **1** | 1 | **fail** |

## What changed

**`check:strict` → Composer's array form**, which short-circuits and propagates
the exit code the way the `&&` was meant to.

**Shape choice — plain `./vendor/bin/X`, not the `if [ -f ... ]` guard.** phpmd,
psalm and phpstan are all in `require-dev` and CI runs `composer install`, so an
absent binary is itself a defect that should fail loudly rather than skip
quietly. This repo's other scripts (`lint`, `cs:check`, `phpcs`) already use the
plain form. The guarded shape is the better choice where a tool may legitimately
be absent; that is not the case here — and a "skip when missing" branch is
exactly the failure mode this PR removes.

## What was fixed vs. baselined

**phpstan: 1 → 0, fixed in code, no baseline.** The finding was a redundant
`?? false` on `$report['valid']`. Every return path of
`SitemapService::validateDiwooOutput()` — including the `diwooError()` helper —
sets `'valid'`, so the coalesce was dead. Removed.

**psalm: 1 → 0, config entry, no baseline.** The error was the cross-app
`OCA\OpenRegister\Service\Resolver\Exception\MissingConfigException`, which
exists only at runtime. Added to the `UndefinedClass` suppress list that already
documents ~30 other OpenRegister classes, plus a narrowly-scoped `InvalidThrow`
handler (suppressing that error *class-scoped*, not globally — psalm reclassified
the error once the class was known).

**phpmd: 99 → baselined (56 entries), with reason.** All 99 are complexity/style:

| rule | count |
|---|---|
| MissingImport | 34 |
| ElseExpression | 21 |
| CyclomaticComplexity | 11 |
| UnusedFormalParameter / NPathComplexity / ExcessiveMethodLength | 6 each |
| ExcessiveClassComplexity | 5 |
| long tail (StaticAccess, LongVariable, ErrorControlOperator, CouplingBetweenObjects, ExcessiveParameterList, ExcessiveClassLength) | 10 |

**None is a correctness defect.** Baselining makes the gate *ratchet* — new
violations fail, existing debt is tracked in **#785** — rather than papering over
a real problem. Fixing 99 style violations in the same PR that repairs the gate
would have made the gate change unreviewable.

## Proof the repaired gate is live, not newly-dead

```
$ composer check:strict
... all five steps execute ...
 [OK] No errors
OC_CHECKSTRICT_EXIT=0
"skipping" messages: 0        "Could not open input file": 0
```

**Negative control** — re-introduce the `?? false` and run again:

```
 [ERROR] Found 1 error
NEGATIVE_CONTROL_EXIT=1
```

The gate goes red on a real finding. Green here means green, not silent.

## Not done

`test:all` is **not** in this repo's `check:strict`, so it was out of scope and
is untouched. It still carries `|| echo`.

Host load during these runs was 60–100 (shared box), so wall-clock timings are
not meaningful; only counts and exit codes are reported.

Closes nothing; tracked debt in #785.
