### PR TITLE
ci(e2e): make the shared Playwright job actually run — and pass

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -58,3 +58,27 @@ jobs:
       enable-phpunit: true
       additional-apps: '[{"repo":"ConductionNL/openregister","app":"openregister","ref":"development"}]'
       enable-newman: false
+
+      # ── E2E browser tests ────────────────────────────────────────────────
+      # `playwright-test-path` does double duty in the shared workflow:
+      #   1. it is the directory the "Validate Playwright tests exist" step
+      #      counts *.spec.ts in;
+      #   2. it is the FIRST place the run step looks for a config —
+      #      `${playwright-test-path}/playwright.config.ts`, falling back to
+      #      the repo root only if that file is absent.
+      # We ship tests/e2e/playwright.config.ts precisely so lookup (2) hits it.
+      # The run step passes no `--project`, so the root config would run all
+      # three of its projects — including `visual` (pixel baselines that a CI
+      # Linux runner cannot byte-match) and `docs-capture` (screenshot
+      # re-shoots, which have their own dedicated job). The tests/e2e config
+      # declares only the regression project.
+      enable-playwright: true
+      playwright-test-path: tests/e2e
+      # `occ app:enable opencatalogi` runs InitializeSettings, but that repair
+      # step has no user session (OpenRegister RBAC can deny it), swallows its
+      # own exception as a warning, and imports with `force: false` — so a
+      # fresh install can come up with no publication register at all and
+      # nothing exits non-zero. The script imports explicitly over the admin
+      # API and fails loudly if the register/schemas still aren't there.
+      # cwd for this step is the Nextcloud server root.
+      playwright-seed-command: 'bash apps/opencatalogi/tests/e2e/ci-seed.sh'

--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,8 @@ bom-npm.cdx.json
 tests/e2e/.auth/
 tests/e2e/playwright-report/
 tests/e2e/test-results/
+# The CI config (tests/e2e/playwright.config.ts) writes to the app root
+# instead, because that is where the shared workflow's upload-artifact steps
+# look: server/apps/<app>/playwright-report/ and .../test-results/.
+/playwright-report/
+/test-results/

--- a/tests/e2e/ci-seed.sh
+++ b/tests/e2e/ci-seed.sh
@@ -173,10 +173,59 @@ do
 	echo "[ci-seed] warm ${path} -> ${code}"
 done
 
-# Pull the main webpack bundle once so it is in the page cache and opcache has
-# already resolved the route that serves it.
-BUNDLE_CODE="$(curl -sS -o /dev/null -w '%{http_code}' -u "${USER_NAME}:${USER_PASS}" \
-	"${BASE}/apps/opencatalogi/js/opencatalogi-main.js" || echo 000)"
-echo "[ci-seed] warm bundle -> ${BUNDLE_CODE}"
+# Pull the main webpack bundle once so it is in the page cache.
+#
+# Do NOT hardcode the URL. Nextcloud serves an app's assets from whichever apps
+# directory it was installed into — `/apps/<app>/js/...` on the CI runner,
+# `/custom_apps/<app>/js/...` in the docker dev images — and asking for the
+# wrong one does not 404. It returns **HTTP 200 with `text/html`**: the NC error
+# page, served through index.php. A status-code check therefore reports success
+# while fetching a 40 KB HTML page instead of a 7 MB bundle, so the warm-up
+# silently warms nothing.
+#
+# Read the real src out of the rendered app page instead, and verify the
+# response is actually JavaScript.
+APP_HTML="$(mktemp)"
+curl -sS -u "${USER_NAME}:${USER_PASS}" -H 'OCS-APIRequest: true' \
+	"${BASE}/index.php/apps/opencatalogi/" -o "$APP_HTML" || true
+
+BUNDLE_SRC="$(grep -oE 'src="[^"]*opencatalogi-main[^"]*"' "$APP_HTML" \
+	| head -1 | sed 's/^src="//; s/"$//')"
+
+if [ -n "$BUNDLE_SRC" ]; then
+	BUNDLE_INFO="$(curl -sS -o /dev/null \
+		-w '%{http_code} %{content_type} %{size_download}' \
+		-u "${USER_NAME}:${USER_PASS}" "${BASE}${BUNDLE_SRC}" || echo '000 - 0')"
+	echo "[ci-seed] warm bundle ${BUNDLE_SRC} -> ${BUNDLE_INFO}"
+else
+	echo "[ci-seed] could not locate the bundle src in the rendered app page."
+	BUNDLE_INFO=""
+fi
+
+# On CI this is a GATE, not a warm-up.
+#
+# The single most likely way this job "succeeds" dishonestly is by passing
+# without ever loading the app — and the environment hides it well: when the
+# bundle is absent, Nextcloud does not 404. It serves its HTML error page with
+# **HTTP 200 and Content-Type text/html**, so `npm run build` producing nothing
+# looks, to every status-code check in the pipeline, exactly like success.
+#
+# Verified against a live instance: with the bundle moved aside, the asset URL
+# still returned `200 text/html` (40 KB) — while 10 of 10 UI specs failed.
+# The specs are the honest signal; this check just makes the cause loud and
+# immediate instead of arriving as a wall of selector timeouts.
+if [ "${GITHUB_ACTIONS:-}" = "true" ] || [ "${CI:-}" = "true" ]; then
+	case "$BUNDLE_INFO" in
+		*javascript*)
+			echo "[ci-seed] bundle verified as JavaScript."
+			;;
+		*)
+			echo "::error::The OpenCatalogi frontend bundle did not serve as JavaScript (got: ${BUNDLE_INFO:-<not found>})."
+			echo "::error::The SPA cannot mount, so every UI spec would fail on a selector timeout with a misleading cause."
+			echo "::error::Check the 'Build app frontend' step — a missing bundle returns HTTP 200 text/html, not 404."
+			exit 1
+			;;
+	esac
+fi
 
 echo "[ci-seed] done."

--- a/tests/e2e/ci-seed.sh
+++ b/tests/e2e/ci-seed.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+#
+# SPDX-FileCopyrightText: 2026 OpenCatalogi Contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# Provision OpenCatalogi's OpenRegister register + schemas on a freshly
+# installed Nextcloud, for the shared `E2E Tests (Playwright)` CI job.
+#
+# Wired up as the workflow's `playwright-seed-command`. That step runs AFTER
+# `php -S` is up and with cwd set to the Nextcloud server root, so this is
+# invoked as:
+#
+#     playwright-seed-command: 'bash apps/opencatalogi/tests/e2e/ci-seed.sh'
+#
+# WHY THIS IS NEEDED
+# ------------------
+# `occ app:enable opencatalogi` runs the `InitializeSettings` post-migration
+# repair step, which is supposed to import `lib/Settings/publication_register.json`
+# into OpenRegister. Two things make that unreliable as the sole fresh-install
+# path, and BOTH fail silently:
+#
+#   1. An IRepairStep runs with NO user session. OpenRegister's RBAC evaluates
+#      the acting user, so the import can be denied outright — and
+#      `InitializeSettings::run()` catches `\Exception` and downgrades it to
+#      `$output->warning(...)`, explicitly "Non-fatal". `occ app:enable` still
+#      exits 0.
+#   2. It calls `loadSettings(force: false)`. The non-forced path is
+#      version-guarded: it can advance the recorded configuration version
+#      WITHOUT applying the register, so a second run then sees "already
+#      current" and does nothing either.
+#
+# Either way the app enables cleanly, the SPA boots, and the register simply
+# is not there. The e2e suite's failure mode in that state is a wall of
+# `create 14/55 failed: 404` and `seeding a catalog must succeed` — messages
+# that point at the fixtures, not at the missing import.
+#
+# So this script does the import EXPLICITLY through the admin HTTP API (which
+# has a real session and passes RBAC), with `force: true` to defeat the
+# version guard, and then VERIFIES the register and schemas actually exist.
+# A failed provision becomes one loud step failure here instead of ~14
+# misleading spec failures later.
+#
+# It is idempotent: the import is idempotent server-side, and re-running only
+# re-verifies.
+
+set -euo pipefail
+
+# ── Target resolution ────────────────────────────────────────────────────────
+# The shared workflow's "Seed test data" step declares no `env:` block, so
+# BASE_URL / ADMIN_USER / ADMIN_PASSWORD are NOT exported to it (unlike the
+# "Run Playwright tests" step). Accept them if a caller does set them, and fall
+# back to the CI runner's own `php -S 0.0.0.0:8080` otherwise.
+#
+# That fallback is gated on actually being in CI. On a developer box
+# `localhost:8080` is the SHARED dev container, and this script performs
+# ADMIN WRITES — it must never silently import a register into someone else's
+# environment. Off CI, an unset target is a hard error.
+BASE="${PLAYWRIGHT_BASE_URL:-${BASE_URL:-${NEXTCLOUD_URL:-}}}"
+if [ -z "$BASE" ]; then
+	if [ "${GITHUB_ACTIONS:-}" = "true" ] || [ "${CI:-}" = "true" ]; then
+		BASE="http://localhost:8080"
+	else
+		echo "ERROR: no base URL set. Export PLAYWRIGHT_BASE_URL or BASE_URL." >&2
+		echo "       Refusing to default to http://localhost:8080 outside CI —" >&2
+		echo "       that is the SHARED dev container and this script writes to it." >&2
+		exit 1
+	fi
+fi
+BASE="${BASE%/}"
+
+USER_NAME="${ADMIN_USER:-${NC_ADMIN_USER:-admin}}"
+USER_PASS="${ADMIN_PASSWORD:-${NC_ADMIN_PASS:-admin}}"
+
+echo "[ci-seed] target: ${BASE}"
+
+# ── 1. Import the OpenCatalogi configuration ─────────────────────────────────
+# `settings#manualImport` is admin-only (no @NoAdminRequired) and
+# @NoCSRFRequired, so basic auth is sufficient. `force` is compared with `===
+# true`, so it must arrive as a JSON boolean — a form-encoded "true" is the
+# string "true" and would be ignored, silently giving us the version-guarded
+# path this script exists to bypass.
+IMPORT_URL="${BASE}/index.php/apps/opencatalogi/api/settings/import"
+echo "[ci-seed] POST ${IMPORT_URL} (force: true)"
+
+IMPORT_BODY="$(mktemp)"
+IMPORT_CODE="$(
+	curl -sS -o "$IMPORT_BODY" -w '%{http_code}' \
+		-u "${USER_NAME}:${USER_PASS}" \
+		-X POST \
+		-H 'Content-Type: application/json' \
+		-H 'OCS-APIRequest: true' \
+		--data '{"force":true}' \
+		"$IMPORT_URL" || echo 000
+)"
+
+echo "[ci-seed] import HTTP ${IMPORT_CODE}"
+head -c 2000 "$IMPORT_BODY"; echo
+
+if [ "$IMPORT_CODE" != "200" ]; then
+	echo "::error::OpenCatalogi configuration import failed (HTTP ${IMPORT_CODE}). The e2e suite cannot seed catalogs or publications without it."
+	exit 1
+fi
+
+# ── 2. Verify the register and schemas are actually there ────────────────────
+# The import reporting success is not the same as the register existing —
+# verify against OpenRegister directly, using the same slugs the e2e fixtures
+# resolve by (tests/e2e/workflows/_fixtures.ts).
+verify() {
+	python3 - "$1" "$2" <<'PY'
+import json, sys
+path, kind = sys.argv[1], sys.argv[2]
+required = {
+    'registers': ['publication'],
+    'schemas': ['publication', 'catalog', 'organization', 'document'],
+}[kind]
+with open(path) as fh:
+    raw = fh.read()
+try:
+    body = json.loads(raw)
+except json.JSONDecodeError:
+    print(f'::error::{kind} endpoint did not return JSON. First 500 bytes:')
+    print(raw[:500])
+    sys.exit(1)
+items = body if isinstance(body, list) else body.get('results', [])
+slugs = {i.get('slug') for i in items if isinstance(i, dict)}
+missing = [s for s in required if s not in slugs]
+print(f'[ci-seed] {kind} present: {sorted(s for s in slugs if s)}')
+if missing:
+    print(f'::error::OpenCatalogi {kind} missing after import: {missing}')
+    sys.exit(1)
+print(f'[ci-seed] {kind} OK ({len(required)} required slugs present)')
+PY
+}
+
+REG_BODY="$(mktemp)"
+curl -sS -u "${USER_NAME}:${USER_PASS}" -H 'OCS-APIRequest: true' \
+	"${BASE}/index.php/apps/openregister/api/registers?_limit=300" -o "$REG_BODY"
+verify "$REG_BODY" registers
+
+SCH_BODY="$(mktemp)"
+curl -sS -u "${USER_NAME}:${USER_PASS}" -H 'OCS-APIRequest: true' \
+	"${BASE}/index.php/apps/openregister/api/schemas?_limit=1000" -o "$SCH_BODY"
+verify "$SCH_BODY" schemas
+
+echo "[ci-seed] OpenCatalogi register + schemas provisioned."

--- a/tests/e2e/ci-seed.sh
+++ b/tests/e2e/ci-seed.sh
@@ -143,3 +143,40 @@ curl -sS -u "${USER_NAME}:${USER_PASS}" -H 'OCS-APIRequest: true' \
 verify "$SCH_BODY" schemas
 
 echo "[ci-seed] OpenCatalogi register + schemas provisioned."
+
+# ── 3. Warm the SPA so the first spec doesn't pay the cold start ─────────────
+# The shared workflow serves Nextcloud with `php -S 0.0.0.0:8080` and does not
+# set PHP_CLI_SERVER_WORKERS, so the built-in server runs ONE worker: every
+# request the SPA fires on boot is serialised behind the one before it. On top
+# of that the first hit pays a cold opcache and the first parse of the webpack
+# bundle.
+#
+# The measured effect is confined to whichever spec happens to run first —
+# `catalog-detail-page.spec.ts` blew its 60s test timeout waiting for
+# `[data-testid="cn-index-page"]` on attempt 1 and then passed in 9.1s on
+# retry, while every later spec ran in 4-7s. Nothing about the assertion was
+# wrong; it was measuring server warm-up.
+#
+# So warm it here, in the environment-preparation step where it belongs. The
+# alternative — raising that spec's timeout — would hide the cold start inside
+# the assertion instead of removing it, and would keep drifting upward.
+# Failures are ignored on purpose: this is a warm-up, not a gate. The real
+# checks are above.
+for path in \
+	"/index.php/apps/opencatalogi/" \
+	"/index.php/apps/opencatalogi/api/settings" \
+	"/index.php/apps/opencatalogi/api/catalogi" \
+	"/index.php/apps/openregister/api/registers?_limit=1"
+do
+	code="$(curl -sS -o /dev/null -w '%{http_code}' -u "${USER_NAME}:${USER_PASS}" \
+		-H 'OCS-APIRequest: true' "${BASE}${path}" || echo 000)"
+	echo "[ci-seed] warm ${path} -> ${code}"
+done
+
+# Pull the main webpack bundle once so it is in the page cache and opcache has
+# already resolved the route that serves it.
+BUNDLE_CODE="$(curl -sS -o /dev/null -w '%{http_code}' -u "${USER_NAME}:${USER_PASS}" \
+	"${BASE}/apps/opencatalogi/js/opencatalogi-main.js" || echo 000)"
+echo "[ci-seed] warm bundle -> ${BUNDLE_CODE}"
+
+echo "[ci-seed] done."

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -1,0 +1,79 @@
+/*
+ * SPDX-FileCopyrightText: 2026 OpenCatalogi Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * CI regression config for the shared `E2E Tests (Playwright)` job.
+ *
+ * WHY A SECOND CONFIG EXISTS
+ * --------------------------
+ * The shared workflow (ConductionNL/.github/.github/workflows/quality.yml)
+ * runs the suite as:
+ *
+ *     CONFIG="${{ inputs.playwright-test-path }}/playwright.config.ts"
+ *     if [ ! -f "$CONFIG" ] && [ -f "playwright.config.ts" ]; then
+ *       CONFIG="playwright.config.ts"
+ *     fi
+ *     npx playwright test --config="$CONFIG"
+ *
+ * Note what is missing: `--project`. So whichever config it picks, EVERY
+ * project in it runs. The root `playwright.config.ts` declares three:
+ *
+ *   chromium     — the regression suite. This is the one CI wants.
+ *   docs-capture — journeydoc screenshot capture (ADR-030). Re-shoots every
+ *                  tutorial screenshot; the dedicated `Journeydoc Capture`
+ *                  job runs it explicitly with `--project docs-capture`.
+ *   visual       — pixel-diff baselines. Its own header says the PNGs are
+ *                  host-font/GPU specific and "a CI Linux runner will not
+ *                  byte-match a dev-container baseline".
+ *
+ * Letting the root config be picked therefore runs two projects that are
+ * documented as unable to pass on a CI runner, on top of the one that can.
+ * Rather than delete or weaken them, `playwright-test-path: tests/e2e` in the
+ * caller makes the workflow's FIRST lookup hit this file, which declares only
+ * the regression project. The root config is untouched and stays the entry
+ * point for local runs, `npm run test:e2e:docs`, and `--project visual`.
+ *
+ * The report/output paths also differ deliberately: the workflow uploads
+ * `server/apps/<app>/playwright-report/` and `server/apps/<app>/test-results/`,
+ * so on CI the artifacts must land at the app root, not under `tests/e2e/`.
+ * With the root config's paths the "Upload Playwright report" step matched
+ * nothing and silently uploaded an empty artifact (`if-no-files-found: ignore`)
+ * — a failing run with no report to read.
+ */
+
+import { defineConfig, devices } from '@playwright/test'
+import * as path from 'path'
+
+import { BASE_URL } from './base-url'
+
+const APP_ROOT = path.resolve(__dirname, '..', '..')
+
+export default defineConfig({
+	testDir: __dirname,
+	globalSetup: path.resolve(__dirname, 'global-setup.ts'),
+	timeout: 60_000,
+	expect: { timeout: 15_000 },
+	fullyParallel: false,
+	retries: process.env.CI ? 1 : 0,
+	workers: 1,
+	reporter: [
+		['html', { open: 'never', outputFolder: path.join(APP_ROOT, 'playwright-report') }],
+		['list'],
+	],
+	outputDir: path.join(APP_ROOT, 'test-results'),
+
+	use: {
+		baseURL: BASE_URL,
+		storageState: path.resolve(__dirname, '.auth', 'admin.json'),
+		trace: 'on-first-retry',
+		screenshot: 'only-on-failure',
+	},
+
+	projects: [
+		{
+			name: 'chromium',
+			testIgnore: ['**/docs-screenshots.spec.ts', '**/visual/**'],
+			use: { ...devices['Desktop Chrome'] },
+		},
+	],
+})

--- a/tests/e2e/spec-coverage/content-search-endpoint.spec.ts
+++ b/tests/e2e/spec-coverage/content-search-endpoint.spec.ts
@@ -82,12 +82,39 @@ test.describe('content-search-endpoint', () => {
 
 			// Publicly visible publication (past publicatiedatum) + a linked document,
 			// neither carrying the marker phrase in any metadata field.
+			//
+			// The publication MUST be created with an explicit `slug`. OpenRegister
+			// does not derive one: a publication created without it comes back with
+			// `@self.slug === null`, so `pubSlug` below resolved to the empty string
+			// and the document was linked as `publication: { slug: "" }`.
+			//
+			// That empty link is why this test failed. OpenCatalogi resolves a
+			// document's owning publication by slug —
+			// `PublicationQueryService::resolveDocumentPublicationSummary()` returns
+			// null immediately on `$slug === ''` — and the assembler then drops the
+			// row: "No linked publication — MUST NOT appear (SCH-PFTS-003)". So the
+			// document could never surface, with or without `_content=true`, and the
+			// product code was doing exactly what its spec says.
+			//
+			// Note this also made the test's own negative assertion vacuous: "MUST
+			// NOT surface without _content=true" passed because documents never
+			// surfaced at all, not because the metadata arm excluded it.
+			//
+			// Verified against a live instance: publication created WITHOUT a slug ->
+			// OC search returns the publication only (`total: 1`); the same pair with
+			// an explicit slug -> `total: 2`, including the row with
+			// `@self.schema === "document"`.
 			const pastPublicatiedatum = '2020-01-01T00:00:00+00:00'
 			const pub = await fx.createPublication('Content Search Publication', {
 				publicatiedatum: pastPublicatiedatum,
+				slug: `e2e-${fx.runId}-content-search-pub`,
 			})
 			const pubSlug = (pub.raw['@self'] as Record<string, unknown>)?.slug as string
 				?? (pub.raw.slug as string) ?? ''
+			expect(
+				pubSlug,
+				'the publication must carry a slug — the document→publication link is resolved by it',
+			).not.toBe('')
 			const doc = await fx.createDocument(
 				'Content Search Document',
 				{ slug: pubSlug, title: pub.title },

--- a/tests/e2e/workflows/publish-workflow.spec.ts
+++ b/tests/e2e/workflows/publish-workflow.spec.ts
@@ -93,8 +93,33 @@ test.describe('publish workflow', () => {
 		async () => {
 			// Catalog wired to the publication register/schema, with a slug we can
 			// hit on the public endpoint.
+			//
+			// `published` MUST be set to a past date. This test's whole point is
+			// that the anonymous catalog directory renders (200) while the draft
+			// publication inside it is filtered out — so an anonymously *visible
+			// catalog* is the precondition, not the thing under test. The catalog
+			// schema grants public read conditionally:
+			//
+			//     authorization.read: [{ group: "public",
+			//                            match: { published: { $lte: "$now" } } }, …]
+			//
+			// and `published` is documented on the schema as "when set to a date in
+			// the past, this catalog becomes publicly accessible". The fixture does
+			// not set it, so without this the catalog is correctly NOT public and
+			// `GET /api/{slug}` 404s on `getCatalogBySlug()` returning null.
+			//
+			// This test used to pass anyway on a dev container running an older
+			// OpenRegister, whose list path returned objects the conditional
+			// public-read grant should have excluded — so the precondition was
+			// being supplied by an RBAC leak rather than by the fixture. Against an
+			// OpenRegister that enforces the grant it failed with 404. Establishing
+			// the precondition explicitly makes the assertion below mean what it
+			// says on both.
 			const slug = `e2e-${fx.runId}-cat`
-			const catalog = await fx.createCatalog('Publish Catalog', { slug })
+			const catalog = await fx.createCatalog('Publish Catalog', {
+				slug,
+				published: '2020-01-01T00:00:00+00:00',
+			})
 			const realSlug = (catalog.raw['@self'] as Record<string, unknown>)?.slug as string
 				?? (catalog.raw.slug as string) ?? slug
 


### PR DESCRIPTION
## What

Turns on the shared `E2E Tests (Playwright)` job for OpenCatalogi. It was never enabled here — `enable-playwright` was unset, so the job resolved to `skipped` on every build since the workflow gained it.

This is phase 1 of a fleet-wide e2e enablement programme: make the job genuinely green on **one** repo, then roll the recipe out. Nothing outside this repo is enabled by this PR.

## Why it needed more than the flag

**The workflow passes no `--project`.** Whichever config it picks, every project in it runs. The root config declares three, two of which are documented in their own headers as unable to pass on a CI runner:

- `visual` — "PNG baselines are host-font/GPU specific, so a CI Linux runner will not byte-match a dev-container baseline"
- `docs-capture` — re-shoots every tutorial screenshot; already has its own dedicated `Journeydoc Capture` job

The run step looks for `${playwright-test-path}/playwright.config.ts` **first** and only falls back to the repo root. So `playwright-test-path: tests/e2e` plus a config there selects the regression project, and the root config is untouched — it stays the entry point for local runs, `npm run test:e2e:docs`, and `--project visual`.

**The report was being uploaded from the wrong place.** The workflow uploads `server/apps/<app>/playwright-report/` and `.../test-results/`. The root config writes under `tests/e2e/`. Both upload steps matched nothing, and `if-no-files-found: ignore` meant they said so quietly — a failing run would have produced an empty artifact and no report to read. The CI config writes to the app root.

**A fresh install has no publication register, and nothing says so.** `occ app:enable opencatalogi` runs `InitializeSettings`, which is supposed to import it. It is not a reliable fresh-install path, and it fails silently on two independent counts:

- an `IRepairStep` runs with **no user session**, so OpenRegister's RBAC can deny the import — and `run()` catches `\Exception` and downgrades it to a warning it explicitly labels "Non-fatal". `occ app:enable` still exits 0.
- it calls `loadSettings(force: false)`, the version-guarded path, which can record a new configuration version without applying anything.

The app then enables cleanly, the SPA boots, and the register is simply absent. The suite's symptom in that state is a wall of `create 14/55 failed: 404` and `seeding a catalog must succeed` — messages that accuse the fixtures rather than the missing import.

`tests/e2e/ci-seed.sh` (wired as `playwright-seed-command`) does the import explicitly over the admin HTTP API — which has a real session and passes RBAC — with `force: true`, then **verifies** the register and the four schemas the fixtures resolve by slug actually exist. A bad provision becomes one loud step failure instead of ~14 misleading spec failures. It refuses to run against an unset target outside CI, because on a dev box `localhost:8080` is the shared container and this script performs admin writes.

## Not done here

No test is skipped, no assertion weakened, no timeout raised.