### PR TITLE
chore(ci): stop check:strict reporting a plain green when the tests did not run

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
 		"phpqa": "./vendor/bin/phpqa --report --analyzedDirs lib --buildDir phpqa",
 		"phpqa:full": "./vendor/bin/phpqa --report --analyzedDirs lib --buildDir phpqa --tools phpcs:0,phpmd:0,phploc:0,phpmetrics,phpcpd:0,parallel-lint:0",
 		"phpqa:ci": "./vendor/bin/phpqa --report --analyzedDirs lib --buildDir phpqa --tools phpcs,phpmd,phploc,phpmetrics,phpcpd,parallel-lint",
-		"check:strict": "E=0; for CMD in lint phpcs phpmd psalm phpstan test:all; do echo; echo \"=== $CMD ===\"; composer $CMD || E=1; done; echo; if [ $E -eq 0 ]; then echo \"ALL CHECKS PASSED\"; else echo \"SOME CHECKS FAILED (see above)\"; fi; exit $E",
+		"check:strict": "E=0; for CMD in lint phpcs phpmd psalm phpstan test:all; do echo; echo \"=== $CMD ===\"; composer $CMD || E=1; done; echo; if [ $E -ne 0 ]; then echo \"SOME CHECKS FAILED (see above)\"; elif [ ! -f ../../lib/base.php ]; then echo \"ALL CHECKS PASSED - EXCEPT test:all, WHICH DID NOT RUN.\"; echo \"The unit suite needs a Nextcloud server tree (../../lib/base.php). In a bare\"; echo \"checkout it is skipped, so this green says NOTHING about the tests. Verified:\"; echo \"a deliberately failing test still produces this exact line. Run check:strict\"; echo \"from inside a Nextcloud checkout, or rely on the CI PHPUnit job, for a real\"; echo \"test verdict.\"; else echo \"ALL CHECKS PASSED\"; fi; exit $E",
 		"qa:check": [
 			"@phpqa"
 		],


### PR DESCRIPTION
The reported "1180 of 1255 opencatalogi tests error" is **not 1180 defects, and not any defects**. It is one environment fault, reproduced exactly.

## Root cause

`tests/bootstrap.php` only loads `../../lib/base.php` when the app is checked out inside a Nextcloud server tree. Without it, `OCP\*` and `OCA\OpenRegister\*` are not autoloadable, and every test that builds a mock of one dies with

```
PHPUnit\Framework\MockObject\Generator\UnknownTypeException:
Class or interface "OCA\OpenRegister\Service\ObjectService" does not exist
```

Reproduced on a fresh `composer install` at `origin/development` (39583c67), PHP 8.3:

| environment | result |
|---|---|
| bare worktree, no server tree | `Tests: 1255, Errors: 1180` — the reported number, to the test |
| same tree inside a Nextcloud 34 checkout | `Tests: 1255, Assertions: 3065` — **0 errors, 0 failures** |
| CI `PHPUnit (PHP 8.3 / 8.4, NC stable32)` on 39583c67 | both green |

**True defect count behind the 1180: zero.** #788 already landed the guarded loud skip that keeps a bare checkout from manufacturing them.

## What this PR changes

One residual hole, found by running the positive control in *both* environments rather than one.

With a deliberately failing test dropped into `tests/Unit/`:

- bare checkout — `composer check:strict` **exits 0** and prints `ALL CHECKS PASSED`
- inside a Nextcloud checkout — exits 1, `=== test:all ===`, names the test

The skip is loud where it happens, but it scrolls past several thousand lines of lint and phpcs output, and the last line on screen was an unqualified green. The gate was live in one environment and dead in the other and the summary could not tell them apart.

So the summary now reflects it:

```
ALL CHECKS PASSED - EXCEPT test:all, WHICH DID NOT RUN.
The unit suite needs a Nextcloud server tree (../../lib/base.php). In a bare
checkout it is skipped, so this green says NOTHING about the tests. ...
```

Inside a Nextcloud checkout the line is still the plain `ALL CHECKS PASSED`.

The skip itself stays. The suite genuinely cannot run standalone, and CI covers it properly in the PHPUnit job. **Nothing is muted, baselined, or skipped** — `phpmd`, `psalm`, `phpstan` and `test:all` all remain able to fail, and the exit code is untouched in every case.

## Evidence

| run | exit | summary |
|---|---|---|
| bare, clean tree | 0 | `ALL CHECKS PASSED - EXCEPT test:all, WHICH DID NOT RUN.` |
| bare, failing test injected | 0 | same line — the point of the change |
| NC tree, clean | 0 | `ALL CHECKS PASSED` / `Tests: 1255` |
| NC tree, failing test injected | **1** | `FAILURES!` under `=== test:all ===`, `Tests: 1256`, probe named |

The injected probe was confirmed to actually run before drawing any conclusion — it appears in `--list-tests`, the test count moves 1255 → 1256, and its assertion message is printed in the failure output. A control that silently fails to apply looks identical to a control that worked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)