### PR TITLE
fix(e2e): stop the harness healing a failed CI build, and let the bundle gate speak

### DIFF
--- a/tests/e2e/ci-seed.sh
+++ b/tests/e2e/ci-seed.sh
@@ -189,8 +189,12 @@ APP_HTML="$(mktemp)"
 curl -sS -u "${USER_NAME}:${USER_PASS}" -H 'OCS-APIRequest: true' \
 	"${BASE}/index.php/apps/opencatalogi/" -o "$APP_HTML" || true
 
+# `|| true` is load-bearing: grep exits 1 when it matches nothing, and under
+# `set -euo pipefail` that aborts the script right here — so the case the gate
+# below exists to explain (no bundle) would die with a bare non-zero exit and
+# none of the diagnosis. Let it fall through to the gate instead.
 BUNDLE_SRC="$(grep -oE 'src="[^"]*opencatalogi-main[^"]*"' "$APP_HTML" \
-	| head -1 | sed 's/^src="//; s/"$//')"
+	| head -1 | sed 's/^src="//; s/"$//' || true)"
 
 if [ -n "$BUNDLE_SRC" ]; then
 	BUNDLE_INFO="$(curl -sS -o /dev/null \

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -34,6 +34,27 @@ function ensureBundleBuilt(): void {
 	if (fs.existsSync(BUNDLE_PATH)) {
 		return
 	}
+	// On CI this is a hard error, not something to repair.
+	//
+	// The shared workflow has already run its own "Build app frontend" step by
+	// the time we get here, so a missing bundle means that step did not produce
+	// one — and silently rebuilding turns a broken build into a green run with
+	// nothing to show for it. It also makes the bundle genuinely untestable:
+	// a positive control that removes the bundle to prove the specs depend on it
+	// gets healed right back before the first spec runs, and the suite passes.
+	// (Observed: run 30791459241 passed 82/82 with the bundle deleted, because
+	// this function rebuilt it — the control proved nothing until it was changed
+	// to truncate the file instead.)
+	//
+	// Locally the rebuild stays, because there it is a genuine convenience:
+	// a fresh checkout has no `js/` and nothing else is going to build it.
+	if (process.env.CI === 'true' || process.env.GITHUB_ACTIONS === 'true') {
+		throw new Error(
+			`[playwright globalSetup] bundle missing at ${BUNDLE_PATH} on CI. `
+			+ 'The workflow\'s "Build app frontend" step should already have produced it — '
+			+ 'check that step rather than rebuilding here, because a rebuild would hide it.',
+		)
+	}
 	// eslint-disable-next-line no-console
 	console.log(`[playwright globalSetup] bundle missing at ${BUNDLE_PATH}; running 'npm run build' once…`)
 	execSync('npm run build', { cwd: APP_ROOT, stdio: 'inherit' })


### PR DESCRIPTION
Two follow-ups to #787. Same failure mode both times: the suite quietly repairing or swallowing the one condition that would make a green run meaningless.

## 1. `globalSetup` rebuilt the bundle on CI

`ensureBundleBuilt()` runs `npm run build` whenever `js/opencatalogi-main.js` is absent. On CI the workflow's own **Build app frontend** step has already run by then — so a missing bundle means *that step produced nothing*, and rebuilding here turns a build failure into a green run.

It also **defeated the positive control for #787**. Run [30791459241](https://github.com/ConductionNL/opencatalogi/actions/runs/30791459241) deleted the bundle before the specs and still passed 82/82. Not a false green — a neutralised control. The log says it outright:

```
POSITIVE CONTROL ACTIVE — bundle moved aside. The suite MUST now fail.
[playwright globalSetup] bundle missing at …/js/opencatalogi-main.js; running 'npm run build' once…
> NODE_ENV=production webpack --config webpack.config.js --progress
```

The control only became valid once it **truncated** the file instead of removing it, since this function checks existence and never contents. (Verified locally: a 14-byte bundle fails the UI specs; restoring the 7,664,588-byte one passes them.)

On CI a missing bundle is now a thrown error naming the step to look at. Locally the rebuild stays — there it's a genuine convenience, since a fresh checkout has no `js/` and nothing else will build it.

## 2. The bundle gate died before it could explain itself

`set -euo pipefail` plus `grep | head | sed` in a command substitution meant that when the bundle src wasn't found — exactly the case the gate exists to diagnose — the script aborted on grep's exit 1 at that line. Exit status was still non-zero so the gate "worked", but it emitted none of the three error lines saying what to check.

Verified both ways with the bundle moved aside: before, a bare non-zero exit; after, `could not locate the bundle src in the rendered app page` plus the full diagnosis, still exit 1.