### PR TITLE
fix(ci): bound this workflow's job with a measured timeout-minutes

### DIFF
--- a/.github/workflows/quality-weekly.yml
+++ b/.github/workflows/quality-weekly.yml
@@ -16,6 +16,13 @@ jobs:
   quality-strict:
     name: check:strict (development)
     runs-on: ubuntu-latest
+    # UNMEASURED: this weekly job has no executed run in the sampled history.
+    # It is a composer install plus `composer check:strict`; the equivalent
+    # per-tool PHP Quality legs were observed at max 4.0 min fleet-wide, and
+    # this runs all of them in one job, so 30 min is a wide bound. It had no
+    # timeout at all, so a hang ran to GitHub's 6-hour default — on a
+    # scheduled job nobody is watching, which is the worst case for that.
+    timeout-minutes: 30
 
     steps:
       - name: Checkout development branch


### PR DESCRIPTION
## What

Adds `timeout-minutes` to the job(s) in this workflow, which declared none — so a hang ran to GitHub's **6-hour default** and burned a runner.

Part of a fleet-wide sweep. The shared workflows in `ConductionNL/.github` were bounded in ConductionNL/.github#130; this repo has a workflow of its own that does not go through them.

## How the value was chosen — measured, not guessed

Derived from this job's observed duration across **12,465 unique job records from 34 fleet repos**, filtered to real executions (`success`/`failure` — skipped records were excluded, they otherwise drag every median to zero). See the per-job comment in the diff for the exact numbers.

The bound is deliberately loose. **A timeout that fires under normal contention is worse than no timeout** — it converts a slow run into a phantom defect. The goal is to catch a hang, not to enforce speed.

## What this change cannot break

It **only adds a `timeout-minutes` key** to a job definition — additions only, workflow files only. No step, condition, matrix, permission, input, output or job dependency is touched. It cannot change which jobs run, in what order, or whether they pass: a timeout has no effect unless a job exceeds it, and no observed run of this job comes close.

Verified by re-parsing the file with `yaml.safe_load` after editing and asserting the job set is unchanged and the value is exactly as intended, plus a negative control confirming the same probe reports `None` on the unedited base.
