### PR TITLE
feat(publiccode): add the publiccode.yml schema to the publication register

### DIFF
--- a/lib/Settings/register.d/publiccode-software.json
+++ b/lib/Settings/register.d/publiccode-software.json
@@ -1,0 +1,170 @@
+{
+  "$comment": "publiccode.yml as an OpenRegister schema. Harvested from forge repositories by the publiccode-harvest flow and searched by OpenCatalogi like any other object — no bespoke integration, because a harvested component IS an ordinary OpenRegister object. Field names and semantics follow the publiccode.yml standard (https://yml.publiccode.tools) v0.4; the x-publiccode key on each property records the source path so the mapping stays checkable against the standard rather than against our memory of it.",
+  "components": {
+    "registers": {
+      "publication": {
+        "$comment": "List arrays are CONCATENATED by deepMergeConfig, so this attaches publiccode to the publication register without restating the other schemas. Defining the schema without this line would leave it valid but unattached — present in components.schemas and absent from every register, which reads as 'the import did nothing'.",
+        "schemas": ["publiccode"]
+      }
+    },
+    "schemas": {
+      "publiccode": {
+        "slug": "publiccode",
+        "title": "Public code component",
+        "version": "0.1.0",
+        "published": true,
+        "summary": "A software component described by a publiccode.yml file",
+        "description": "One harvested publiccode.yml. The identity of a component is its repository URL, not its name: names collide across forges and change on rebrand, while the URL is what the harvest actually dereferenced. `slug` is derived from the repository full name so a re-harvest UPDATES rather than duplicates — the flow engine has no synchronisation contracts yet, so idempotency has to come from a deterministic identifier.",
+        "icon": "package-variant-closed",
+        "searchable": true,
+        "hardValidation": false,
+        "required": ["name", "url"],
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name",
+            "description": "Name of the software component, as declared in publiccode.yml.",
+            "x-publiccode": "name",
+            "facetable": false
+          },
+          "applicationSuite": {
+            "type": "string",
+            "title": "Application suite",
+            "description": "The suite this component belongs to, when it is part of one.",
+            "x-publiccode": "applicationSuite",
+            "facetable": true
+          },
+          "url": {
+            "type": "string",
+            "format": "uri",
+            "title": "Repository URL",
+            "description": "Canonical repository URL. This is the component's IDENTITY — see the schema description.",
+            "x-publiccode": "url"
+          },
+          "landingURL": {
+            "type": "string",
+            "format": "uri",
+            "title": "Landing page",
+            "x-publiccode": "landingURL"
+          },
+          "softwareVersion": {
+            "type": "string",
+            "title": "Version",
+            "x-publiccode": "softwareVersion"
+          },
+          "releaseDate": {
+            "type": "string",
+            "format": "date",
+            "title": "Release date",
+            "x-publiccode": "releaseDate"
+          },
+          "logo": {
+            "type": "string",
+            "title": "Logo",
+            "description": "Path or URL to the logo. Left as declared: publiccode.yml permits a repository-relative path, and resolving it to an absolute URL is the harvest's job, not the schema's.",
+            "x-publiccode": "logo"
+          },
+          "platforms": {
+            "type": "array",
+            "title": "Platforms",
+            "items": { "type": "string" },
+            "x-publiccode": "platforms",
+            "facetable": true
+          },
+          "categories": {
+            "type": "array",
+            "title": "Categories",
+            "items": { "type": "string" },
+            "description": "publiccode.yml's controlled category vocabulary.",
+            "x-publiccode": "categories",
+            "facetable": true
+          },
+          "developmentStatus": {
+            "type": "string",
+            "title": "Development status",
+            "description": "One of: concept, development, beta, stable, obsolete.",
+            "x-publiccode": "developmentStatus",
+            "facetable": true
+          },
+          "softwareType": {
+            "type": "string",
+            "title": "Software type",
+            "description": "One of: standalone/mobile, standalone/iot, standalone/desktop, standalone/web, standalone/backend, standalone/other, addon, library, configurationFiles.",
+            "x-publiccode": "softwareType",
+            "facetable": true
+          },
+          "description": {
+            "type": "object",
+            "title": "Descriptions by language",
+            "description": "publiccode.yml nests descriptions per language code (description.en.shortDescription, …). Kept nested rather than flattened to one language: flattening would silently discard every other translation on write.",
+            "x-publiccode": "description"
+          },
+          "maintenanceType": {
+            "type": "string",
+            "title": "Maintenance type",
+            "description": "One of: internal, contract, community, none.",
+            "x-publiccode": "maintenance.type",
+            "facetable": true
+          },
+          "maintainers": {
+            "type": "array",
+            "title": "Maintainers",
+            "items": { "type": "object" },
+            "x-publiccode": "maintenance.contractors + maintenance.contacts"
+          },
+          "legalLicense": {
+            "type": "string",
+            "title": "Licence",
+            "description": "SPDX identifier, as declared in legal.license.",
+            "x-publiccode": "legal.license",
+            "facetable": true
+          },
+          "legalRepoOwner": {
+            "type": "string",
+            "title": "Repository owner",
+            "x-publiccode": "legal.repoOwner"
+          },
+          "localisationAvailableLanguages": {
+            "type": "array",
+            "title": "Available languages",
+            "items": { "type": "string" },
+            "x-publiccode": "localisation.availableLanguages",
+            "facetable": true
+          },
+          "itConformsTo": {
+            "type": "array",
+            "title": "Standards conformed to",
+            "items": { "type": "string" },
+            "description": "country-specific extensions, e.g. it.conformsTo / nl.conformsTo.",
+            "x-publiccode": "*.conformsTo",
+            "facetable": true
+          },
+          "publiccodeYmlVersion": {
+            "type": "string",
+            "title": "publiccode.yml version",
+            "description": "Which version of the standard the harvested file declared. Recorded because the mapping is version-sensitive: a v0.2 file and a v0.4 file put maintainers in different places.",
+            "x-publiccode": "publiccodeYmlVersion",
+            "facetable": true
+          },
+          "harvestedFrom": {
+            "type": "string",
+            "title": "Harvested from",
+            "description": "The forge host the file came from (github.com, gitlab.com, codeberg.org). Recorded so a harvest can be re-run per forge, and so a component that disappears from one forge is not confused with one that never existed.",
+            "facetable": true
+          },
+          "harvestedAt": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Harvested at",
+            "description": "When this object was last written by a harvest. A component whose harvestedAt stops advancing is one the harvest no longer finds — which is information, not an error."
+          },
+          "rawPubliccode": {
+            "type": "object",
+            "title": "Raw publiccode.yml",
+            "description": "The decoded file as harvested. Kept because the mapping above is lossy by construction: any field the standard adds, or any country extension we do not model, would otherwise be discarded silently at harvest time and be unrecoverable without re-fetching."
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
A harvested software component is an ordinary OpenRegister object, so OpenCatalogi searches it with no bespoke integration. This adds the schema the publiccode harvest writes into.

Field names follow publiccode.yml v0.4; each property carries `x-publiccode` recording its source path, so the mapping stays checkable against the standard rather than against our memory of it — several fields move between versions (maintainers sit elsewhere in v0.2).

Four decisions, each avoiding a silent loss:

- **Identity is the repository URL, not the name.** Names collide across forges and change on rebrand; the URL is what the harvest dereferenced. `slug` derives from the repo full name so a re-harvest UPDATES rather than duplicates — the flow engine has no synchronisation contracts yet, so idempotency has to come from a deterministic identifier.
- **`description` stays nested per language.** Flattening to one language would discard every other translation on write, invisibly.
- **`rawPubliccode` keeps the decoded file.** The mapping is lossy by construction: any field the standard adds, or any country extension not modelled, would otherwise be dropped at harvest and be unrecoverable without re-fetching.
- **`harvestedFrom` / `harvestedAt`** so a component that stops being found is distinguishable from one that never existed.

The register attachment rides in the same fragment — `deepMergeConfig` concatenates list arrays, so `["publiccode"]` appends without restating the others. Without it the schema would be defined but attached to no register: valid, and indistinguishable from an import that did nothing.