### PR TITLE
feat(schema): mark the Catalog collection definition shareable for federated config sharing

### DIFF
--- a/lib/Settings/publication_register.json
+++ b/lib/Settings/publication_register.json
@@ -475,7 +475,7 @@
           }
         },
         "title": "Catalog",
-        "version": "0.1.0",
+        "version": "0.2.0",
         "published": "2025-01-01T00:00:00+00:00",
         "summary": "A collection of publications organized by theme and schema",
         "description": "A catalog represents a curated collection of publications that can be organized by themes and schemas. It serves as the main organizational unit for content, allowing administrators to group related publications together and make them accessible through a unified interface. Catalogs can be public or private and can be associated with specific organizations.",
@@ -609,7 +609,8 @@
           }
         },
         "configuration": {
-          "autoPublish": false
+          "autoPublish": false,
+          "x-openregister-shareable": true
         },
         "hardValidation": true,
         "searchable": true,


### PR DESCRIPTION
**Rescued from Codeberg before the remote is removed.**

Landed on `codeberg.org/Conduction/opencatalogi` as `be7b2cbb` (PR #148, 2026-07-26); never reached GitHub. Part of the 2026-07-26 *federated-config-sharing* wave, which six repos merged only on Codeberg.

Absence on GitHub verified across all 312 `origin` refs, not just `development`:

    git grep -l 'x-openregister-shareable' <gh_dev> --   ->  (empty)

## Only the hunk, not the file

GitHub's register is **58 commits newer** than Codeberg's. Taking the Codeberg file wholesale would have reverted unrelated work.

    gh 0.2.0 {'autoPublish': False, 'x-openregister-shareable': True}
    cb 0.2.0 {'autoPublish': False, 'x-openregister-shareable': True}
    MATCH
    shareable schemas: gh 1  cb 1

The schema-count line is the control: it shows the flag landed on exactly one schema per side, so "the flag is present" is not being satisfied by some other schema happening to carry it.