### PR TITLE
chore: normalise licence declarations to EUPL-1.2

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 OpenCatalogi Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Playwright config for OpenCatalogi.
  *

--- a/src/components/GenericObjectTable.vue
+++ b/src/components/GenericObjectTable.vue
@@ -5,7 +5,7 @@
  * @package opencatalogi
  * @author Ruben Linde
  * @copyright 2024
- * @license AGPL-3.0-or-later
+ * @license EUPL-1.2
  * @version 1.0.0
  * @link https://github.com/opencatalogi/opencatalogi
  */

--- a/src/components/PublishedIcon.vue
+++ b/src/components/PublishedIcon.vue
@@ -3,7 +3,7 @@
  * @module Components
  * @author Your Name
  * @copyright 2024 Your Organization
- * @license AGPL-3.0-or-later
+ * @license EUPL-1.2
  * @version 1.0.0
  */
 

--- a/src/components/SearchResults.vue
+++ b/src/components/SearchResults.vue
@@ -5,7 +5,7 @@
  * @package opencatalogi
  * @author Ruben Linde
  * @copyright 2024
- * @license AGPL-3.0-or-later
+ * @license EUPL-1.2
  * @version 1.0.0
  * @link https://github.com/opencatalogi/opencatalogi
  *

--- a/src/components/SelectAttachmentsList.vue
+++ b/src/components/SelectAttachmentsList.vue
@@ -3,7 +3,7 @@
  * @module Components
  * @author Your Name
  * @copyright 2024 Your Organization
- * @license AGPL-3.0-or-later
+ * @license EUPL-1.2
  * @version 1.0.0
  */
 

--- a/src/dialogs/category/DeleteCategoryDialog.vue
+++ b/src/dialogs/category/DeleteCategoryDialog.vue
@@ -71,7 +71,7 @@ import Delete from 'vue-material-design-icons/Delete.vue'
  * @package
  * @author Ruben Linde
  * @copyright 2024
- * @license AGPL-3.0-or-later
+ * @license EUPL-1.2
  * @version 1.0.0
  * @see {@link https://github.com/opencatalogi/opencatalogi}
  * @spec openspec/specs/generic-object-modals/spec.md

--- a/src/dialogs/category/DeleteMultipleCategoriesDialog.vue
+++ b/src/dialogs/category/DeleteMultipleCategoriesDialog.vue
@@ -71,7 +71,7 @@ import Delete from 'vue-material-design-icons/Delete.vue'
  * @package
  * @author Ruben Linde
  * @copyright 2024
- * @license AGPL-3.0-or-later
+ * @license EUPL-1.2
  * @version 1.0.0
  * @see {@link https://github.com/opencatalogi/opencatalogi}
  * @spec openspec/specs/generic-object-modals/spec.md

--- a/src/dialogs/generic/CopyObjectDialog.vue
+++ b/src/dialogs/generic/CopyObjectDialog.vue
@@ -202,7 +202,7 @@ const closeDialog = () => {
  * @package
  * @author Ruben Linde
  * @copyright 2024
- * @license AGPL-3.0-or-later
+ * @license EUPL-1.2
  * @version 1.0.0
  * @see {@link https://github.com/opencatalogi/opencatalogi}
  * @spec openspec/specs/generic-object-modals/spec.md

--- a/src/dialogs/listing/DeleteListingDialog.vue
+++ b/src/dialogs/listing/DeleteListingDialog.vue
@@ -5,7 +5,7 @@
  * @package opencatalogi
  * @author Ruben Linde
  * @copyright 2024
- * @license AGPL-3.0-or-later
+ * @license EUPL-1.2
  * @version 1.0.0
  * @link https://github.com/opencatalogi/opencatalogi
  */

--- a/src/dialogs/logs/ViewLogDialog.vue
+++ b/src/dialogs/logs/ViewLogDialog.vue
@@ -49,7 +49,7 @@ import Cancel from 'vue-material-design-icons/Cancel.vue'
  * @package
  * @author Ruben Linde
  * @copyright 2024
- * @license AGPL-3.0-or-later
+ * @license EUPL-1.2
  * @version 1.0.0
  * @see {@link https://github.com/opencatalogi/opencatalogi}
  * @spec openspec/specs/generic-object-modals/spec.md

--- a/src/dialogs/menu/CopyMenuDialog.vue
+++ b/src/dialogs/menu/CopyMenuDialog.vue
@@ -5,7 +5,7 @@
  * @package opencatalogi
  * @author Ruben Linde
  * @copyright 2024
- * @license AGPL-3.0-or-later
+ * @license EUPL-1.2
  * @version 1.0.0
  * @link https://github.com/opencatalogi/opencatalogi
  */

--- a/src/dialogs/theme/DeleteMultipleThemesDialog.vue
+++ b/src/dialogs/theme/DeleteMultipleThemesDialog.vue
@@ -71,7 +71,7 @@ import Delete from 'vue-material-design-icons/Delete.vue'
  * @package
  * @author Ruben Linde
  * @copyright 2024
- * @license AGPL-3.0-or-later
+ * @license EUPL-1.2
  * @version 1.0.0
  * @see {@link https://github.com/opencatalogi/opencatalogi}
  */

--- a/src/entities/catalogi/catalogi.mock.ts
+++ b/src/entities/catalogi/catalogi.mock.ts
@@ -4,7 +4,7 @@
  * @package
  * @author Ruben Linde
  * @copyright 2024
- * @license AGPL-3.0-or-later
+ * @license EUPL-1.2
  * @version 1.0.0
  * @see {@link https://github.com/opencatalogi/opencatalogi}
  */

--- a/src/entities/catalogi/catalogi.spec.ts
+++ b/src/entities/catalogi/catalogi.spec.ts
@@ -4,7 +4,7 @@
  * @package
  * @author Ruben Linde
  * @copyright 2024
- * @license AGPL-3.0-or-later
+ * @license EUPL-1.2
  * @version 1.0.0
  * @see {@link https://github.com/opencatalogi/opencatalogi}
  */

--- a/src/entities/catalogi/catalogi.ts
+++ b/src/entities/catalogi/catalogi.ts
@@ -4,7 +4,7 @@
  * @package
  * @author Ruben Linde
  * @copyright 2024
- * @license AGPL-3.0-or-later
+ * @license EUPL-1.2
  * @version 1.0.0
  * @see {@link https://github.com/opencatalogi/opencatalogi}
  */

--- a/src/entities/catalogi/catalogi.types.ts
+++ b/src/entities/catalogi/catalogi.types.ts
@@ -4,7 +4,7 @@
  * @package
  * @author Ruben Linde
  * @copyright 2024
- * @license AGPL-3.0-or-later
+ * @license EUPL-1.2
  * @version 1.0.0
  * @see {@link https://github.com/opencatalogi/opencatalogi}
  */

--- a/src/entities/glossary/glossary.mock.ts
+++ b/src/entities/glossary/glossary.mock.ts
@@ -4,7 +4,7 @@
  * @package
  * @author Ruben Linde
  * @copyright 2024
- * @license AGPL-3.0-or-later
+ * @license EUPL-1.2
  * @version 1.0.0
  * @see {@link https://github.com/opencatalogi/opencatalogi}
  */

--- a/src/entities/glossary/glossary.spec.ts
+++ b/src/entities/glossary/glossary.spec.ts
@@ -4,7 +4,7 @@
  * @package
  * @author Ruben Linde
  * @copyright 2024
- * @license AGPL-3.0-or-later
+ * @license EUPL-1.2
  * @version 1.0.0
  * @see {@link https://github.com/opencatalogi/opencatalogi}
  */

--- a/src/entities/glossary/glossary.ts
+++ b/src/entities/glossary/glossary.ts
@@ -4,7 +4,7 @@
  * @package
  * @author Ruben Linde
  * @copyright 2024
- * @license AGPL-3.0-or-later
+ * @license EUPL-1.2
  * @version 1.0.0
  * @see {@link https://github.com/opencatalogi/opencatalogi}
  */

--- a/src/entities/glossary/glossary.types.ts
+++ b/src/entities/glossary/glossary.types.ts
@@ -4,7 +4,7 @@
  * @package
  * @author Ruben Linde
  * @copyright 2024
- * @license AGPL-3.0-or-later
+ * @license EUPL-1.2
  * @version 1.0.0
  * @see {@link https://github.com/opencatalogi/opencatalogi}
  */

--- a/src/entities/glossary/index.js
+++ b/src/entities/glossary/index.js
@@ -5,7 +5,7 @@
  * @package
  * @author Ruben Linde
  * @copyright 2024
- * @license AGPL-3.0-or-later
+ * @license EUPL-1.2
  * @version 1.0.0
  * @see https://github.com/opencatalogi/opencatalogi
  * @spec openspec/specs/entity-typescript-models/spec.md

--- a/src/entities/listing/listing.mock.ts
+++ b/src/entities/listing/listing.mock.ts
@@ -4,7 +4,7 @@
  * @package
  * @author Ruben Linde
  * @copyright 2024
- * @license AGPL-3.0-or-later
+ * @license EUPL-1.2
  * @version 1.0.0
  * @see {@link https://github.com/opencatalogi/opencatalogi}
  */

--- a/src/entities/listing/listing.ts
+++ b/src/entities/listing/listing.ts
@@ -4,7 +4,7 @@
  * @package
  * @author Ruben Linde
  * @copyright 2024
- * @license AGPL-3.0-or-later
+ * @license EUPL-1.2
  * @version 1.0.0
  * @see {@link https://github.com/opencatalogi/opencatalogi}
  */

--- a/src/entities/listing/listing.types.ts
+++ b/src/entities/listing/listing.types.ts
@@ -4,7 +4,7 @@
  * @package
  * @author Ruben Linde
  * @copyright 2024
- * @license AGPL-3.0-or-later
+ * @license EUPL-1.2
  * @version 1.0.0
  * @see {@link https://github.com/opencatalogi/opencatalogi}
  */

--- a/src/entities/menu/menu.mock.ts
+++ b/src/entities/menu/menu.mock.ts
@@ -4,7 +4,7 @@
  * @package
  * @author Ruben Linde
  * @copyright 2024
- * @license AGPL-3.0-or-later
+ * @license EUPL-1.2
  * @version 1.0.0
  * @see {@link https://github.com/opencatalogi/opencatalogi}
  */

--- a/src/entities/menu/menu.spec.ts
+++ b/src/entities/menu/menu.spec.ts
@@ -4,7 +4,7 @@
  * @package
  * @author Ruben Linde
  * @copyright 2024
- * @license AGPL-3.0-or-later
+ * @license EUPL-1.2
  * @version 1.0.0
  * @see {@link https://github.com/opencatalogi/opencatalogi}
  */

--- a/src/entities/organization/organization.mock.ts
+++ b/src/entities/organization/organization.mock.ts
@@ -4,7 +4,7 @@
  * @package
  * @author Ruben Linde
  * @copyright 2024
- * @license AGPL-3.0-or-later
+ * @license EUPL-1.2
  * @version 1.0.0
  * @see {@link https://github.com/opencatalogi/opencatalogi}
  */

--- a/src/entities/organization/organization.spec.ts
+++ b/src/entities/organization/organization.spec.ts
@@ -4,7 +4,7 @@
  * @package
  * @author Ruben Linde
  * @copyright 2024
- * @license AGPL-3.0-or-later
+ * @license EUPL-1.2
  * @version 1.0.0
  * @see {@link https://github.com/opencatalogi/opencatalogi}
  */

--- a/src/entities/organization/organization.ts
+++ b/src/entities/organization/organization.ts
@@ -4,7 +4,7 @@
  * @package
  * @author Ruben Linde
  * @copyright 2024
- * @license AGPL-3.0-or-later
+ * @license EUPL-1.2
  * @version 1.0.0
  * @see {@link https://github.com/opencatalogi/opencatalogi}
  */

--- a/src/entities/organization/organization.types.ts
+++ b/src/entities/organization/organization.types.ts
@@ -4,7 +4,7 @@
  * @package
  * @author Ruben Linde
  * @copyright 2024
- * @license AGPL-3.0-or-later
+ * @license EUPL-1.2
  * @version 1.0.0
  * @see {@link https://github.com/opencatalogi/opencatalogi}
  */

--- a/src/modals/directory/AddDirectoryModal.vue
+++ b/src/modals/directory/AddDirectoryModal.vue
@@ -5,7 +5,7 @@
  * @package opencatalogi
  * @author Ruben Linde
  * @copyright 2024
- * @license AGPL-3.0-or-later
+ * @license EUPL-1.2
  * @version 1.0.0
  * @link https://github.com/opencatalogi/opencatalogi
  */

--- a/src/modals/directory/EditListingModal.vue
+++ b/src/modals/directory/EditListingModal.vue
@@ -5,7 +5,7 @@
  * @package opencatalogi
  * @author Ruben Linde
  * @copyright 2024
- * @license AGPL-3.0-or-later
+ * @license EUPL-1.2
  * @version 1.0.0
  * @link https://github.com/opencatalogi/opencatalogi
  *

--- a/src/modals/directory/ViewDirectoryModal.vue
+++ b/src/modals/directory/ViewDirectoryModal.vue
@@ -5,7 +5,7 @@
  * @package opencatalogi
  * @author Ruben Linde
  * @copyright 2024
- * @license AGPL-3.0-or-later
+ * @license EUPL-1.2
  * @version 1.0.0
  * @link https://github.com/opencatalogi/opencatalogi
  */

--- a/src/modals/glossary/ViewGlossaryModal.vue
+++ b/src/modals/glossary/ViewGlossaryModal.vue
@@ -5,7 +5,7 @@
  * @package opencatalogi
  * @author Ruben Linde
  * @copyright 2024
- * @license AGPL-3.0-or-later
+ * @license EUPL-1.2
  * @version 1.0.0
  * @link https://github.com/opencatalogi/opencatalogi
  */

--- a/src/modals/listing/EditListingModal.vue
+++ b/src/modals/listing/EditListingModal.vue
@@ -5,7 +5,7 @@
  * @package opencatalogi
  * @author Ruben Linde
  * @copyright 2024
- * @license AGPL-3.0-or-later
+ * @license EUPL-1.2
  * @version 1.0.0
  * @link https://github.com/opencatalogi/opencatalogi
  *

--- a/src/modals/menu/ViewMenuModal.vue
+++ b/src/modals/menu/ViewMenuModal.vue
@@ -5,7 +5,7 @@
  * @package opencatalogi
  * @author Ruben Linde
  * @copyright 2024
- * @license AGPL-3.0-or-later
+ * @license EUPL-1.2
  * @version 1.0.0
  * @link https://github.com/opencatalogi/opencatalogi
  */

--- a/src/modals/menuItem/DeleteMenuItemModal.vue
+++ b/src/modals/menuItem/DeleteMenuItemModal.vue
@@ -5,7 +5,7 @@
  * @package opencatalogi
  * @author Ruben Linde
  * @copyright 2024
- * @license AGPL-3.0-or-later
+ * @license EUPL-1.2
  * @version 1.0.0
  * @link https://github.com/opencatalogi/opencatalogi
  */

--- a/src/modals/menuItem/MenuItemForm.vue
+++ b/src/modals/menuItem/MenuItemForm.vue
@@ -31,7 +31,7 @@ import { buildMenuItemIconCatalogues } from './menuItemIconCatalogues.js'
  * @category Components
  * @package opencatalogi
  * @author Ruben Linde
- * @license AGPL-3.0-or-later
+ * @license EUPL-1.2
  */
 export default {
 	name: 'MenuItemForm',

--- a/src/modals/menuItem/menuItemIconCatalogues.js
+++ b/src/modals/menuItem/menuItemIconCatalogues.js
@@ -12,7 +12,7 @@
  *
  * @category Services
  * @package opencatalogi
- * @license AGPL-3.0-or-later
+ * @license EUPL-1.2
  */
 
 import { fromFontAwesome, fromOpenGemeenten } from '@conduction/nextcloud-vue'

--- a/src/modals/object/MassLockObjects.vue
+++ b/src/modals/object/MassLockObjects.vue
@@ -3,7 +3,7 @@
  * @module Modals/Object
  * @author Your Name
  * @copyright 2024 Your Organization
- * @license AGPL-3.0-or-later
+ * @license EUPL-1.2
  * @version 1.0.0
  */
 

--- a/src/modals/object/MassUnlockObjects.vue
+++ b/src/modals/object/MassUnlockObjects.vue
@@ -3,7 +3,7 @@
  * @module Modals/Object
  * @author Your Name
  * @copyright 2024 Your Organization
- * @license AGPL-3.0-or-later
+ * @license EUPL-1.2
  * @version 1.0.0
  */
 

--- a/src/modals/object/MassValidateObjects.vue
+++ b/src/modals/object/MassValidateObjects.vue
@@ -3,7 +3,7 @@
  * @module Modals/Object
  * @author Your Name
  * @copyright 2024 Your Organization
- * @license AGPL-3.0-or-later
+ * @license EUPL-1.2
  * @version 1.0.0
  */
 

--- a/src/modals/page/ViewPageModal.vue
+++ b/src/modals/page/ViewPageModal.vue
@@ -5,7 +5,7 @@
  * @package opencatalogi
  * @author Ruben Linde
  * @copyright 2024
- * @license AGPL-3.0-or-later
+ * @license EUPL-1.2
  * @version 1.0.0
  * @link https://github.com/opencatalogi/opencatalogi
  */

--- a/src/modals/theme/ViewThemeModal.vue
+++ b/src/modals/theme/ViewThemeModal.vue
@@ -5,7 +5,7 @@
  * @package opencatalogi
  * @author Ruben Linde
  * @copyright 2024
- * @license AGPL-3.0-or-later
+ * @license EUPL-1.2
  * @version 1.0.0
  * @link https://github.com/opencatalogi/opencatalogi
  */

--- a/src/services/nextcloudGroups.js
+++ b/src/services/nextcloudGroups.js
@@ -8,7 +8,7 @@
  * @package
  * @author OpenCatalogi Development Team
  * @copyright 2024
- * @license AGPL-3.0-or-later
+ * @license EUPL-1.2
  * @version 1.0.0
  * @see {@link https://github.com/opencatalogi/opencatalogi}
  *

--- a/src/store/modules/catalog.js
+++ b/src/store/modules/catalog.js
@@ -12,7 +12,7 @@ import { buildHeaders } from '@conduction/nextcloud-vue'
  * @package
  * @author Ruben Linde
  * @copyright 2024
- * @license AGPL-3.0-or-later
+ * @license EUPL-1.2
  * @version 1.0.0
  * @see {@link https://github.com/opencatalogi/opencatalogi}
  */

--- a/src/store/modules/object.js
+++ b/src/store/modules/object.js
@@ -82,7 +82,7 @@ const useInnerObjectStore = createObjectStore('opencatalogi-objects-inner', {
  * @package
  * @author Ruben Linde
  * @copyright 2024
- * @license AGPL-3.0-or-later
+ * @license EUPL-1.2
  * @version 2.0.0
  * @see {@link https://github.com/opencatalogi/opencatalogi}
  */

--- a/src/store/modules/search.js
+++ b/src/store/modules/search.js
@@ -8,7 +8,7 @@
  * @package
  * @author   Ruben van der Linde
  * @copyright 2024
- * @license  AGPL-3.0-or-later
+ * @license  EUPL-1.2
  * @version  1.0.0
  * @see     {@link https://github.com/opencatalogi/opencatalogi}
  */

--- a/tests/e2e/base-url.ts
+++ b/tests/e2e/base-url.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 OpenCatalogi Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * The ONE place the e2e suite learns which Nextcloud to talk to.
  *

--- a/tests/e2e/ci-seed.sh
+++ b/tests/e2e/ci-seed.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # SPDX-FileCopyrightText: 2026 OpenCatalogi Contributors
-# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-License-Identifier: EUPL-1.2
 #
 # Provision OpenCatalogi's OpenRegister register + schemas on a freshly
 # installed Nextcloud, for the shared `E2E Tests (Playwright)` CI job.

--- a/tests/e2e/docs-screenshots.spec.ts
+++ b/tests/e2e/docs-screenshots.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 OpenCatalogi Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Documentation screenshot capture suite — opencatalogi.
  *

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 OpenCatalogi Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Playwright globalSetup — logs into Nextcloud once and persists the
  * resulting cookie jar / localStorage to `tests/e2e/.auth/admin.json`.

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 OpenCatalogi Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * CI regression config for the shared `E2E Tests (Playwright)` job.
  *

--- a/tests/e2e/spec-coverage.spec.ts
+++ b/tests/e2e/spec-coverage.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 OpenCatalogi Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Spec-coverage e2e suite for OpenCatalogi — API-level contracts.
  *

--- a/tests/e2e/spec-coverage/_nav.ts
+++ b/tests/e2e/spec-coverage/_nav.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 OpenCatalogi Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Shared navigation + assertion helpers for the OpenCatalogi behavioral
  * e2e suite.

--- a/tests/e2e/spec-coverage/catalog-detail-page.spec.ts
+++ b/tests/e2e/spec-coverage/catalog-detail-page.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 OpenCatalogi Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Behavioral UI coverage for the OpenCatalogi Catalog detail page
  * (manifest page type:custom → CatalogDetailPageView, built on

--- a/tests/e2e/spec-coverage/content-search-endpoint.spec.ts
+++ b/tests/e2e/spec-coverage/content-search-endpoint.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 OpenCatalogi Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * WOO-517 content-search e2e coverage (SCH-PFTS-CONTENT-001/-002/-003).
  *

--- a/tests/e2e/spec-coverage/dashboard-page.spec.ts
+++ b/tests/e2e/spec-coverage/dashboard-page.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 OpenCatalogi Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Behavioral UI coverage for the OpenCatalogi Dashboard (manifest page
  * type:custom → DashboardView, built on CnDashboardPage). This is the

--- a/tests/e2e/spec-coverage/directory-page.spec.ts
+++ b/tests/e2e/spec-coverage/directory-page.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 OpenCatalogi Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Behavioral UI coverage for the OpenCatalogi Directory page, reached via
  * its CnAppNav entry (AdminGroup).

--- a/tests/e2e/spec-coverage/features-roadmap-page.spec.ts
+++ b/tests/e2e/spec-coverage/features-roadmap-page.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 OpenCatalogi Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Behavioral UI coverage for the OpenCatalogi "Features & roadmap" page
  * (manifest page type:"roadmap", route /features-roadmap), reached via its

--- a/tests/e2e/spec-coverage/gate19.spec.ts
+++ b/tests/e2e/spec-coverage/gate19.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 OpenCatalogi Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Gate-19 spec-coverage e2e suite for OpenCatalogi.
  *

--- a/tests/e2e/spec-coverage/list-pages.spec.ts
+++ b/tests/e2e/spec-coverage/list-pages.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 OpenCatalogi Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Behavioral UI coverage for OpenCatalogi's CnIndexPage-backed list pages,
  * reached by clicking their CnAppNav entries (manifest-shell SPA).

--- a/tests/e2e/spec-coverage/openapi-document.spec.ts
+++ b/tests/e2e/spec-coverage/openapi-document.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 OpenCatalogi Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * public-api-openapi-document e2e coverage (API-DOC-003).
  *

--- a/tests/e2e/spec-coverage/search-page.spec.ts
+++ b/tests/e2e/spec-coverage/search-page.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 OpenCatalogi Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Behavioral UI coverage for the OpenCatalogi Search page (manifest page
  * type:"search", route /search), reached via the top-level "Search"

--- a/tests/e2e/spec-coverage/woo-batches-page.spec.ts
+++ b/tests/e2e/spec-coverage/woo-batches-page.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 OpenCatalogi Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Regression guard for the `/woo` green-but-dead defect
  * (fix-woo-capability-provisioning, WOO-PROV-001..003).

--- a/tests/e2e/visual/_visual-helpers.ts
+++ b/tests/e2e/visual/_visual-helpers.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Shared helpers for the visual-regression layer (GAP-5).
  *

--- a/tests/e2e/workflows/_crud.ts
+++ b/tests/e2e/workflows/_crud.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 OpenCatalogi Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Shared UI-driving helpers for the CnIndexPage-backed CRUD-with-persistence
  * workflow specs. These click through the genuine user journey (Add CTA →

--- a/tests/e2e/workflows/_fixtures.ts
+++ b/tests/e2e/workflows/_fixtures.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 OpenCatalogi Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Seeded-fixture helpers for the DEEP, data-dependent OpenCatalogi e2e
  * workflow suite.

--- a/tests/e2e/workflows/catalog-crud-persistence.spec.ts
+++ b/tests/e2e/workflows/catalog-crud-persistence.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 OpenCatalogi Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * DEEP, data-dependent CRUD-with-persistence coverage for CATALOGS.
  *

--- a/tests/e2e/workflows/publication-crud-persistence.spec.ts
+++ b/tests/e2e/workflows/publication-crud-persistence.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 OpenCatalogi Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * DEEP, data-dependent CRUD-with-persistence coverage for PUBLICATIONS.
  *

--- a/tests/e2e/workflows/publish-workflow.spec.ts
+++ b/tests/e2e/workflows/publish-workflow.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 OpenCatalogi Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * HIGH-VALUE discoverability coverage: prove that whether a publication is
  * discoverable to an anonymous visitor is governed by OpenRegister's RBAC


### PR DESCRIPTION
## What

All app metadata (`composer.json`, `package.json`, `appinfo/info.xml`, `LICENSE`) already declares **EUPL-1.2**, but 71 source files still carried `AGPL-3.0-or-later` declarations left over from the original Nextcloud app scaffolding. This aligns them with the project licence.

| Category | Count |
|---|---|
| `@license AGPL-3.0-or-later` → `@license EUPL-1.2` (`src/**`, `.vue`/`.js`/`.ts`) | 47 |
| `SPDX-License-Identifier: AGPL-3.0-or-later` → `EUPL-1.2` (`playwright.config.ts`, `tests/e2e/**`) | 24 |
| **Total** | **71** |

No trailing-dot (`EUPL-1.2.`) or field-order (`@license <url> EUPL-1.2`) defects existed in this repo — all four metadata files were already correct and were not touched.

## What is deliberately NOT changed

- **Every `@copyright` / `SPDX-FileCopyrightText` line.** This normalises the licence only; holders and years are untouched.
- No third-party or vendored file. `vendor/`, `node_modules/`, `dist/`, `build/` are excluded, and this repo has no vendored upstream source carrying a foreign copyright holder.
- Files whose header is a scaffolding placeholder (`@author Your Name` / `@copyright 2024 Your Organization` — `PublishedIcon.vue`, `SelectAttachmentsList.vue`, `MassLockObjects.vue`, `MassUnlockObjects.vue`, `MassValidateObjects.vue`) **were** changed: they are our own code, the placeholder is template residue, not a third-party claim.
- `src/modals/menuItem/menuItemIconCatalogues.js` **was** changed. Its prose mentions a CC0 OpenGemeenten icon sample and a CC BY-NC-ND npm package — those statements describe the *icon data*, not this file, and are left verbatim. The file itself is ours.

## Diff shape

71 files changed, 71 insertions(+), 71 deletions(-) — exactly one line per file, and **every changed line contains `license`**. Nothing else in any file moves.

## Verification

Identically conditioned before and after:

| Check | Before | After |
|---|---|---|
| vitest (`npm run test:unit`) | 6 files / 56 tests passed | 6 files / 56 tests passed |
| jest (`npm test`) | 15 suites / 66 tests passed | 15 suites / 66 tests passed |
| phpunit (`phpunit-unit.xml`, PHP 8.4 in `nextcloud:latest`) | 1255 tests, 3065 assertions, 4 warnings, 66 deprecations, 2 skipped | identical |
| eslint (`npm run lint`) | — | 0 errors (1195 pre-existing warnings) |
| hydra **gate-28** (license-triangle) | PASS | PASS |

Host PHP is 8.2 and the vendor tree requires >= 8.3, so the PHP suite was run under PHP 8.4 in a throwaway `nextcloud:latest` container — the host run exits 255 (platform check), which is VOID, not a result.

No `@SuppressWarnings`, baseline entry, threshold change, `.skip`, waiver, `continue-on-error`, or weakened assertion was added anywhere.