### PR TITLE
chore(ci): stop pinning hydra-gates — track the package at @main

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -123,46 +123,18 @@ jobs:
       # ── Hydra mechanical gates ───────────────────────────────────────────
       # `enable-hydra-gates` defaults to FALSE, so this tier has never executed
       # here — the job reported `skipped`, which the Quality Report renders
-      # identically to a pass. Pinned to v1.0.1 so a change to the gate package
-      # cannot move this repo's verdict without a commit here.
-      # `enable-axe` deliberately NOT set: a vanilla Nextcloud 34 already carries
-      # serious/critical violations from core's own UI.
-      #
-      # v1.0.1 -> v1.3.0 (ConductionNL/.github#159). Two defects, one bump.
-      #
-      # 1. STALE. v1.0.1 is `f4d9756` (2026-08-03) and predates three gate
-      #    fixes, so every Hydra Gates run this repo has ever made executed a
-      #    script in which 16 gates reported PASS when their helper never ran
-      #    (#147), gate-33 had no axe report to read and never said so (#148),
-      #    and gates 6 and 7 reported PASS on an EMPTY scope (#149). A gate
-      #    that reports PASS without running emits a tick identical to a real
-      #    one, which is why nothing in this repo's history shows it.
-      #
-      # 2. RED. quality.yml is referenced `@main` while this package is
-      #    PINNED, so the two can desync — and on 2026-08-05 they did. #164
-      #    flipped `hydra-gates-require-full-coverage` to default TRUE, but
-      #    the accounting that makes that flag survivable (NOT APPLICABLE, as
-      #    distinct from a structural or a wiring gap) ships in the PACKAGE.
-      #    So every pin older than `f7eaf2a` now fails the coverage assertion
-      #    for gates it has no subject matter for. Measured diff-scoped,
-      #    exactly as CI scopes it:
-      #      v1.0.1  exit 98  FAIL — "GATES THAT DID NOT RUN: 24 33"
-      #      v1.3.0  exit 0   PASS — those gates named NOT APPLICABLE
-      #    The old pin was not merely stale, it was failing this repo's CI for
-      #    a reason that had nothing to do with this repo — and it is what is
-      #    currently blocking #807 and #805.
-      #
-      # v1.3.0 is `f7eaf2a` = .github@main, tagged so the ref stays
-      # reproducible and a later gate change cannot move this repo's verdict
-      # without a commit here.
+      # identically to a pass.
       enable-hydra-gates: true
-      hydra-gates-ref: v1.4.0
-      # PIN MOVED v1.3.0 -> v1.4.0 (fleet consumer-ref sweep, 2026-08-05).
-      # A pinned ref is a silent expiry date on every upstream fix: this repo
-      # cannot receive a gate-package fix until this line moves. v1.4.0 is the
-      # latest tag and the FIRST one carrying `hydra-gates/scripts/axe-run.cjs`
-      # (verified absent at v1.3.0), so it is also the first that has #168's
-      # axe DOM scoping and #165's gate-46 fix.
+      # No `hydra-gates-ref` here on purpose. The shared workflow defaults it
+      # to @main, and this workflow is itself consumed at @main, so the two
+      # sides move together and a gate fix reaches this repo without a commit
+      # in this repo. A pin is a silent expiry date: 22 repos sat on v1.0.1 and
+      # 16 gates were dead fleet-wide while every one reported PASS (.github#159),
+      # and a default flipped at @main later reached those old runners and made
+      # them red on gates they had no subject matter for (.github#173).
+      # To hold this repo still for a specific reason, set the input explicitly
+      # and say why — it is still honoured. To roll back for everyone, revert on
+      # ConductionNL/.github main.
       # `enable-axe` is deliberately still NOT set — a vanilla Nextcloud 34
       # reports serious/critical violations on core's OWN routes that DOM
       # scoping does not remove. Enabling axe is a separate decision.

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -156,4 +156,13 @@ jobs:
       # reproducible and a later gate change cannot move this repo's verdict
       # without a commit here.
       enable-hydra-gates: true
-      hydra-gates-ref: v1.3.0
+      hydra-gates-ref: v1.4.0
+      # PIN MOVED v1.3.0 -> v1.4.0 (fleet consumer-ref sweep, 2026-08-05).
+      # A pinned ref is a silent expiry date on every upstream fix: this repo
+      # cannot receive a gate-package fix until this line moves. v1.4.0 is the
+      # latest tag and the FIRST one carrying `hydra-gates/scripts/axe-run.cjs`
+      # (verified absent at v1.3.0), so it is also the first that has #168's
+      # axe DOM scoping and #165's gate-46 fix.
+      # `enable-axe` is deliberately still NOT set — a vanilla Nextcloud 34
+      # reports serious/critical violations on core's OWN routes that DOM
+      # scoping does not remove. Enabling axe is a separate decision.


### PR DESCRIPTION
## What changed

This PR started life as a pin bump (`hydra-gates-ref: v1.3.0 -> v1.4.0`). It now **removes the `hydra-gates-ref` line entirely** so this caller inherits the shared workflow's default.

```diff
       enable-hydra-gates: true
-      hydra-gates-ref: v1.4.0
```

`enable-hydra-gates: true` is unchanged. `enable-axe` remains unset. The comment block that justified the pin is replaced with a short note explaining why there is deliberately no pin.

## Why

`ConductionNL/.github/.github/workflows/quality.yml` **already defaults `hydra-gates-ref` to `main`**, and this repo consumes `quality.yml` at `@main`. Overriding the input was the only thing holding the gates package still. Drop the override and both sides move together — a gate fix reaches this repo without a commit in this repo.

Bumping the pin is a treadmill: it works until the next fix lands upstream, and between bumps the repo is running whatever the gates package looked like on the day someone last remembered.

**A pin is a silent expiry date on every upstream fix.** We have paid for that twice:

- **[.github#159](https://github.com/ConductionNL/.github/issues/159)** — 22 repos sat pinned on `v1.0.1`, which predated the gate fixes. **16 gates were dead fleet-wide and every one of them reported PASS.** A gate that never runs emits a tick identical to one that did, so nothing in any repo's CI history showed it.
- **[.github#173](https://github.com/ConductionNL/.github/issues/173)** — the shared side flipped a default at `@main` while the package stayed pinned per caller. Old pinned runners did not carry the coverage accounting the new default assumed, so they went **red on gates they had no subject matter for**.

The two failures are opposite shapes of the same split: shared workflow at `@main`, package pinned. Removing the pin closes both.

## Rollback

- **For everyone:** revert on `ConductionNL/.github` `main`. One commit reaches the whole fleet — which is the point.
- **For this repo only:** set `hydra-gates-ref:` explicitly again, with a comment saying why this repo needs to hold still. The input is still honoured; it just is not the default posture.

## Safety net

[`ConductionNL/.github#177`](https://github.com/ConductionNL/.github/pull/177) adds the resolve probe plus the gates package suite gating `.github` `main`, so a broken package cannot reach `main` unnoticed now that consumers track it.
