### PR TITLE
chore(deps): declare PHP 8.3 as the floor — 8.0 advertised a configuration that cannot exist

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -76,7 +76,26 @@ Doe een [featureverzoek](https://github.com/OpenCatalogi/.github/issues/new/choo
     <screenshot>https://codeberg.org/Conduction/opencatalogi/raw/branch/main/img/screenshot-publications.png</screenshot>
 
    	<dependencies>
-        <php min-version="8.0" min-int-size="64"/>
+        <!--
+        min-version is 8.3, not 8.0. The 8.0 floor advertised a configuration
+        that cannot exist and that nothing here has ever exercised:
+
+          - composer.json already declares `"php": "^8.3"` and pins
+            config.platform.php = 8.3, so `composer install` aborts on anything
+            older. The app could not have its own dependencies installed on the
+            version its own manifest advertised.
+          - The <nextcloud min-version> below is 32, and Nextcloud 32 refuses to
+            boot below PHP 8.1 outright (lib/versioncheck.php:
+            `if (PHP_VERSION_ID < 80100)`, verified against a running 32.0.12.1).
+            8.0 was unreachable through the server, never mind through composer.
+          - CI runs `php-version: "8.3"` with `php-test-versions: ["8.3","8.4"]`.
+            No leg below 8.3 has ever executed, so 8.0/8.1/8.2 were advertised
+            and untested at the same time.
+
+        Same class of defect as openconnector#1173: an App Store listing that
+        promises a range the app cannot deliver.
+        -->
+        <php min-version="8.3" min-int-size="64"/>
         <database min-version="10">pgsql</database>
         <database>sqlite</database>
         <database min-version="8.0">mysql</database>

--- a/tests/Unit/AppManifestPhpFloorTest.php
+++ b/tests/Unit/AppManifestPhpFloorTest.php
@@ -1,0 +1,225 @@
+<?php
+/**
+ * Coherence assertion: the PHP floor this app advertises to the App Store is
+ * the same floor its own dependency manifest enforces.
+ *
+ * `appinfo/info.xml` is what users and the App Store read; `composer.json` is
+ * what actually decides whether the app can be installed. When they disagree,
+ * the listing promises a configuration that cannot exist — the app advertised
+ * `<php min-version="8.0"/>` while `composer.json` required `^8.3`, so
+ * `composer install` aborted on every version the listing claimed to support.
+ * Nothing caught it, because CI only ever ran 8.3 and 8.4.
+ *
+ * Same class of defect as openconnector#1173 (an App Store range the app's own
+ * dependencies could not deliver).
+ *
+ * @category Test
+ * @package  OCA\OpenCatalogi\Tests
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @link https://www.OpenCatalogi.nl
+ */
+
+declare(strict_types=1);
+
+namespace Unit;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Asserts info.xml, composer.json's `require.php` and composer.json's
+ * `config.platform.php` all name the same PHP floor.
+ */
+class AppManifestPhpFloorTest extends TestCase
+{
+
+    /**
+     * Repository root, derived from this file's own location.
+     *
+     * @return string Absolute path to the repository root.
+     */
+    private function repoRoot(): string
+    {
+        return dirname(__DIR__, 2);
+
+    }//end repoRoot()
+
+
+    /**
+     * The `min-version` attribute of info.xml's `<php>` dependency.
+     *
+     * @return string The declared floor, e.g. "8.3".
+     */
+    private function infoXmlPhpFloor(): string
+    {
+        $path = $this->repoRoot().'/appinfo/info.xml';
+        $this->assertFileExists($path, 'appinfo/info.xml is missing');
+
+        $xml = simplexml_load_file($path);
+        $this->assertNotFalse($xml, 'appinfo/info.xml is not parseable XML');
+
+        $nodes = $xml->xpath('/info/dependencies/php');
+        $this->assertNotEmpty($nodes, 'info.xml declares no <php> dependency at all');
+
+        $floor = (string) $nodes[0]['min-version'];
+        $this->assertNotSame('', $floor, '<php> carries no min-version attribute');
+
+        return $floor;
+
+    }//end infoXmlPhpFloor()
+
+
+    /**
+     * composer.json, decoded.
+     *
+     * @return array<string, mixed> The decoded manifest.
+     */
+    private function composerManifest(): array
+    {
+        $path = $this->repoRoot().'/composer.json';
+        $this->assertFileExists($path, 'composer.json is missing');
+
+        $decoded = json_decode((string) file_get_contents($path), true);
+        $this->assertIsArray($decoded, 'composer.json is not valid JSON');
+
+        return $decoded;
+
+    }//end composerManifest()
+
+
+    /**
+     * Lowest concrete version a Composer caret/tilde/>= constraint admits.
+     *
+     * Deliberately narrow: it understands `^X.Y`, `~X.Y`, `>=X.Y` and a bare
+     * `X.Y`, which is the whole vocabulary this repository uses. Anything else
+     * fails the test rather than being silently accepted — a parser that
+     * shrugs at an unknown constraint would report "coherent" for a manifest
+     * it never actually read.
+     *
+     * @param string $constraint The raw Composer constraint.
+     *
+     * @return string The lowest admitted version.
+     */
+    private function lowestAdmitted(string $constraint): string
+    {
+        $trimmed = trim($constraint);
+        $matches = [];
+        $matched = preg_match('/^(?:\^|~|>=)?\s*(\d+\.\d+(?:\.\d+)?)$/', $trimmed, $matches);
+
+        $this->assertSame(
+            1,
+            $matched,
+            sprintf(
+                'composer.json php constraint "%s" is not one of the forms this '
+                .'test understands (^X.Y, ~X.Y, >=X.Y, X.Y). Widen the test '
+                .'deliberately rather than letting it pass on a constraint it '
+                .'cannot read.',
+                $trimmed
+            )
+        );
+
+        return $matches[1];
+
+    }//end lowestAdmitted()
+
+
+    /**
+     * The App Store listing must not advertise a PHP version on which the
+     * app's own dependencies refuse to install.
+     *
+     * @return void
+     */
+    public function testInfoXmlFloorIsNotBelowComposerRequirement(): void
+    {
+        $infoFloor     = $this->infoXmlPhpFloor();
+        $composerFloor = $this->lowestAdmitted((string) $this->composerManifest()['require']['php']);
+
+        $this->assertTrue(
+            version_compare($infoFloor, $composerFloor, '>='),
+            sprintf(
+                'appinfo/info.xml advertises PHP >= %s but composer.json requires '
+                .'php %s, so `composer install` aborts on every version between '
+                .'them. The listing promises a configuration that cannot exist.',
+                $infoFloor,
+                $composerFloor
+            )
+        );
+
+    }//end testInfoXmlFloorIsNotBelowComposerRequirement()
+
+
+    /**
+     * The pinned Composer platform must itself satisfy the declared
+     * requirement — otherwise the lock file was resolved for a PHP the app
+     * says it does not support.
+     *
+     * @return void
+     */
+    public function testPinnedPlatformSatisfiesComposerRequirement(): void
+    {
+        $manifest = $this->composerManifest();
+        $platform = (string) ($manifest['config']['platform']['php'] ?? '');
+
+        $this->assertNotSame(
+            '',
+            $platform,
+            'composer.json pins no config.platform.php, so the lock file was '
+            .'resolved against whatever PHP happened to run — not a declared target.'
+        );
+
+        $required = $this->lowestAdmitted((string) $manifest['require']['php']);
+
+        $this->assertTrue(
+            version_compare($platform, $required, '>='),
+            sprintf(
+                'composer.json pins config.platform.php = %s but requires php >= %s.',
+                $platform,
+                $required
+            )
+        );
+
+    }//end testPinnedPlatformSatisfiesComposerRequirement()
+
+
+    /**
+     * Nextcloud 32 — the floor this app declares — refuses to boot below PHP
+     * 8.1 (`lib/versioncheck.php`: `if (PHP_VERSION_ID < 80100)`). Advertising
+     * anything lower describes a server that would never start.
+     *
+     * @return void
+     */
+    public function testInfoXmlFloorIsReachableOnTheDeclaredNextcloudFloor(): void
+    {
+        $xml   = simplexml_load_file($this->repoRoot().'/appinfo/info.xml');
+        $nodes = $xml->xpath('/info/dependencies/nextcloud');
+        $this->assertNotEmpty($nodes, 'info.xml declares no <nextcloud> dependency');
+
+        $ncFloor = (int) $nodes[0]['min-version'];
+        $this->assertGreaterThanOrEqual(
+            32,
+            $ncFloor,
+            'This assertion is written against a Nextcloud floor of 32 or later; '
+            .'lowering the floor invalidates the PHP 8.1 figure below and the '
+            .'test must be revisited, not relaxed.'
+        );
+
+        $this->assertTrue(
+            version_compare($this->infoXmlPhpFloor(), '8.1', '>='),
+            sprintf(
+                'info.xml advertises PHP >= %s, but the declared Nextcloud floor '
+                .'(%d) will not boot below PHP 8.1.',
+                $this->infoXmlPhpFloor(),
+                $ncFloor
+            )
+        );
+
+    }//end testInfoXmlFloorIsReachableOnTheDeclaredNextcloudFloor()
+
+
+}//end class

--- a/tests/Unit/AppManifestPhpFloorTest.php
+++ b/tests/Unit/AppManifestPhpFloorTest.php
@@ -52,19 +52,60 @@ class AppManifestPhpFloorTest extends TestCase
 
 
     /**
+     * Parse appinfo/info.xml.
+     *
+     * Deliberately `file_get_contents()` + `simplexml_load_string()` rather than
+     * `simplexml_load_file()`. When these tests run inside a Nextcloud server
+     * tree, `tests/bootstrap.php` loads `lib/base.php`, which calls
+     * `libxml_set_external_entity_loader()` with a loader that returns null
+     * (base.php:589). That intercepts libxml's *file* loader — including for the
+     * primary document — so `simplexml_load_file()` returns `false` and every
+     * assertion below reports "info.xml is not parseable XML" for a file that is
+     * perfectly well-formed. Reading the bytes through PHP and parsing a string
+     * never touches that loader.
+     *
+     * Worth stating because it is the failure this test itself hit: it passed
+     * under `phpunit-unit.xml` (whose bootstrap does NOT load base.php) and failed
+     * under the CI job that does. A green from the lightweight bootstrap says
+     * nothing about the hardened one.
+     *
+     * @return \SimpleXMLElement The parsed manifest.
+     */
+    private function infoXml(): \SimpleXMLElement
+    {
+        $path = $this->repoRoot().'/appinfo/info.xml';
+        $this->assertFileExists($path, 'appinfo/info.xml is missing');
+
+        $previous = libxml_use_internal_errors(true);
+        libxml_clear_errors();
+
+        $xml    = simplexml_load_string((string) file_get_contents($path));
+        $errors = libxml_get_errors();
+
+        libxml_clear_errors();
+        libxml_use_internal_errors($previous);
+
+        $this->assertNotFalse(
+            $xml,
+            'appinfo/info.xml is not parseable XML: '.implode(
+                '; ',
+                array_map(static fn (\LibXMLError $e): string => trim($e->message).' (line '.$e->line.')', $errors)
+            )
+        );
+
+        return $xml;
+
+    }//end infoXml()
+
+
+    /**
      * The `min-version` attribute of info.xml's `<php>` dependency.
      *
      * @return string The declared floor, e.g. "8.3".
      */
     private function infoXmlPhpFloor(): string
     {
-        $path = $this->repoRoot().'/appinfo/info.xml';
-        $this->assertFileExists($path, 'appinfo/info.xml is missing');
-
-        $xml = simplexml_load_file($path);
-        $this->assertNotFalse($xml, 'appinfo/info.xml is not parseable XML');
-
-        $nodes = $xml->xpath('/info/dependencies/php');
+        $nodes = $this->infoXml()->xpath('/info/dependencies/php');
         $this->assertNotEmpty($nodes, 'info.xml declares no <php> dependency at all');
 
         $floor = (string) $nodes[0]['min-version'];
@@ -196,8 +237,7 @@ class AppManifestPhpFloorTest extends TestCase
      */
     public function testInfoXmlFloorIsReachableOnTheDeclaredNextcloudFloor(): void
     {
-        $xml   = simplexml_load_file($this->repoRoot().'/appinfo/info.xml');
-        $nodes = $xml->xpath('/info/dependencies/nextcloud');
+        $nodes = $this->infoXml()->xpath('/info/dependencies/nextcloud');
         $this->assertNotEmpty($nodes, 'info.xml declares no <nextcloud> dependency');
 
         $ncFloor = (int) $nodes[0]['min-version'];


### PR DESCRIPTION
## What

`appinfo/info.xml` declared `<php min-version="8.0"/>`. Raised to **8.3**, plus a unit test that stops the three PHP declarations in this repo from drifting apart again.

`opencatalogi` was the only one of the 16 fleet apps still on `8.0`; every other app declares `8.3`.

## Why this is not cosmetic

The listing promised a configuration that **cannot exist**. Three independent confirmations, each measured rather than assumed:

**1. The app's own dependency manifest already required 8.3.**

`composer.json` declares `"require": {"php": "^8.3"}` and pins `"config": {"platform": {"php": "8.3"}}`. So `composer install` aborts on every PHP version between the advertised floor and the real one:

```
$ docker run --rm -v <worktree>:/app -w /app php:8.2-cli php -r '...'
PHP 8.2.33 (cli)
composer.json requires php ^8.3 — runtime is 8.2.33
satisfied? NO — install would abort
```

**2. The declared Nextcloud floor cannot run PHP 8.0 either.**

`<nextcloud min-version="32"/>`, and NC 32 refuses to boot below PHP 8.1 outright. Read out of a running 32.0.12.1, not from memory:

```
$ docker exec <nc32> head -20 /var/www/html/lib/versioncheck.php
// Show warning if a PHP version below 8.1 is used,
if (PHP_VERSION_ID < 80100) {
    echo 'This version of Nextcloud requires at least PHP 8.1<br/>';
```

**3. CI has never exercised anything below 8.3.**

`.github/workflows/code-quality.yml`:

```yaml
php-version: "8.3"
php-test-versions: '["8.3", "8.4"]'
```

So 8.0 / 8.1 / 8.2 were advertised and untested at the same time. **No matrix leg is being dropped by this PR** — there was never one to drop. After this change the declared floor and the tested floor are the same number for the first time.

Same class of defect as `ConductionNL/openconnector#1173`: an App Store listing promising a range the app's own dependencies cannot deliver.

## The test, and proof it can fail

`tests/Unit/AppManifestPhpFloorTest.php` asserts three things:

1. info.xml's `<php min-version>` is not below the floor `composer.json`'s `require.php` admits;
2. `config.platform.php` satisfies `require.php` (otherwise the lock file was resolved for a PHP the app says it does not support);
3. the floor is reachable on the declared Nextcloud floor (≥ 8.1 for NC ≥ 32).

The constraint parser understands `^X.Y`, `~X.Y`, `>=X.Y` and bare `X.Y`, and **fails on anything else** rather than shrugging — a parser that accepts a constraint it cannot read would report "coherent" for a manifest it never actually parsed.

**Can-fail proof.** With the fix in place, then with `info.xml` mutated back to the pre-fix `8.0` and nothing else changed:

```
########## ARM 1: with the fix (info.xml = 8.3) ##########
OK (3 tests, 25 assertions)
PHPUNIT_EXIT=0

########## ARM 2: mutated back to the pre-fix value (info.xml = 8.0) ##########
F.F                                                                 3 / 3 (100%)

1) Unit\AppManifestPhpFloorTest::testInfoXmlFloorIsNotBelowComposerRequirement
appinfo/info.xml advertises PHP >= 8.0 but composer.json requires php 8.3, so
`composer install` aborts on every version between them. The listing promises a
configuration that cannot exist.

2) Unit\AppManifestPhpFloorTest::testInfoXmlFloorIsReachableOnTheDeclaredNextcloudFloor
info.xml advertises PHP >= 8.0, but the declared Nextcloud floor (32) will not
boot below PHP 8.1.

FAILURES!
Tests: 3, Assertions: 25, Failures: 2.
PHPUNIT_EXIT=1
```

Both arms run under PHP 8.4 in a container; the host's PHP 8.2 kills phpmd with exit 255, which reads like a clean run, so nothing in this PR was measured on the host.

## Full unit suite

1258 tests, 3084 assertions. 3 errors, all `Class "ZipArchive" not found` from `FileServiceTest` — my container lacks `ext-zip`; CI has it (`<lib>zip</lib>` is a declared dependency). Nothing related to this change.

## Visible but deliberately not resolved here

`max-version` is **34 in every fleet app except `openconnector`, which declares 35**. Flagging it because a divergent ceiling is the same shape of defect as the floor this PR fixes — but it is a fleet-level decision, not a leaf-local one, so it is not touched here.
