### PR TITLE
fix(publiccode): register the schema icon so it actually renders, and describe the seven undocumented properties (gate-51, gate-60)

### DIFF
--- a/lib/Settings/register.d/publiccode-software.json
+++ b/lib/Settings/register.d/publiccode-software.json
@@ -15,7 +15,7 @@
         "published": true,
         "summary": "A software component described by a publiccode.yml file",
         "description": "One harvested publiccode.yml. The identity of a component is its repository URL, not its name: names collide across forges and change on rebrand, while the URL is what the harvest actually dereferenced. `slug` is derived from the repository full name so a re-harvest UPDATES rather than duplicates — the flow engine has no synchronisation contracts yet, so idempotency has to come from a deterministic identifier.",
-        "icon": "package-variant-closed",
+        "icon": "PackageVariantClosed",
         "searchable": true,
         "hardValidation": false,
         "required": ["name", "url"],
@@ -45,17 +45,20 @@
             "type": "string",
             "format": "uri",
             "title": "Landing page",
+            "description": "Public landing page for the software — the human-readable page a prospective user should be sent to. Deliberately separate from `url`: publiccode.yml treats the repository as the identity and the landing page as the front door, and for many components they are different sites.",
             "x-publiccode": "landingURL"
           },
           "softwareVersion": {
             "type": "string",
             "title": "Version",
+            "description": "Latest released version, as the maintainer numbers it. Kept as a free-form string rather than parsed: publiccode.yml records whatever the project publishes, and forcing it into semver would silently rewrite versions that are dates or build numbers.",
             "x-publiccode": "softwareVersion"
           },
           "releaseDate": {
             "type": "string",
             "format": "date",
             "title": "Release date",
+            "description": "Date the version in `softwareVersion` was released (YYYY-MM-DD). Read together with that field this is what separates a maintained component from an abandoned one, so it is the main signal behind any recency facet.",
             "x-publiccode": "releaseDate"
           },
           "logo": {
@@ -67,6 +70,7 @@
           "platforms": {
             "type": "array",
             "title": "Platforms",
+            "description": "Platforms the software runs on. publiccode.yml reserves the values `web`, `windows`, `mac`, `linux`, `ios` and `android`, and allows free text for anything else — which is why this is not an enum: constraining it would reject valid harvested documents.",
             "items": { "type": "string" },
             "x-publiccode": "platforms",
             "facetable": true
@@ -109,6 +113,7 @@
           "maintainers": {
             "type": "array",
             "title": "Maintainers",
+            "description": "Who to contact about this component. Flattened from two separate publiccode.yml lists — `maintenance.contractors` (organisations under contract) and `maintenance.contacts` (named people) — because a catalogue reader is asking one question, not two. The distinction survives in each entry's own fields.",
             "items": { "type": "object" },
             "x-publiccode": "maintenance.contractors + maintenance.contacts"
           },
@@ -122,11 +127,13 @@
           "legalRepoOwner": {
             "type": "string",
             "title": "Repository owner",
+            "description": "Legal entity that owns the repository. Not the same question as who publishes or maintains the component — this is the party that can relicense or transfer it, which is what a reuse decision actually turns on.",
             "x-publiccode": "legal.repoOwner"
           },
           "localisationAvailableLanguages": {
             "type": "array",
             "title": "Available languages",
+            "description": "Languages the interface is already available in, as BCP 47 tags. Distinct from publiccode.yml's `localisation.localisationReady`, which only claims that translating it is possible — an empty list here with `localisationReady: true` means nobody has translated it yet.",
             "items": { "type": "string" },
             "x-publiccode": "localisation.availableLanguages",
             "facetable": true

--- a/src/icons.js
+++ b/src/icons.js
@@ -30,6 +30,7 @@ import Magnify from 'vue-material-design-icons/Magnify.vue'
 import MapMarkerPath from 'vue-material-design-icons/MapMarkerPath.vue'
 import OfficeBuilding from 'vue-material-design-icons/OfficeBuilding.vue'
 import Package from 'vue-material-design-icons/Package.vue'
+import PackageVariantClosed from 'vue-material-design-icons/PackageVariantClosed.vue'
 import PlayCircleOutline from 'vue-material-design-icons/PlayCircleOutline.vue'
 import ShieldAccountOutline from 'vue-material-design-icons/ShieldAccountOutline.vue'
 import Sitemap from 'vue-material-design-icons/Sitemap.vue'
@@ -57,6 +58,7 @@ export default {
 	MapMarkerPath,
 	OfficeBuilding,
 	Package,
+	PackageVariantClosed,
 	PlayCircleOutline,
 	ShieldAccountOutline,
 	Sitemap,


### PR DESCRIPTION
Two gate findings, measured **full-tree** at `origin/development` (`9e63d9f3`) rather than from a CI verdict — no job in this repo reports a full-tree gate result, so neither of these was ever going to surface as a red check.

```
[gate-51] schema-property-titles: FAIL — 7 schema property(ies) missing a human-friendly title/description
[gate-60] icon-vocabulary:        FAIL — 1 icon(s) outside the canonical vocabulary (ADR-077)
```

After this branch, same command, same tree: both **PASS**.

## The icon was broken in two layers, and the second only appeared once the first was fixed

**Layer 1 — wrong case.** `lib/Settings/register.d/publiccode-software.json` declared `"icon": "package-variant-closed"`. ADR-077 rule 1: a kebab-case or lowercase spelling of an MDI name resolves to nothing. The real component is `PackageVariantClosed` — I confirmed `vue-material-design-icons/PackageVariantClosed.vue` exists rather than assuming the name — and every icon in `src/manifest.json` is already PascalCase (`AccountGroup`, `ViewDashboardOutline`, `Package`, …).

**Layer 2 — not registered.** Correcting the spelling did **not** make gate-60 pass. It produced a different, sharper finding:

```
FAIL  src/icons.js: 1 icon name(s) used by the manifests are NOT registered — they render
      with no icon at all, not a fallback: PackageVariantClosed (ADR-077 rule 3).
```

`src/icons.js` had no import and no export for it. Its own header says exactly what that costs: *"A name that is not registered renders NO icon in the navigation — not a fallback glyph."* So the publiccode schema has never had an icon, and nothing anywhere would have reported an error — an absent glyph is not an exception. Fixed both layers.

Note on measurement: gate-60 emits `NOTE: vue-material-design-icons is not installed — could not verify that icon names exist upstream` when the package cannot be resolved. Every verdict quoted here was produced with the package resolvable, so the upstream-existence half of the gate actually ran.

## Proof both fixes can fail

Three mutations against this branch, each reverting exactly one thing and re-running the same full-tree command:

```
### ARM A: icons.js registration removed (manifest still says PackageVariantClosed)
[gate-51] schema-property-titles: PASS
[gate-60] icon-vocabulary: FAIL — 1 icon(s) outside the canonical vocabulary (ADR-077)

### ARM B: manifest icon put back to the pre-fix kebab-case spelling
[gate-51] schema-property-titles: PASS
[gate-60] icon-vocabulary: FAIL — 1 icon(s) outside the canonical vocabulary (ADR-077)

### ARM C: one description removed (legalRepoOwner)
[gate-51] schema-property-titles: FAIL — 1 schema property(ies) missing a human-friendly title/description
[gate-60] icon-vocabulary: PASS

### ARM D: restored
[gate-51] schema-property-titles: PASS
[gate-60] icon-vocabulary: PASS
```

Arms A and B are the two layers failing independently, which is the evidence that both edits are load-bearing rather than one masking the other.

## The seven descriptions

`landingURL`, `softwareVersion`, `releaseDate`, `platforms`, `maintainers`, `legalRepoOwner`, `localisationAvailableLanguages` each had a `title` but no `description`. They now follow the style of the properties that already had one (`name`, `logo`, `legalLicense`): what the field is for, and — where the publiccode.yml v0.4 standard draws a distinction the field name hides — what that distinction is:

- `landingURL` vs `url`: publiccode treats the repository as identity and the landing page as front door; for many components these are different sites.
- `softwareVersion` stays a free-form string on purpose — parsing it as semver would silently rewrite versions that are dates or build numbers.
- `platforms` is deliberately not an enum: publiccode reserves six values *and* allows free text, so constraining it would reject valid harvested documents.
- `maintainers` is flattened from two separate publiccode lists (`maintenance.contractors` + `maintenance.contacts`), because a catalogue reader is asking one question.
- `legalRepoOwner` is the party that can relicense or transfer — not the publisher, not the maintainer.
- `localisationAvailableLanguages` vs `localisation.localisationReady`: the latter only claims translation is *possible*.

## Deliberately out of scope

`lib/Settings/register.d/ooapi-catalog-publication.json` is **not touched**, even though it has a real and still-unfixed defect (it declares four schemas and no `components.registers` block at all, so OpenRegister creates the schema rows and orphans them). That is #775's fix and it is still needed on today's tip — I verified it and said so on that PR rather than colliding with it.

Also unchanged and still failing full-tree after this branch: gate-32 (5), gate-38 (1), gate-39 (4), gate-40 (13), gate-43 (15), gate-45 (8), gate-46 (26), gate-50 (9), gate-57 (2). gate-39/40 are covered by #826.
