### PR TITLE
fix(listings): stop /api/listings returning every object on the instance when the register is unconfigured

### DIFF
--- a/lib/Controller/ListingsController.php
+++ b/lib/Controller/ListingsController.php
@@ -57,6 +57,8 @@ use RuntimeException;
  */
 class ListingsController extends Controller
 {
+    use ResolvesRegisterConfiguration;
+
     /**
      * Constructor for ListingsController.
      *
@@ -100,6 +102,27 @@ class ListingsController extends Controller
         throw new RuntimeException('OpenRegister service is not available.');
 
     }//end getObjectService()
+
+    /**
+     * Get the register and schema configuration for listings.
+     *
+     * Resolved through the shared trait, which raises MissingConfigException when
+     * either key is unconfigured instead of handing back `''`. That distinction is
+     * the whole point: an empty string is not "no scope requested", it is "scope
+     * requested and lost", and every caller below treats it as fatal.
+     *
+     * @return array<string, string> Array containing register and schema configuration.
+     *
+     * @throws \RuntimeException                                                   When OpenRegister is unavailable.
+     * @throws \OCA\OpenRegister\Service\Resolver\Exception\MissingConfigException When a context key is unconfigured.
+     *
+     * @spec openspec/specs/opencatalogi-adopt-or-abstractions/spec.md (Requirement: Adopt RegisterResolverService)
+     */
+    private function getListingConfiguration(): array
+    {
+        return $this->resolveRegisterConfiguration('listing_register', 'listing_schema');
+
+    }//end getListingConfiguration()
 
     /**
      * Resolve the Access-Control-Allow-Origin header value for the current request.
@@ -181,24 +204,42 @@ class ListingsController extends Controller
         // Retrieve all request parameters.
         $requestParams = $this->request->getParams();
 
-        // Get listing schema and register from configuration.
-        $listingSchema   = $this->config->getValueString('opencatalogi', 'listing_schema', '');
-        $listingRegister = $this->config->getValueString('opencatalogi', 'listing_register', '');
-
-        // Build query for searchObjectsPaginated.
-        $query = [];
-
-        // Add metadata filters.
-        if (empty($listingSchema) === false || empty($listingRegister) === false) {
-            $query['@self'] = [];
-            if (empty($listingSchema) === false) {
-                $query['@self']['schema'] = $listingSchema;
-            }
-
-            if (empty($listingRegister) === false) {
-                $query['@self']['register'] = $listingRegister;
-            }
+        // FAIL-CLOSED, and this is the reason the endpoint is written this way.
+        //
+        // This method used to read both keys with an `''` default and then build
+        // the `@self` filter under `if (empty($schema) === false || empty($register)
+        // === false)`. When BOTH keys were unset that condition was false, so no
+        // `@self` key was added at all and searchObjectsPaginated() ran with an
+        // unconstrained query — returning every object the caller may read across
+        // EVERY register and schema on the instance, served from /api/listings as
+        // though they were listings. The partial case leaked too: register set,
+        // schema empty scoped to the register and ignored the schema entirely.
+        //
+        // The endpoint is #[NoAdminRequired], so that is a scope loss available to
+        // any authenticated user on a not-yet-configured instance. destroy() below
+        // already refuses to run scope-less for exactly this reason ("OR's
+        // $hasScope check silently disables scoping"); index() was the same defect
+        // on the read side, unguarded.
+        //
+        // Resolving through the trait makes an unconfigured context a 503 that
+        // names the missing key, so the unscoped branch is unreachable rather than
+        // merely unlikely.
+        try {
+            $listingConfig = $this->getListingConfiguration();
+        } catch (\Throwable $e) {
+            return $this->registerConfigErrorResponse($e);
         }
+
+        $listingRegister = $listingConfig['register'];
+        $listingSchema   = $listingConfig['schema'];
+
+        // Build query for searchObjectsPaginated, always scoped.
+        $query = [
+            '@self' => [
+                'schema'   => $listingSchema,
+                'register' => $listingRegister,
+            ],
+        ];
 
         // Add any additional filters from request params.
         if (isset($requestParams['filters']) === true) {
@@ -241,9 +282,17 @@ class ListingsController extends Controller
      */
     public function show(string | int $id): JSONResponse
     {
-        // Get listing schema and register from configuration.
-        $listingRegister = $this->config->getValueString('opencatalogi', 'listing_register', '');
-        $listingSchema   = $this->config->getValueString('opencatalogi', 'listing_schema', '');
+        // Get listing register/schema from configuration; 503 if unconfigured.
+        // An `''` here would reach OR's setRegister('') and surface as an uncaught
+        // DoesNotExistException — a 500 that tells an operator nothing.
+        try {
+            $listingConfig = $this->getListingConfiguration();
+        } catch (\Throwable $e) {
+            return $this->registerConfigErrorResponse($e);
+        }
+
+        $listingRegister = $listingConfig['register'];
+        $listingSchema   = $listingConfig['schema'];
 
         // Fetch the listing object by its ID with register/schema context.
         $object = $this->getObjectService()->find($id, [], false, $listingRegister, $listingSchema);
@@ -313,9 +362,18 @@ class ListingsController extends Controller
             }
         }//end if
 
-        // Get listing schema and register from configuration.
-        $listingRegister = $this->config->getValueString('opencatalogi', 'listing_register', '');
-        $listingSchema   = $this->config->getValueString('opencatalogi', 'listing_schema', '');
+        // Get listing register/schema from configuration; 503 if unconfigured.
+        // Writing with an empty pair would let OR resolve the target scope from
+        // whatever its own defaults are, which is not the same thing as "the
+        // listing register".
+        try {
+            $listingConfig = $this->getListingConfiguration();
+        } catch (\Throwable $e) {
+            return $this->registerConfigErrorResponse($e);
+        }
+
+        $listingRegister = $listingConfig['register'];
+        $listingSchema   = $listingConfig['schema'];
 
         // Save the new listing object.
         $object = $this->getObjectService()->saveObject(
@@ -390,9 +448,15 @@ class ListingsController extends Controller
             }
         }
 
-        // Get listing schema and register from configuration.
-        $listingRegister = $this->config->getValueString('opencatalogi', 'listing_register', '');
-        $listingSchema   = $this->config->getValueString('opencatalogi', 'listing_schema', '');
+        // Get listing register/schema from configuration; 503 if unconfigured.
+        try {
+            $listingConfig = $this->getListingConfiguration();
+        } catch (\Throwable $e) {
+            return $this->registerConfigErrorResponse($e);
+        }
+
+        $listingRegister = $listingConfig['register'];
+        $listingSchema   = $listingConfig['schema'];
 
         // Load the existing listing and merge the allow-listed PUT body onto
         // it. OR's saveObject() treats its input as the full record —
@@ -537,8 +601,16 @@ class ListingsController extends Controller
         try {
             if ($id !== null) {
                 // Look up the listing to get its directory URL.
-                $listingRegister = $this->config->getValueString('opencatalogi', 'listing_register', '');
-                $listingSchema   = $this->config->getValueString('opencatalogi', 'listing_schema', '');
+                // 503 if unconfigured, for the same reason as show(): an unscoped
+                // find() is not a narrower search, it is a different one.
+                try {
+                    $listingConfig = $this->getListingConfiguration();
+                } catch (\Throwable $e) {
+                    return $this->registerConfigErrorResponse($e);
+                }
+
+                $listingRegister = $listingConfig['register'];
+                $listingSchema   = $listingConfig['schema'];
                 $object          = $this->getObjectService()->find($id, [], false, $listingRegister, $listingSchema);
                 $objectData      = $object;
                 if ($object instanceof \OCP\AppFramework\Db\Entity) {

--- a/tests/Unit/Controller/ListingsControllerTest.php
+++ b/tests/Unit/Controller/ListingsControllerTest.php
@@ -141,12 +141,50 @@ class ListingsControllerTest extends TestCase
         $this->appManager->method('getInstalledApps')
             ->willReturn(['openregister']);
 
+        // ResolvesRegisterConfiguration asks the container for two more things:
+        // OpenRegister's RegisterResolverService (which has not landed yet, so the
+        // trait's documented fallback path runs) and IAppConfig (which the fallback
+        // reads the keys through). A `->with('...ObjectService')` constraint here
+        // would turn either of those into a mock-expectation failure that looks
+        // like a controller bug, so route by id instead.
         $this->container->method('get')
-            ->with('OCA\OpenRegister\Service\ObjectService')
-            ->willReturn($mockObjService);
+            ->willReturnCallback(
+                function (string $id) use ($mockObjService) {
+                    if ($id === 'OCA\OpenRegister\Service\ObjectService') {
+                        return $mockObjService;
+                    }
+
+                    if ($id === \OCP\IAppConfig::class) {
+                        return $this->config;
+                    }
+
+                    throw new \RuntimeException('not available: '.$id);
+                }
+            );
 
         return $mockObjService;
     }//end mockObjectService()
+
+
+    /**
+     * Configure `listing_register` / `listing_schema` on the IAppConfig mock.
+     *
+     * @param string $register Value for listing_register.
+     * @param string $schema   Value for listing_schema.
+     *
+     * @return void
+     */
+    private function configureListingScope(string $register = '3', string $schema = '5'): void
+    {
+        $this->config->method('getValueString')
+            ->willReturnCallback(
+                static fn (string $app, string $key, string $default = '') => match ($key) {
+                    'listing_register' => $register,
+                    'listing_schema'   => $schema,
+                    default            => $default,
+                }
+            );
+    }//end configureListingScope()
 
     /**
      * Index() returns a 200 JSON response when OpenRegister is available.
@@ -160,8 +198,11 @@ class ListingsControllerTest extends TestCase
         $mockObjService->method('searchObjectsPaginated')
             ->willReturn(['results' => [], 'total' => 0]);
 
-        $this->config->method('getValueString')
-            ->willReturn('');
+        // This used to stub every config key to '' and still assert 200 — which
+        // is precisely the unscoped-search state index() must now refuse. The
+        // scope is configured here so the test exercises the normal path; the
+        // unconfigured path has its own test below.
+        $this->configureListingScope();
 
         $this->request->method('getParams')
             ->willReturn([]);
@@ -171,6 +212,141 @@ class ListingsControllerTest extends TestCase
         $this->assertInstanceOf(JSONResponse::class, $response);
         $this->assertEquals(200, $response->getStatus());
     }//end testIndexReturnsJsonResponse()
+
+
+    /**
+     * Index() refuses to run an unscoped search when the listing register/schema
+     * are unconfigured, and does not reach OpenRegister at all.
+     *
+     * Regression test for the fail-open this PR closes: with both keys empty the
+     * old code added no `@self` filter, so searchObjectsPaginated() ran with an
+     * unconstrained query and returned every object the caller could read across
+     * every register and schema on the instance — from a #[NoAdminRequired] GET.
+     *
+     * The `never()` expectation is the point. Asserting only on the status code
+     * would still pass if the controller queried first and then returned a 503,
+     * which would leak into logs, metrics and any cache in between.
+     *
+     * @return void
+     */
+    public function testIndexRefusesUnscopedSearchWhenRegisterConfigEmpty(): void
+    {
+        $mockObjService = $this->mockObjectService();
+
+        $mockObjService->expects($this->never())
+            ->method('searchObjectsPaginated');
+
+        $this->configureListingScope(register: '', schema: '');
+
+        $this->request->method('getParams')
+            ->willReturn([]);
+
+        $response = $this->controller->index();
+
+        $this->assertInstanceOf(JSONResponse::class, $response);
+        $this->assertEquals(503, $response->getStatus());
+        $this->assertSame('register_not_configured', $response->getData()['error']);
+    }//end testIndexRefusesUnscopedSearchWhenRegisterConfigEmpty()
+
+
+    /**
+     * A half-configured context is refused too.
+     *
+     * The old condition was `if (empty($schema) === false || empty($register) === false)`
+     * — an OR — so a configured register with an empty schema produced a query
+     * scoped to the register and silently unscoped across schemas. That is a
+     * smaller leak than the both-empty case, not a safe one.
+     *
+     * @return void
+     */
+    public function testIndexRefusesWhenOnlyOneOfRegisterOrSchemaIsConfigured(): void
+    {
+        $mockObjService = $this->mockObjectService();
+
+        $mockObjService->expects($this->never())
+            ->method('searchObjectsPaginated');
+
+        $this->configureListingScope(register: '3', schema: '');
+
+        $this->request->method('getParams')
+            ->willReturn([]);
+
+        $response = $this->controller->index();
+
+        $this->assertEquals(503, $response->getStatus());
+    }//end testIndexRefusesWhenOnlyOneOfRegisterOrSchemaIsConfigured()
+
+
+    /**
+     * The query handed to OpenRegister always carries the configured scope.
+     *
+     * Captures the actual argument rather than trusting the status code: a 200
+     * says the call happened, not that it was constrained.
+     *
+     * @return void
+     */
+    public function testIndexAlwaysScopesTheQueryToTheConfiguredRegisterAndSchema(): void
+    {
+        $mockObjService = $this->mockObjectService();
+
+        $captured = null;
+        $mockObjService->method('searchObjectsPaginated')
+            ->willReturnCallback(
+                function (array $query) use (&$captured) {
+                    $captured = $query;
+                    return ['results' => [], 'total' => 0];
+                }
+            );
+
+        $this->configureListingScope(register: '3', schema: '5');
+
+        $this->request->method('getParams')
+            ->willReturn([]);
+
+        $this->controller->index();
+
+        $this->assertIsArray($captured, 'searchObjectsPaginated was never called');
+        $this->assertArrayHasKey('@self', $captured);
+        $this->assertSame('3', $captured['@self']['register']);
+        $this->assertSame('5', $captured['@self']['schema']);
+    }//end testIndexAlwaysScopesTheQueryToTheConfiguredRegisterAndSchema()
+
+
+    /**
+     * A caller cannot widen the scope back out through request filters.
+     *
+     * index() already drops `schema` / `register` from `filters`; this pins that
+     * behaviour against the new always-scoped query so a future refactor cannot
+     * reintroduce caller-controlled scope.
+     *
+     * @return void
+     */
+    public function testIndexIgnoresCallerSuppliedRegisterAndSchemaFilters(): void
+    {
+        $mockObjService = $this->mockObjectService();
+
+        $captured = null;
+        $mockObjService->method('searchObjectsPaginated')
+            ->willReturnCallback(
+                function (array $query) use (&$captured) {
+                    $captured = $query;
+                    return ['results' => [], 'total' => 0];
+                }
+            );
+
+        $this->configureListingScope(register: '3', schema: '5');
+
+        $this->request->method('getParams')
+            ->willReturn(['filters' => ['register' => '999', 'schema' => '888', 'status' => 'active']]);
+
+        $this->controller->index();
+
+        $this->assertSame('3', $captured['@self']['register']);
+        $this->assertSame('5', $captured['@self']['schema']);
+        $this->assertArrayNotHasKey('register', $captured);
+        $this->assertArrayNotHasKey('schema', $captured);
+        $this->assertSame('active', $captured['status']);
+    }//end testIndexIgnoresCallerSuppliedRegisterAndSchemaFilters()
 
     /**
      * Index() honours filters, limit and offset request parameters.
@@ -205,10 +381,18 @@ class ListingsControllerTest extends TestCase
      *
      * @return void
      */
-    public function testIndexThrowsWhenOpenRegisterNotInstalled(): void
+    public function testIndexReturns503WhenOpenRegisterNotInstalled(): void
     {
+        // Previously this asserted a raw RuntimeException escaping the controller,
+        // i.e. a 500 with a stack trace. index() now resolves the register context
+        // BEFORE touching OpenRegister, and an unavailable container surfaces as
+        // the same operator-actionable 503 the sibling controllers return
+        // (cf. CatalogiControllerTest::testIndexReturns503WhenOpenRegisterNotInstalled).
         $this->appManager->method('getInstalledApps')
             ->willReturn([]);
+
+        $this->container->method('get')
+            ->willThrowException(new RuntimeException('not available'));
 
         $this->config->method('getValueString')
             ->willReturn('');
@@ -216,10 +400,11 @@ class ListingsControllerTest extends TestCase
         $this->request->method('getParams')
             ->willReturn([]);
 
-        $this->expectException(RuntimeException::class);
+        $response = $this->controller->index();
 
-        $this->controller->index();
-    }//end testIndexThrowsWhenOpenRegisterNotInstalled()
+        $this->assertInstanceOf(JSONResponse::class, $response);
+        $this->assertEquals(503, $response->getStatus());
+    }//end testIndexReturns503WhenOpenRegisterNotInstalled()
 
     /**
      * Show() returns the requested listing's data as a 200 JSON response.
@@ -237,8 +422,7 @@ class ListingsControllerTest extends TestCase
         $mockObjService->method('find')
             ->willReturn($mockEntity);
 
-        $this->config->method('getValueString')
-            ->willReturn('');
+        $this->configureListingScope();
 
         $response = $this->controller->show('123');
 
@@ -283,8 +467,7 @@ class ListingsControllerTest extends TestCase
         $mockObjService->method('saveObject')
             ->willReturn($mockEntity);
 
-        $this->config->method('getValueString')
-            ->willReturn('');
+        $this->configureListingScope();
 
         $this->request->method('getParams')
             ->willReturn(['title' => 'New Listing']);
@@ -347,8 +530,7 @@ class ListingsControllerTest extends TestCase
                     }
                     );
 
-        $this->config->method('getValueString')
-            ->willReturn('');
+        $this->configureListingScope();
 
         $this->request->method('getParams')
             ->willReturn(
@@ -428,8 +610,7 @@ class ListingsControllerTest extends TestCase
         $mockObjService->method('saveObject')
             ->willReturn($this->createMock(\OCA\OpenRegister\Db\ObjectEntity::class));
 
-        $this->config->method('getValueString')
-            ->willReturn('');
+        $this->configureListingScope();
 
         $this->request->method('getParams')
             ->willReturn(['title' => 'New Listing', 'directory' => 'https://federated-peer.example.com']);
@@ -456,8 +637,7 @@ class ListingsControllerTest extends TestCase
         $mockObjService->method('saveObject')
             ->willReturn($mockEntity);
 
-        $this->config->method('getValueString')
-            ->willReturn('');
+        $this->configureListingScope();
 
         $this->request->method('getParams')
             ->willReturn(['title' => 'Updated Listing']);


### PR DESCRIPTION
## The defect

`GET /api/listings` → `ListingsController::index()`, `#[NoAdminRequired]`, routed at `appinfo/routes.php:149`. On `development` (`9e63d9f3`):

```php
$listingSchema   = $this->config->getValueString('opencatalogi', 'listing_schema', '');
$listingRegister = $this->config->getValueString('opencatalogi', 'listing_register', '');

$query = [];
if (empty($listingSchema) === false || empty($listingRegister) === false) {
    $query['@self'] = [];
    if (empty($listingSchema) === false)   { $query['@self']['schema']   = $listingSchema; }
    if (empty($listingRegister) === false) { $query['@self']['register'] = $listingRegister; }
}
...
$data = $this->getObjectService()->searchObjectsPaginated($query);
```

When both keys are unset the condition is **false**, so no `@self` key is added at all and `searchObjectsPaginated()` runs with `[]` — an unconstrained query. `searchObjectsPaginated` defaults `$_rbac = true`, so it returns everything the caller *may* read — but that is every object across **every register and schema on the instance**, served from `/api/listings` as though it were a listing. RBAC is not scope; it decides who may read an object, not which register the endpoint is about.

The condition is an **OR**, so the half-configured case leaks as well: register set, schema empty → scoped to the register, unscoped across schemas.

This is not a hypothetical state. It is the state of every instance that has not yet run the setup wizard.

**The same controller already knows this is dangerous.** `destroy()` refuses to proceed, and says why in its own comment:

> FAIL-CLOSED: if either config key is empty, OR's `$hasScope` check silently disables scoping (`register !== null && schema !== null`), which reverts to the pre-fix behaviour. So we refuse the delete outright rather than letting the defence quietly evaporate.

`index()` was the identical defect on the read side, unguarded.

## The fix

Adopt `ResolvesRegisterConfiguration` — the trait this repo added for precisely this, per its own docblock: *"IAppConfig::getValueString(..., '') — the empty-string fallback that silently hides a misconfigured register/schema (audit .claude/audit-2026-05-03/04-hardcoded.md, Stream 4)"*. Six sibling controllers already use it: `CatalogiController`, `ThemesController`, `MenusController`, `PagesController`, `GlossaryController`, `OoapiController`. `ListingsController` was the register-backed controller that was never converted.

An unconfigured context now raises `MissingConfigException` → `registerConfigErrorResponse()` → **503 naming the missing key**, and the query is **unconditionally** scoped. The unscoped branch is removed, not made unlikely.

Applied to `index()`, `show()`, `create()`, `update()`, `synchronise()`. `destroy()` is deliberately untouched — it already has a correct fail-closed guard returning 409, and converting it would change that contract for no gain.

## Proof the fix can fail — and what the failure prints

Four new tests. Reverting **only** `lib/Controller/ListingsController.php` to `development`'s version and keeping the tests:

```
### CAN-FAIL ARM: controller reverted to development's version, new tests kept ###
.FF...E.......................                                    30 / 30 (100%)

1) testIndexRefusesUnscopedSearchWhenRegisterConfigEmpty
OCA\OpenRegister\Service\ObjectService::searchObjectsPaginated([], true, true, false, null, null, null): array was not expected to be called.
  /app/lib/Controller/ListingsController.php:222

2) testIndexRefusesWhenOnlyOneOfRegisterOrSchemaIsConfigured
OCA\OpenRegister\Service\ObjectService::searchObjectsPaginated([...], true, true, false, null, null, null): array was not expected to be called.
  /app/lib/Controller/ListingsController.php:222

ERRORS!
Tests: 30, Assertions: 64, Errors: 1, Failures: 2.
PHPUNIT_EXIT=2
```

PHPUnit prints the leak for us: **`searchObjectsPaginated([], ...)`** — the empty query, the unscoped search, from the mock's own failure message rather than from my description of it.

With the fix restored:

```
OK (30 tests, 70 assertions)
PHPUNIT_EXIT=0
```

The `never()` expectation is deliberate. Asserting only on the status code would still pass if the controller queried first and returned 503 afterwards — which would leak into logs, metrics and any cache in between.

The third arm (`testIndexReturns503WhenOpenRegisterNotInstalled`, `RuntimeException: OpenRegister service is not available`) is the pre-existing test I converted: it used to assert a raw exception escaping the controller — a 500 with a stack trace. It now asserts the same 503 the sibling controllers return (`CatalogiControllerTest::testIndexReturns503WhenOpenRegisterNotInstalled`).

**Six existing tests had to change, and that is the point.** `testIndexReturnsJsonResponse`, `testShowReturnsListingData`, `testCreateReturnsNewListing`, `testCreateAllowListsFieldsAndDropsOffListFields`, `testCreateAcceptsSafeDirectoryUrl` and `testUpdateReturnsUpdatedListing` all stubbed `getValueString → ''` and asserted **200**. They were pinning the unconfigured-and-serving behaviour as correct. They now configure the scope; the unconfigured path has its own tests.

## Measurements

Everything below ran under PHP 8.4 in a container. The host is PHP 8.2, where phpmd exits **255** — which reads like a clean run.

**gate-50 (security-config-fail-mode), full-tree:** `FAIL — 9` → `FAIL — 2`.

**PHPMD:** exit 0 (with the repo's baseline, unchanged — no entry added).

**PHPCS:** 0 errors. One warning remains: `Class ListingsController is missing @spec PHPDoc tag`. Proven **pre-existing** by running phpcs against the *base* tree on the same file, not by comparing counts:

```
# base tree (origin/development), lib/Controller/ListingsController.php
FOUND 0 ERRORS AND 1 WARNING AFFECTING 1 LINE
 58 | WARNING | Class ListingsController is missing @spec PHPDoc tag
```

**Full unit suite:** 1259 tests, 3075 assertions. 3 errors, all `Class "ZipArchive" not found` in `FileServiceTest` — my container lacks `ext-zip`; CI has it (`<lib>zip</lib>` is declared). Unrelated.

## The 2 remaining gate-50 findings are false positives, and I did not suppress them

```
lib/Service/DcatService.php:601: security-relevant config read of "catalog_register" has no fail-mode guard within 10 lines
lib/Service/DcatService.php:602: security-relevant config read of "catalog_schema"   has no fail-mode guard within 10 lines
```

The guard is on the very next line:

```php
601  $register = $this->appConfig->getValueString('opencatalogi', 'catalog_register', '');
602  $schema   = $this->appConfig->getValueString('opencatalogi', 'catalog_schema', '');
603  if ($register === '' || $schema === '') {
604      return [];
605  }
```

Two independent parts of gate-50's rule miss it:

1. Its empty-string pattern is `if\s*\(\s*[\$\w\->]+\s*(===|!==|==|!=)\s*['\"]{2}\s*\)` — the `)` must come **immediately** after the `''`. Here `''` is followed by ` || `, so **a compound guard never matches**. That is exactly the shape a two-key register/schema guard takes.
2. Its early-return alternative is only `return new JSONResponse|Response|DataResponse`. A *service* cannot return a `JSONResponse`, yet the gate scopes itself to `(Controller|Service)[^/]*\.php$` — so the early-return escape is structurally unreachable for every file under `lib/Service/`.

`DcatService` is correct as written. Adding a redundant single-condition `if` there to satisfy a regex would be comment-satisfaction with extra steps.

## And one thing gate-50 got backwards

Gate-50 marked lines **185–186** — the very lines this PR fixes — as **PASS**, because the literal `if (empty(` at line 192 falls inside its 10-line window. It matched the token and never asked which way the branch falls, nor whether the guard mentions the variable that was read. So the gate reported a correct guard in `DcatService` as a violation *and* accepted the actual scope-loss in `ListingsController` as guarded — failing in both directions inside one 700-line file. That is why this finding came from reading the code rather than from the gate's verdict, and it is being reported separately to `ConductionNL/.github`.

## Not verified

Not exercised against a live instance — there is no running `nextcloud` container in this environment. The evidence is the unit-level `never()` expectation plus the argument capture asserting `@self.register` / `@self.schema` are present on every call.
