### PR TITLE
fix(settings): add canonical PUT /api/settings (settings#update)

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -34,6 +34,10 @@ return [
 		// Global Configuration
 		['name' => 'settings#index', 'url' => '/api/settings', 'verb' => 'GET'],
 		['name' => 'settings#create', 'url' => '/api/settings', 'verb' => 'POST'],
+		// Canonical AppHost write verb (OpenRegister\AppHost\Routes): PUT is the canonical
+		// settings write and the POST above is the legacy alias. Measured 2026-08-08: without
+		// this entry PUT /api/settings returned 405 (no route for the verb).
+		['name' => 'settings#update', 'url' => '/api/settings', 'verb' => 'PUT'],
 		['name' => 'settings#load', 'url' => '/api/settings/load', 'verb' => 'GET'],
 		// Generic per-user preferences (used by shared nextcloud-vue widgets, e.g. CnSupportDialog) —
 		// served by OpenRegister's AppHost GenericPreferencesController (aliased in Application::register).

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -89,21 +89,42 @@ class SettingsController extends Controller
     }//end index()
 
     /**
-     * Handle the post request to update settings.
+     * Write the app-configuration settings and return the persisted values.
      *
-     * Admin-only (no @NoAdminRequired → NC SecurityMiddleware default enforces admin gate).
-     * CSRF protection is enforced (no @NoCSRFRequired).
-     * #[AuthorizedAdminSetting] makes this endpoint auditable via NC's delegated-admin
-     * system and scopes it to the OpenCatalogiAdmin settings class (WF3 / wave-12).
+     * This is the canonical write in OpenRegister's AppHost dialect
+     * ({@see \OCA\OpenRegister\AppHost\Routes}), where `PUT /api/settings` maps to
+     * `settings#update` and `POST /api/settings` (`settings#create`) is the legacy
+     * alias. OpenCatalogi hand-declares its own route table and ships its own
+     * SettingsController, so `AppHost\Bootstrap::aliasControllerUnlessLeafDefinesIt()`
+     * never aliases the generic in — this leaf owes every `settings#` method itself.
+     * Measured 2026-08-08 on the dev instance: `PUT /api/settings` returned 405
+     * (no route for the verb) while GET and POST returned 200.
+     *
+     * Scope: this writes ONLY the app-configuration payload that `create()` has
+     * always written — `SettingsService::updateSettings()` persists the
+     * allowlisted `*_source` / `*_schema` / `*_register`, DCAT, OOAPI, publishing
+     * and Woo-index keys via `IAppConfig`. It deliberately does NOT absorb the
+     * other surfaces this controller happens to host: `updatePublishingOptions()`
+     * (POST /api/settings/publishing) and `manualImport()`
+     * (POST /api/settings/import) keep their own routes, payload shapes and
+     * response contracts.
+     *
+     * Auth posture is identical to `create()` — admin-only (no @NoAdminRequired,
+     * so NC SecurityMiddleware enforces the admin gate) and auditable via NC's
+     * delegated-admin system through #[AuthorizedAdminSetting], scoped to
+     * OpenCatalogiAdmin. `@NoCSRFRequired` mirrors `create()` because the admin
+     * UI (`src/views/settings/Settings.vue`) calls this endpoint with a bare
+     * `fetch()` that sends no `requesttoken` header. Net privilege change is
+     * zero: the identical operation was already reachable via POST.
      *
      * @return JSONResponse JSON response containing the updated settings.
      *
      * @NoCSRFRequired
      *
-     * @spec openspec/specs/admin-settings/spec.md
+     * @spec openspec/specs/admin-settings/spec.md#requirement-admin-settings-page-loads-and-saves-configuration-set-or-006
      */
     #[AuthorizedAdminSetting(settings: OpenCatalogiAdmin::class)]
-    public function create(): JSONResponse
+    public function update(): JSONResponse
     {
         try {
             $data   = $this->request->getParams();
@@ -112,6 +133,36 @@ class SettingsController extends Controller
         } catch (\Exception $e) {
             return new JSONResponse(data: ['error' => $e->getMessage()], statusCode: 500);
         }
+
+    }//end update()
+
+    /**
+     * Legacy alias for {@see update()} — handles the post request to update settings.
+     *
+     * The canonical AppHost route table still ships `settings#create`
+     * (POST /api/settings) for the pre-ADR-066 `index/create/load` dialect, and
+     * OpenCatalogi's own admin UI (`src/views/settings/Settings.vue`, both
+     * `saveConfiguration()` and `saveRegistration()`) still POSTs here, so this
+     * stays reachable and behaviourally identical (ADR-029).
+     *
+     * The attributes below are repeated rather than inherited from `update()`:
+     * NC's SecurityMiddleware evaluates the attributes of the *dispatched* method,
+     * so delegating in the body does not carry `update()`'s posture across.
+     *
+     * Admin-only (no @NoAdminRequired → NC SecurityMiddleware default enforces admin gate).
+     * #[AuthorizedAdminSetting] makes this endpoint auditable via NC's delegated-admin
+     * system and scopes it to the OpenCatalogiAdmin settings class (WF3 / wave-12).
+     *
+     * @return JSONResponse JSON response containing the updated settings.
+     *
+     * @NoCSRFRequired
+     *
+     * @spec openspec/specs/admin-settings/spec.md#requirement-admin-settings-page-loads-and-saves-configuration-set-or-006
+     */
+    #[AuthorizedAdminSetting(settings: OpenCatalogiAdmin::class)]
+    public function create(): JSONResponse
+    {
+        return $this->update();
 
     }//end create()
 

--- a/openspec/specs/admin-settings/spec.md
+++ b/openspec/specs/admin-settings/spec.md
@@ -251,7 +251,8 @@ required keys before first use.
 | Method | Endpoint | Description |
 |--------|----------|-------------|
 | GET | `/api/settings` | Get current settings (authenticated) |
-| POST | `/api/settings` | Update settings (admin only) |
+| PUT | `/api/settings` | Update settings — canonical write, OR AppHost dialect (admin only) |
+| POST | `/api/settings` | Update settings — legacy alias for `PUT`, delegates to it (admin only) |
 | GET | `/api/settings/load` | Load settings from publication_register.json (admin only) |
 | GET | `/api/settings/publishing` | Get publishing options (authenticated) |
 | POST | `/api/settings/publishing` | Update publishing options (admin only) |

--- a/tests/Unit/AppInfo/CanonicalSettingsRouteContractTest.php
+++ b/tests/Unit/AppInfo/CanonicalSettingsRouteContractTest.php
@@ -1,0 +1,297 @@
+<?php
+/**
+ * OpenCatalogi canonical settings route/method contract test.
+ *
+ * @category Test
+ * @package  OCA\OpenCatalogi\Tests
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @link https://www.OpenCatalogi.nl
+ *
+ * @spec openspec/specs/admin-settings/spec.md#requirement-admin-settings-page-loads-and-saves-configuration-set-or-006
+ */
+
+declare(strict_types=1);
+
+namespace Unit\AppInfo;
+
+use OCA\OpenCatalogi\Controller\SettingsController;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+
+/**
+ * The canonical AppHost route table ({@see \OCA\OpenRegister\AppHost\Routes})
+ * makes `PUT /api/settings` -> `settings#update` the canonical settings write
+ * and `POST /api/settings` -> `settings#create` the legacy alias.
+ *
+ * OpenCatalogi does NOT call `Routes::standard()` — it hand-declares
+ * `appinfo/routes.php` — and it ships its own `SettingsController`, so
+ * `OCA\OpenRegister\AppHost\Bootstrap::aliasControllerUnlessLeafDefinesIt()`
+ * skips the DI alias to the generic controller entirely. That leaves both
+ * halves of the contract owed by this leaf app, and they fail differently:
+ *
+ *   - Route entry missing -> the router never matches the verb and the
+ *     request dies with a 405 Method Not Allowed. Measured 2026-08-08 on the
+ *     dev instance: `PUT /api/settings` -> 405, while GET and POST -> 200.
+ *   - Method missing but routed -> the router matches, the dispatcher
+ *     reflects the method, and the request dies with a 500 (and gate-14,
+ *     route-reachability, flags the unreachable entry).
+ *
+ * Both halves are asserted here so neither can land without the other.
+ *
+ * Every assertion targets the ITEM (each individual method / each individual
+ * route entry), never the container (the controller class or the routes array
+ * merely existing).
+ */
+class CanonicalSettingsRouteContractTest extends TestCase
+{
+
+    /**
+     * The canonical settings dialect: route name => [url, verb].
+     *
+     * `update` is the canonical write; `create` is the legacy alias that must
+     * stay reachable because OpenCatalogi's own admin UI still POSTs to it.
+     *
+     * @var array<string, array{url: string, verb: string}>
+     */
+    private const CANONICAL_SETTINGS_ROUTES = [
+        'settings#update' => [
+            'url'  => '/api/settings',
+            'verb' => 'PUT',
+        ],
+        'settings#create' => [
+            'url'  => '/api/settings',
+            'verb' => 'POST',
+        ],
+        'settings#index'  => [
+            'url'  => '/api/settings',
+            'verb' => 'GET',
+        ],
+    ];
+
+    /**
+     * Load `appinfo/routes.php` and return its `routes` array.
+     *
+     * Evaluates the file as PHP rather than grepping it, so a route that is
+     * commented out, unreachable behind a conditional, or in a different array
+     * cannot masquerade as registered.
+     *
+     * @return array<int, array<string, mixed>> The route entries.
+     */
+    private function loadRoutes(): array
+    {
+        $routes = include __DIR__.'/../../../appinfo/routes.php';
+
+        $this->assertIsArray($routes, 'appinfo/routes.php must return an array');
+        $this->assertArrayHasKey('routes', $routes, 'appinfo/routes.php must expose a "routes" key');
+
+        return $routes['routes'];
+
+    }//end loadRoutes()
+
+    /**
+     * Every canonical settings route MUST be present in `appinfo/routes.php`
+     * with the exact url and verb the AppHost dialect specifies.
+     *
+     * @spec openspec/specs/admin-settings/spec.md#requirement-admin-settings-page-loads-and-saves-configuration-set-or-006
+     *
+     * @return void
+     */
+    public function testCanonicalSettingsRoutesAreRegistered(): void
+    {
+        $routes = $this->loadRoutes();
+
+        // Index the declared table by "name VERB url" so the assertion below
+        // compares the whole triple, not just the presence of a name.
+        $declared = [];
+        foreach ($routes as $route) {
+            $declared[] = $route['name'].' '.strtoupper((string) $route['verb']).' '.$route['url'];
+        }
+
+        // Positive control: the scan must actually have seen the route table.
+        // Without this, an empty or mis-shaped $routes would make every
+        // "missing" assertion below fail loudly rather than a filter silently
+        // matching nothing.
+        $this->assertGreaterThan(
+            0,
+            count($declared),
+            'Positive control failed: appinfo/routes.php yielded no route entries at all.'
+        );
+
+        $inspected = 0;
+        foreach (self::CANONICAL_SETTINGS_ROUTES as $name => $spec) {
+            $inspected++;
+            $expected = $name.' '.$spec['verb'].' '.$spec['url'];
+
+            $this->assertContains(
+                $expected,
+                $declared,
+                'Canonical settings route "'.$expected.'" is not declared in appinfo/routes.php. '.
+                'Without it the verb has no route and the request returns 405 Method Not Allowed.'
+            );
+        }
+
+        // Positive control: the expectation table itself must be non-empty.
+        $this->assertSame(
+            count(self::CANONICAL_SETTINGS_ROUTES),
+            $inspected,
+            'Positive control failed: not every canonical route expectation was inspected.'
+        );
+
+    }//end testCanonicalSettingsRoutesAreRegistered()
+
+    /**
+     * `PUT /api/settings` specifically MUST resolve to `settings#update`.
+     *
+     * Asserted on its own (rather than only as part of the table above) because
+     * this is the exact entry whose absence produced the measured 405.
+     *
+     * @spec openspec/specs/admin-settings/spec.md#requirement-admin-settings-page-loads-and-saves-configuration-set-or-006
+     *
+     * @return void
+     */
+    public function testPutApiSettingsRoutesToSettingsUpdate(): void
+    {
+        $matches = [];
+
+        foreach ($this->loadRoutes() as $route) {
+            if ($route['url'] === '/api/settings' && strtoupper((string) $route['verb']) === 'PUT') {
+                $matches[] = $route['name'];
+            }
+        }
+
+        $this->assertSame(
+            ['settings#update'],
+            $matches,
+            'Expected exactly one PUT /api/settings route targeting settings#update.'
+        );
+
+    }//end testPutApiSettingsRoutesToSettingsUpdate()
+
+    /**
+     * Each canonical settings method MUST exist on SettingsController and be
+     * public (i.e. dispatchable by NC's controller dispatcher).
+     *
+     * Asserts the ITEM — each individual method — never merely that the
+     * SettingsController class exists.
+     *
+     * @spec openspec/specs/admin-settings/spec.md#requirement-admin-settings-page-loads-and-saves-configuration-set-or-006
+     *
+     * @return void
+     */
+    public function testCanonicalSettingsMethodsExistAndArePublic(): void
+    {
+        $inspected = 0;
+
+        foreach (array_keys(self::CANONICAL_SETTINGS_ROUTES) as $name) {
+            [, $methodName] = explode('#', $name, 2);
+
+            $this->assertTrue(
+                method_exists(SettingsController::class, $methodName),
+                'SettingsController::'.$methodName.'() does not exist, but appinfo/routes.php routes "'.
+                $name.'" to it. OpenCatalogi ships its own SettingsController, so the OpenRegister '.
+                'AppHost generic is never aliased in and cannot supply this method.'
+            );
+
+            $method = new ReflectionMethod(SettingsController::class, $methodName);
+
+            $this->assertTrue(
+                $method->isPublic(),
+                'SettingsController::'.$methodName.'() must be public to be dispatchable.'
+            );
+            $this->assertFalse(
+                $method->isStatic(),
+                'SettingsController::'.$methodName.'() must not be static.'
+            );
+            $this->assertFalse(
+                $method->isAbstract(),
+                'SettingsController::'.$methodName.'() must not be abstract.'
+            );
+
+            $inspected++;
+        }//end foreach
+
+        // Positive control: a loop that matched nothing would otherwise pass
+        // silently with zero assertions executed.
+        $this->assertGreaterThan(
+            0,
+            $inspected,
+            'Positive control failed: no canonical settings methods were inspected.'
+        );
+        $this->assertSame(count(self::CANONICAL_SETTINGS_ROUTES), $inspected);
+
+    }//end testCanonicalSettingsMethodsExistAndArePublic()
+
+    /**
+     * `update()` and `create()` MUST carry the same auth posture.
+     *
+     * NC's SecurityMiddleware evaluates the attributes of the *dispatched*
+     * method, so `create()` delegating to `update()` in its body does not carry
+     * `update()`'s posture across — each needs its own. This test is what stops
+     * the new PUT verb from silently becoming more privileged than the POST it
+     * mirrors (net privilege change must be zero).
+     *
+     * @spec openspec/specs/admin-settings/spec.md#requirement-admin-settings-page-loads-and-saves-configuration-set-or-006
+     *
+     * @return void
+     */
+    public function testUpdateAndCreateShareTheSameAuthPosture(): void
+    {
+        $attributeNamesFor = static function (string $methodName): array {
+            $method = new ReflectionMethod(SettingsController::class, $methodName);
+            $names  = array_map(
+                static fn($attribute): string => $attribute->getName(),
+                $method->getAttributes()
+            );
+            sort($names);
+
+            return $names;
+        };
+
+        $updateAttributes = $attributeNamesFor('update');
+        $createAttributes = $attributeNamesFor('create');
+
+        // Positive control: the reflection must actually have found attributes.
+        // An empty-vs-empty comparison would pass while proving nothing.
+        $this->assertNotEmpty(
+            $updateAttributes,
+            'Positive control failed: SettingsController::update() carries no attributes at all.'
+        );
+
+        $this->assertSame(
+            $createAttributes,
+            $updateAttributes,
+            'SettingsController::update() and ::create() must carry identical auth attributes.'
+        );
+
+        // The write reaches instance-wide IAppConfig, so it must be admin-gated
+        // and auditable via NC's delegated-admin system.
+        $this->assertContains(
+            \OCP\AppFramework\Http\Attribute\AuthorizedAdminSetting::class,
+            $updateAttributes,
+            'SettingsController::update() writes instance-wide config and must be admin-gated.'
+        );
+
+        // It must NOT be downgraded to a non-admin endpoint.
+        $this->assertNotContains(
+            \OCP\AppFramework\Http\Attribute\NoAdminRequired::class,
+            $updateAttributes,
+            'SettingsController::update() must never carry #[NoAdminRequired] — it writes instance-wide config.'
+        );
+
+        $updateDoc = (new ReflectionMethod(SettingsController::class, 'update'))->getDocComment();
+        $this->assertIsString($updateDoc, 'Positive control failed: update() has no docblock to inspect.');
+        $this->assertSame(
+            0,
+            preg_match('/^\s*\*\s*@NoAdminRequired\b/m', $updateDoc),
+            'SettingsController::update() must not carry the @NoAdminRequired docblock tag.'
+        );
+
+    }//end testUpdateAndCreateShareTheSameAuthPosture()
+}//end class

--- a/tests/Unit/Controller/SettingsControllerTest.php
+++ b/tests/Unit/Controller/SettingsControllerTest.php
@@ -114,6 +114,114 @@ class SettingsControllerTest extends TestCase
         $this->assertEquals(500, $response->getStatus());
     }
 
+    /**
+     * `update()` is the canonical write (PUT /api/settings): it passes the
+     * request params straight to SettingsService::updateSettings() and returns
+     * the persisted values.
+     *
+     * @spec openspec/specs/admin-settings/spec.md#requirement-admin-settings-page-loads-and-saves-configuration-set-or-006
+     */
+    public function testUpdateWritesRequestParamsAndReturnsPersistedValues(): void
+    {
+        $params = ['catalog_register' => '1', 'catalog_schema' => '5'];
+        $result = ['catalog_register' => '1', 'catalog_schema' => '5'];
+
+        $this->request->expects($this->once())
+            ->method('getParams')
+            ->willReturn($params);
+
+        $this->settingsService->expects($this->once())
+            ->method('updateSettings')
+            ->with($params)
+            ->willReturn($result);
+
+        $response = $this->controller->update();
+
+        $this->assertInstanceOf(JSONResponse::class, $response);
+        $this->assertEquals(200, $response->getStatus());
+        $this->assertSame($result, $response->getData());
+    }
+
+    /**
+     * `update()` surfaces a service failure as a 500 with the error message,
+     * matching the shape `create()` has always returned.
+     *
+     * @spec openspec/specs/admin-settings/spec.md#requirement-admin-settings-page-loads-and-saves-configuration-set-or-006
+     */
+    public function testUpdateReturns500OnException(): void
+    {
+        $this->request->method('getParams')
+            ->willReturn(['invalid' => 'data']);
+
+        $this->settingsService->method('updateSettings')
+            ->willThrowException(new \Exception('Update failed'));
+
+        $response = $this->controller->update();
+
+        $this->assertInstanceOf(JSONResponse::class, $response);
+        $this->assertEquals(500, $response->getStatus());
+        $this->assertSame(['error' => 'Update failed'], $response->getData());
+    }
+
+    /**
+     * `create()` (the legacy POST alias) delegates to `update()` and is
+     * behaviourally identical — same service call, same payload out.
+     *
+     * @spec openspec/specs/admin-settings/spec.md#requirement-admin-settings-page-loads-and-saves-configuration-set-or-006
+     */
+    public function testCreateDelegatesToUpdate(): void
+    {
+        $params = ['theme_register' => '2'];
+        $result = ['theme_register' => '2'];
+
+        $this->request->method('getParams')
+            ->willReturn($params);
+
+        // The single expectation is the proof of delegation: create() must
+        // reach updateSettings() exactly once, via update().
+        $this->settingsService->expects($this->once())
+            ->method('updateSettings')
+            ->with($params)
+            ->willReturn($result);
+
+        $createResponse = $this->controller->create();
+
+        $this->assertInstanceOf(JSONResponse::class, $createResponse);
+        $this->assertEquals(200, $createResponse->getStatus());
+        $this->assertSame($result, $createResponse->getData());
+    }
+
+    /**
+     * `update()` is the app-configuration write, not a catch-all: it must not
+     * absorb the sibling surfaces this controller also hosts. Those keep their
+     * own routes (`POST /api/settings/publishing`, `POST /api/settings/import`)
+     * and their own payload and response contracts.
+     *
+     * @spec openspec/specs/admin-settings/spec.md#requirement-admin-settings-page-loads-and-saves-configuration-set-or-006
+     */
+    public function testUpdateDoesNotTouchPublishingOptionsOrImportSurfaces(): void
+    {
+        $this->request->method('getParams')
+            ->willReturn(['auto_publish_objects' => 'true']);
+
+        $this->settingsService->expects($this->once())
+            ->method('updateSettings')
+            ->willReturn(['auto_publish_objects' => 'true']);
+
+        // update() routes everything through updateSettings(); the dedicated
+        // publishing-options and import entry points must stay untouched.
+        $this->settingsService->expects($this->never())
+            ->method('updatePublishingOptions');
+        $this->settingsService->expects($this->never())
+            ->method('getPublishingOptions');
+        $this->settingsService->expects($this->never())
+            ->method('manualImport');
+
+        $response = $this->controller->update();
+
+        $this->assertEquals(200, $response->getStatus());
+    }
+
     public function testLoadReturnsSettings(): void
     {
         $loadedSettings = ['registers' => [], 'schemas' => [], 'imported' => true];


### PR DESCRIPTION
## Summary

Adds the canonical `PUT /api/settings` (`settings#update`) write to OpenCatalogi, converging it on OpenRegister's AppHost settings dialect. **Strict addition — nothing is removed, and `POST` keeps working identically.**

## ⚠️ This is a 405 / missing-route case, not the fleet's 500 / missing-method case

The fleet-wide brief said `PUT /api/settings` "resolves to a nonexistent method" (a 500). **That is not what opencatalogi does.** Measured on the running dev instance, 2026-08-08, printing the status code explicitly:

```
curl -s -o /dev/null -w "%{http_code}" -X GET  -u admin:admin http://localhost:8080/apps/opencatalogi/api/settings  -> 200
curl -s -o /dev/null -w "%{http_code}" -X PUT  -u admin:admin http://localhost:8080/apps/opencatalogi/api/settings  -> 405   ← Method Not Allowed
curl -s -o /dev/null -w "%{http_code}" -X POST -u admin:admin http://localhost:8080/apps/opencatalogi/api/settings  -> 200
```

**405, not 500.** The reason: opencatalogi does **not** call `\OCA\OpenRegister\AppHost\Routes::standard()` — it hand-declares `appinfo/routes.php` (it aliases dashboard/preferences by FQCN, but declares `settings#*` plainly). There was `settings#index` (GET) and `settings#create` (POST) on `/api/settings`, but no entry for the PUT verb at all, so the router never matched and NC answered 405. The method was not merely missing — the route was.

Because opencatalogi ships its own `lib/Controller/SettingsController.php`, OpenRegister's `AppHost\Bootstrap::aliasControllerUnlessLeafDefinesIt()` skips the DI alias to the generic controller entirely, so this leaf owes every `settings#` method itself. Both halves — route **and** method — land together; a method without a route would be unreachable and trip gate-14.

> Side note: the empty `POST` probe above had no side effect. `SettingsService::updateSettings()` writes only allowlisted keys, so an empty payload wrote nothing — a re-`GET` was byte-identical to the pre-probe response.

## What `update()` writes, and what it deliberately does *not*

`update()` carries the body `create()` has always had: `$this->request->getParams()` → `SettingsService::updateSettings($data)` → `JSONResponse` of the persisted values, with the same 500-on-exception shape.

That service persists **only the app-configuration payload** via `IAppConfig` — the allowlisted `{type}_source` / `{type}_schema` / `{type}_register` keys, plus the DCAT, OOAPI-consumer, publishing-option and Woo-index-registration keys.

It deliberately does **not** absorb the other surfaces this controller happens to host. They keep their own routes, payload shapes and response contracts:

| Surface | Route | Left untouched |
|---|---|---|
| `updatePublishingOptions()` | `POST /api/settings/publishing` | ✅ |
| `getPublishingOptions()` | `GET /api/settings/publishing` | ✅ |
| `manualImport()` | `POST /api/settings/import` | ✅ |
| `getVersionInfo()` | `GET /api/settings/version` | ✅ |
| `load()` | `GET /api/settings/load` | ✅ |

There is a dedicated test asserting `update()` never reaches `updatePublishingOptions()`, `getPublishingOptions()` or `manualImport()` — i.e. it is the config write, not a catch-all.

## Auth decision

**`update()` gets exactly the same posture as `create()`. Net privilege change: zero.**

I read opencatalogi's actual `create()` attributes rather than copying a sibling. This controller genuinely mixes postures — `index()`, `getPublishingOptions()` and `getVersionInfo()` carry `@NoAdminRequired` (reads, with an in-body logged-in guard), while `create()` does not. Copying a *read* method's `@NoAdminRequired` onto this write would have exposed instance-wide `IAppConfig` to any authenticated user. It was not copied.

Both methods now carry, verified by reflection using NC's own `ControllerMethodReflector` regex:

```
index    annotations=[NoAdminRequired,NoCSRFRequired] attributes=[]
update   annotations=[NoCSRFRequired]                 attributes=[AuthorizedAdminSetting]
create   annotations=[NoCSRFRequired]                 attributes=[AuthorizedAdminSetting]
```

`update` and `create` are **identical**, and neither carries `@NoAdminRequired` — so NC's SecurityMiddleware enforces the admin gate on both, scoped and made auditable through `#[AuthorizedAdminSetting(OpenCatalogiAdmin::class)]`.

The attributes are **repeated on both methods rather than inherited**: the middleware evaluates the attributes of the *dispatched* method, so `create()` delegating to `update()` in its body does not carry the posture across. A test asserts the two postures stay equal so the new PUT verb can never drift more privileged than the POST it mirrors.

### On `@NoCSRFRequired` — kept deliberately, and it is load-bearing

`create()` already carried `@NoCSRFRequired`, so `update()` mirrors it. I checked whether it could simply be dropped, and **it cannot**: the admin UI calls this endpoint with a bare `fetch()` that sends no `requesttoken` header —

`src/views/settings/Settings.vue` (`saveConfiguration()` L749, `saveRegistration()` L970) both do `fetch('/index.php/apps/opencatalogi/api/settings', { method: 'POST', headers: { 'Content-Type': 'application/json' }, ... })`.

Removing the tag would break saving admin settings. Docblock annotations are still live in this NC (`ControllerMethodReflector::hasAnnotation`), so this is not dead syntax.

⚠️ **Flagging a pre-existing weakness, not fixed here:** an admin-only, state-changing endpoint with CSRF disabled is a genuine CSRF exposure — a logged-in admin visiting a hostile page could have the app's register/schema mappings rewritten. Closing it requires changing the frontend `fetch()` calls to send the request token, which is out of scope for a convergence PR that must not change behaviour. Raising it here rather than silently propagating it. Note the pre-existing docblock also *claimed* "CSRF protection is enforced (no @NoCSRFRequired)" directly above a live `@NoCSRFRequired` tag; that inaccurate sentence is corrected.

## Can-fail proof

The tests were shown to fail before being shown to pass. Both halves removed with the editor (not `git stash` / `git checkout --`), then restored.

**1. `update()` removed → RED, naming the method:**
```
1) CanonicalSettingsRouteContractTest::testUpdateAndCreateShareTheSameAuthPosture
ReflectionException: Method OCA\OpenCatalogi\Controller\SettingsController::update() does not exist
...
1) CanonicalSettingsRouteContractTest::testCanonicalSettingsMethodsExistAndArePublic
SettingsController::update() does not exist, but appinfo/routes.php routes "settings#update" to it.
ERRORS! Tests: 28, Assertions: 111, Errors: 8, Failures: 1.
```

**2. Route line removed (method intact) → RED on the route tests:**
```
1) CanonicalSettingsRouteContractTest::testCanonicalSettingsRoutesAreRegistered
Canonical settings route "settings#update PUT /api/settings" is not declared in appinfo/routes.php.
Without it the verb has no route and the request returns 405 Method Not Allowed.
2) CanonicalSettingsRouteContractTest::testPutApiSettingsRoutesToSettingsUpdate
FAILURES! Tests: 28, Assertions: 269, Failures: 2.
```

**3. Both restored → GREEN (full unit suite):**
```
Tests: 1270, Assertions: 3153, Warnings: 4, Deprecations: 66, Skipped: 2.
```
(0 errors, 0 failures.)

## Tests

New `tests/Unit/AppInfo/CanonicalSettingsRouteContractTest.php`:
- **Evaluates** the array returned by `appinfo/routes.php` — it does not grep the file, so a commented-out or conditionally-unreachable entry cannot masquerade as registered.
- Asserts the **item, not the container**: each individual canonical method exists and is public, non-static, non-abstract — never merely that `SettingsController` exists.
- Asserts `PUT /api/settings` resolves to exactly `settings#update`.
- **Positive controls** throughout, so a scan that matched nothing cannot pass silently (`assertGreaterThan(0, count($declared))`, `$inspected` counts compared against the expectation table, and a non-empty-attributes check so an empty-vs-empty posture comparison cannot pass while proving nothing).

Added to `SettingsControllerTest`: `update()` writes the request params and returns the persisted payload; its 500 path; `create()` delegates to `update()` (proved by a single `expects($this->once())` on the service); and the non-absorption test above.

### Coverage — new statements are covered

Measured with pcov (`pcov.directory` set; the first run reported a nonsense 0.00% across 10026 lines, which was a broken measurement rather than a result, and was fixed before being believed):

- `SettingsController.php`: **93.88% lines (46/49)**, and both new entry points execute — `update()` 6 hits, `create()` 3 hits.
- The only 3 uncovered lines are pre-existing `'Not logged in'` guards in `index()` / `getPublishingOptions()` / `getVersionInfo()` — none are new.
- Repo total **77.79%**, comfortably above the `.coverage-baseline` floor of `70.69`. No waiver used.

## Mechanical gates

Run with a **freshly extracted** runner: the local `.github` checkout is **77 commits behind `origin/main`** (`git rev-list --left-right --count` → `77 1`), and its runner differs by 660 insertions / 2456 deletions — a materially different program. The stale copy was not trusted.

Verdicts read from **stdout, never the exit byte** — the byte was `11`, exactly the "11 gate(s) failed" count, the count-returned-as-exit-status shape again.

**Diff-scoped run (`--scope-to-diff`, 5 changed files) → exactly one finding, and it is a false positive.** The gates called out in review all passed on the full-repo run: **gate-1 spdx PASS · gate-5 route-auth PASS · gate-9 semantic-auth PASS · gate-14 route-reachability PASS · gate-16 spec-coverage PASS · gate-46 spec-anchor-existence** — my anchor is *not* among its unresolved targets (those 4 are pre-existing: `federation/spec.md` and three `retrofit-*` change dirs). `settings#update` likewise does not appear in gate-25's list (those 9 are pre-existing *public* endpoints — ooapi/retention/woo; this endpoint is admin-only). The other 10 full-repo failures are pre-existing repo debt in files this PR does not touch (a11y gates, manifest gates blocked on ajv not being resolvable, etc.).

### 🐛 gate-48 `csrf-cochange` — false positive, please do not act on it

> `FAIL — @NoCSRFRequired dropped without frontend CSRF co-change`

**No `@NoCSRFRequired` tag was dropped.** The gate matched a removed line of *prose*:

```
-     * CSRF protection is enforced (no @NoCSRFRequired).
```

That was the inaccurate sentence described above. The real docblock tags went **up**:

```
BASE (origin/development): 7    ← grep -cE "^\s*\*\s*@NoCSRFRequired\s*$"
HEAD (this branch):        8
```

and the reflection dump above confirms `create()` still carries its annotation. The gate greps removed lines for `@NoCSRFRequired` without excluding comments/prose — the same "greps a literal, so it matches every comment" shape as the gate-64 bug. Worth fixing in the gate; deliberately **not** worked around here, because deleting a correct documentation fix to appease a buggy grep would be the wrong trade.

## Not measurable in this environment (stated, not claimed as a pass)

- **PHPStan**: reports 2256 errors, but `vendor/nextcloud/ocp` symbols do not resolve in the bare `php:8.4-cli` container — 2140 are direct "class not found / unknown class", and all 116 remaining are downstream of the same failure (`does not extend any class`, `Attribute class ... does not exist`). This affects the whole repo equally and is unrelated to this change. CI runs it correctly.
- **PHPCS** (which lints `lib` only) **is** measurable and is clean: `lib/Controller/SettingsController.php` → **0 errors**, 1 warning, byte-identical to the same file on `origin/development` (a pre-existing class-level `@spec` warning). No regression.
- 3 `ZipArchive not found` errors in the bare image were environmental (`ext-zip` is a declared app requirement absent from that image); they vanish once the extension is installed, giving the clean 1270-test run above.

## Files changed

- `lib/Controller/SettingsController.php` — add `update()`; `create()` becomes `return $this->update();`, keeping its own attributes. SPDX / `@license` / `@copyright` preserved.
- `appinfo/routes.php` — add `settings#update` on `PUT /api/settings` (tabs, matching the file).
- `openspec/specs/admin-settings/spec.md` — document the PUT row in the API-endpoints table. No Scenario added or modified, so gate-19's diff-scoped e2e rule is not engaged.
- `tests/Unit/AppInfo/CanonicalSettingsRouteContractTest.php` (new), `tests/Unit/Controller/SettingsControllerTest.php`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### Gate opt-out (gate-48 only), using the gate's own documented mechanism

[hydra-gate-csrf-cochange exclude] Provably a false positive: no @NoCSRFRequired docblock tag was removed by this PR. The gate greps removed lines in lib/Controller/*.php for the bare token and cannot distinguish a real tag from PROSE; the only line it matched is the stale, factually-wrong comment "CSRF protection is enforced (no @NoCSRFRequired)." which sat directly above a live @NoCSRFRequired tag and is corrected here. Real tag count went UP, not down: 7 on origin/development, 8 on this branch, measured with grep -cE "^\s*\*\s*@NoCSRFRequired\s*$". Reflection through NC's own ControllerMethodReflector regex confirms create() still carries NoCSRFRequired and update() now carries the identical posture, so no endpoint lost CSRF protection and no frontend co-change is owed. Scoped to this gate alone; every other gate passes on the diff-scoped run.
