### PR TITLE
fix(security): enforce CSRF on the admin settings writes

### DIFF
--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -112,14 +112,23 @@ class SettingsController extends Controller
      * Auth posture is identical to `create()` — admin-only (no @NoAdminRequired,
      * so NC SecurityMiddleware enforces the admin gate) and auditable via NC's
      * delegated-admin system through #[AuthorizedAdminSetting], scoped to
-     * OpenCatalogiAdmin. `@NoCSRFRequired` mirrors `create()` because the admin
-     * UI (`src/views/settings/Settings.vue`) calls this endpoint with a bare
-     * `fetch()` that sends no `requesttoken` header. Net privilege change is
-     * zero: the identical operation was already reachable via POST.
+     * OpenCatalogiAdmin.
+     *
+     * CSRF is ENFORCED here (no `@NoCSRFRequired`). This is a state-changing
+     * admin endpoint: with the annotation present, any page the admin visited
+     * could silently rewrite this instance's register/schema configuration
+     * cross-origin, because the admin gate is carried by the session cookie the
+     * browser attaches automatically. The annotation used to be justified by the
+     * admin UI calling this with a bare `fetch()` that sends no `requesttoken`;
+     * that justification was a description of a frontend defect, not a reason.
+     * `src/views/settings/Settings.vue` now issues this write through
+     * `@nextcloud/axios`, which attaches `requesttoken` to every request.
+     *
+     * Non-browser API clients are unaffected: NC's `Request::passesCSRFCheck()`
+     * returns true unconditionally for any request carrying `OCS-APIRequest`,
+     * which is what `tests/e2e/ci-seed.sh` already sends.
      *
      * @return JSONResponse JSON response containing the updated settings.
-     *
-     * @NoCSRFRequired
      *
      * @spec openspec/specs/admin-settings/spec.md#requirement-admin-settings-page-loads-and-saves-configuration-set-or-006
      */
@@ -153,9 +162,11 @@ class SettingsController extends Controller
      * #[AuthorizedAdminSetting] makes this endpoint auditable via NC's delegated-admin
      * system and scopes it to the OpenCatalogiAdmin settings class (WF3 / wave-12).
      *
-     * @return JSONResponse JSON response containing the updated settings.
+     * CSRF is ENFORCED here (no `@NoCSRFRequired`), for the reason given on
+     * {@see update()}: this is the same state-changing admin write under a
+     * second verb, so exempting it would leave the identical hole open.
      *
-     * @NoCSRFRequired
+     * @return JSONResponse JSON response containing the updated settings.
      *
      * @spec openspec/specs/admin-settings/spec.md#requirement-admin-settings-page-loads-and-saves-configuration-set-or-006
      */
@@ -214,12 +225,23 @@ class SettingsController extends Controller
     /**
      * Update the publishing options.
      *
-     * @return JSONResponse JSON response containing the updated publishing options.
+     * CSRF is ENFORCED here (no `@NoCSRFRequired`) — see {@see update()}. This is
+     * a state-changing admin write; `auto_publish_attachments` /
+     * `auto_publish_objects` decide whether uploaded material becomes publicly
+     * readable, so a cross-origin forgery here has a disclosure consequence.
      *
-     * @NoCSRFRequired
+     * Admin-only (no @NoAdminRequired → NC SecurityMiddleware default enforces the
+     * admin gate). #[AuthorizedAdminSetting] matches `update()` / `create()` and
+     * makes this write auditable through NC's delegated-admin system. Until now
+     * this method's ONLY posture declaration was `@NoCSRFRequired`, so it was
+     * the sole marker gate-5 could see; dropping that annotation without adding
+     * this one would have left the method with no declared posture at all.
+     *
+     * @return JSONResponse JSON response containing the updated publishing options.
      *
      * @spec openspec/specs/admin-settings/spec.md
      */
+    #[AuthorizedAdminSetting(settings: OpenCatalogiAdmin::class)]
     public function updatePublishingOptions(): JSONResponse
     {
         try {
@@ -260,12 +282,24 @@ class SettingsController extends Controller
     /**
      * Manually trigger configuration import.
      *
-     * @return JSONResponse JSON response containing import results.
+     * CSRF is ENFORCED here (no `@NoCSRFRequired`) — see {@see update()}. This
+     * rewrites the app's register/schema configuration from the shipped
+     * configuration file, which is the most consequential write in this
+     * controller. `tests/e2e/ci-seed.sh` drives it with `OCS-APIRequest: true`,
+     * which NC's `Request::passesCSRFCheck()` honours unconditionally, so the
+     * seeding path is unaffected.
      *
-     * @NoCSRFRequired
+     * Admin-only (no @NoAdminRequired → NC SecurityMiddleware default enforces the
+     * admin gate). #[AuthorizedAdminSetting] matches `update()` / `create()` and
+     * makes this write auditable through NC's delegated-admin system; as with
+     * `updatePublishingOptions()`, `@NoCSRFRequired` had been this method's only
+     * posture declaration.
+     *
+     * @return JSONResponse JSON response containing import results.
      *
      * @spec openspec/specs/admin-settings/spec.md
      */
+    #[AuthorizedAdminSetting(settings: OpenCatalogiAdmin::class)]
     public function manualImport(): JSONResponse
     {
         try {

--- a/lib/Controller/WooReadinessController.php
+++ b/lib/Controller/WooReadinessController.php
@@ -85,9 +85,15 @@ class WooReadinessController extends Controller
      * HTTP 409 `not-configured` and zero outbound requests when no WOO-enabled catalog
      * exists (WOO-HR-004) — the configuration check runs BEFORE any fetch.
      *
-     * @return JSONResponse The freshly computed and persisted report, or a 409 error.
+     * CSRF is ENFORCED here (no `@NoCSRFRequired`), unlike the read-only
+     * `report()` beside it. This POST both PERSISTS a report and issues outbound
+     * HTTP requests to the configured public WOO surface, so a forged
+     * cross-origin call would let any page the admin visits drive this
+     * instance's outbound fetches and overwrite the stored report.
+     * `src/views/settings/Settings.vue` calls it through `@nextcloud/axios`,
+     * which sends `requesttoken`.
      *
-     * @NoCSRFRequired
+     * @return JSONResponse The freshly computed and persisted report, or a 409 error.
      *
      * @spec openspec/changes/woo-index-harvester-readiness/specs/woo-compliance/spec.md#requirement-readiness-endpoints-are-admin-gated-and-fail-closed-woo-hr-004
      */

--- a/src/views/settings/Settings.vue
+++ b/src/views/settings/Settings.vue
@@ -288,6 +288,17 @@ import Refresh from 'vue-material-design-icons/Refresh.vue'
 import CheckCircle from 'vue-material-design-icons/CheckCircle.vue'
 import CloseCircle from 'vue-material-design-icons/CloseCircle.vue'
 import MinusCircle from 'vue-material-design-icons/MinusCircle.vue'
+// Every state-changing call below goes through @nextcloud/axios rather than a
+// bare fetch(). It attaches the `requesttoken` header Nextcloud's
+// SecurityMiddleware checks, which is what lets the settings write endpoints
+// drop `@NoCSRFRequired` (see lib/Controller/SettingsController.php::update()).
+// A bare fetch() sends no such header, so those endpoints had to be exempted
+// from CSRF entirely — an admin-only, state-changing endpoint with CSRF off is
+// forgeable from any page the admin happens to visit.
+// axios also rejects on a non-2xx status, which the previous `await fetch(...)`
+// calls did not check at all: a 403 or 500 was indistinguishable from a save.
+import axios from '@nextcloud/axios'
+import { generateUrl } from '@nextcloud/router'
 
 /**
  * @class Settings
@@ -745,14 +756,9 @@ export default defineComponent({
 					configToSave[`${type}_schema`] = config.schema ? config.schema.value : ''
 				})
 
-				// Send configuration to backend
-				await fetch('/index.php/apps/opencatalogi/api/settings', {
-					method: 'POST',
-					headers: {
-						'Content-Type': 'application/json',
-					},
-					body: JSON.stringify(configToSave),
-				})
+				// Send configuration to backend. PUT is the canonical settings
+				// write (`settings#update`); POST remains only as a legacy alias.
+				await axios.put(generateUrl('/apps/opencatalogi/api/settings'), configToSave)
 			} catch (error) {
 				console.error('Failed to save settings:', error)
 			} finally {
@@ -806,15 +812,9 @@ export default defineComponent({
 				}
 
 				// Send configuration to backend using the dedicated publishing options endpoint
-				const response = await fetch('/index.php/apps/opencatalogi/api/settings/publishing', {
-					method: 'POST',
-					headers: {
-						'Content-Type': 'application/json',
-					},
-					body: JSON.stringify(configToSave),
-				})
+				const response = await axios.post(generateUrl('/apps/opencatalogi/api/settings/publishing'), configToSave)
 
-				const result = await response.json()
+				const result = response.data
 
 				if (result.error) {
 					console.error('Failed to save publishing options:', result.error)
@@ -871,15 +871,9 @@ export default defineComponent({
 			this.importResult = null
 
 			try {
-				const response = await fetch('/index.php/apps/opencatalogi/api/settings/import', {
-					method: 'POST',
-					headers: {
-						'Content-Type': 'application/json',
-					},
-					body: JSON.stringify({ force }),
-				})
+				const response = await axios.post(generateUrl('/apps/opencatalogi/api/settings/import'), { force })
 
-				const result = await response.json()
+				const result = response.data
 				this.importResult = result
 
 				// If successful, update version info and reload settings
@@ -931,24 +925,21 @@ export default defineComponent({
 			this.wooReadinessError = null
 
 			try {
-				const response = await fetch('/index.php/apps/opencatalogi/api/woo/readiness/run', {
-					method: 'POST',
-					headers: {
-						'Content-Type': 'application/json',
-					},
-				})
+				const response = await axios.post(generateUrl('/apps/opencatalogi/api/woo/readiness/run'))
 
-				const data = await response.json()
-
-				if (!response.ok) {
+				this.wooReadinessReport = response.data
+			} catch (error) {
+				// axios rejects on a non-2xx status, so the 409 `not-configured`
+				// branch that used to sit behind `if (!response.ok)` lives here
+				// now. The error body is still the server's JSON payload.
+				const data = error.response?.data
+				if (data !== undefined) {
 					this.wooReadinessError = data.error === 'not-configured'
 						? this.t('opencatalogi', 'No Woo-enabled catalog is configured yet — enable Woo sitemaps on a catalog first.')
 						: (data.error || this.t('opencatalogi', 'Readiness check failed.'))
 					return
 				}
 
-				this.wooReadinessReport = data
-			} catch (error) {
 				console.error('Failed to run Woo readiness check:', error)
 				this.wooReadinessError = this.t('opencatalogi', 'Readiness check failed.')
 			} finally {
@@ -967,16 +958,10 @@ export default defineComponent({
 			this.savingRegistration = true
 
 			try {
-				await fetch('/index.php/apps/opencatalogi/api/settings', {
-					method: 'POST',
-					headers: {
-						'Content-Type': 'application/json',
-					},
-					body: JSON.stringify({
-						woo_index_registration_status: this.registration.status ? this.registration.status.value : 'not_registered',
-						woo_index_registration_url: this.registration.registeredUrl,
-						woo_index_registration_at: this.registration.registeredAt,
-					}),
+				await axios.put(generateUrl('/apps/opencatalogi/api/settings'), {
+					woo_index_registration_status: this.registration.status ? this.registration.status.value : 'not_registered',
+					woo_index_registration_url: this.registration.registeredUrl,
+					woo_index_registration_at: this.registration.registeredAt,
 				})
 			} catch (error) {
 				console.error('Failed to save Woo-index registration status:', error)

--- a/tests/e2e/spec-coverage/gate19.spec.ts
+++ b/tests/e2e/spec-coverage/gate19.spec.ts
@@ -337,12 +337,47 @@ test.describe('admin-settings', () => {
 		// @e2e admin-settings::save-admin-settings
 		'SET-015 — POST /api/settings endpoint is accessible and accepts data',
 		async ({ request }) => {
+			// `OCS-APIRequest: true` is what makes this a legitimate API client.
+			// Nextcloud's Request::passesCSRFCheck() returns true unconditionally
+			// for a request carrying that header; a browser-shaped request must
+			// instead carry `requesttoken`.
+			//
+			// Before this header was added, this assertion passed BECAUSE the
+			// endpoint was `@NoCSRFRequired` — i.e. the test was pinning the
+			// vulnerable posture as correct, and would have gone red on the fix.
+			// The companion test below is the positive control that proves CSRF
+			// is now actually enforced.
+			const resp = await request.post('/index.php/apps/opencatalogi/api/settings', {
+				data: {},
+				headers: { 'Content-Type': 'application/json', 'OCS-APIRequest': 'true' },
+			})
+			// 200 (saved), 400 (validation error), 401 (auth), 403 (admin required) are all acceptable
+			expect([200, 400, 401, 403]).toContain(resp.status())
+		},
+	)
+
+	/**
+	 * SET-015 — the settings write REFUSES a request with no CSRF token.
+	 * GIVEN a state-changing admin endpoint
+	 * WHEN it is called browser-shaped (no `requesttoken`, no `OCS-APIRequest`)
+	 * THEN Nextcloud MUST reject it with 412 Precondition Failed.
+	 *
+	 * This is the positive control for the test above: without it, re-adding
+	 * `@NoCSRFRequired` to SettingsController::update()/create() would make the
+	 * whole suite green again and nothing would notice.
+	 */
+	test(
+		// @e2e admin-settings::save-admin-settings
+		'SET-015 — POST /api/settings is refused without a CSRF token',
+		async ({ request }) => {
 			const resp = await request.post('/index.php/apps/opencatalogi/api/settings', {
 				data: {},
 				headers: { 'Content-Type': 'application/json' },
 			})
-			// 200 (saved), 400 (validation error), 401 (auth), 403 (admin required) are all acceptable
-			expect([200, 400, 401, 403]).toContain(resp.status())
+			expect(
+				resp.status(),
+				'a tokenless, browser-shaped write must be refused — 412 is NC\'s CrossSiteRequestForgeryException status',
+			).toBe(412)
 		},
 	)
 
@@ -356,9 +391,11 @@ test.describe('admin-settings', () => {
 		// @e2e admin-settings::run-a-manual-import
 		'SET-015 — POST /api/settings/import endpoint is accessible',
 		async ({ request }) => {
+			// See the note on SET-015 POST /api/settings above — `OCS-APIRequest`
+			// is the API-client posture, and it is what ci-seed.sh already sends.
 			const resp = await request.post('/index.php/apps/opencatalogi/api/settings/import', {
 				data: {},
-				headers: { 'Content-Type': 'application/json' },
+				headers: { 'Content-Type': 'application/json', 'OCS-APIRequest': 'true' },
 			})
 			// 200 (import ran), 400 (bad request/unconfigured), 401/403 (auth/admin), 500 are valid
 			expect([200, 400, 401, 403, 500]).toContain(resp.status())


### PR DESCRIPTION
## What

Five admin-only, **state-changing** endpoints carried `@NoCSRFRequired`:

| endpoint | route |
|---|---|
| `settings#update` / `settings#create` | `PUT`/`POST /api/settings` |
| `settings#updatePublishingOptions` | `POST /api/settings/publishing` |
| `settings#manualImport` | `POST /api/settings/import` |
| `wooReadiness#run` | `POST /api/woo/readiness/run` |

The admin gate on these is carried by the **session cookie**, which the browser attaches automatically. With CSRF off, any page an admin visited could rewrite this instance's register/schema configuration, flip `auto_publish_attachments` / `auto_publish_objects` (which decide whether uploaded material becomes publicly readable), re-run the configuration import, or drive the readiness check's outbound fetches — cross-origin, with no token.

## Why the annotation was there, and why that was not a reason

It was justified in-tree by the admin UI calling these with a bare `fetch()` that sends no `requesttoken`. That is a description of a **frontend defect**, not a reason — so the frontend is fixed first. `src/views/settings/Settings.vue` now issues all five writes through `@nextcloud/axios`, which attaches `requesttoken`.

`axios` also rejects on a non-2xx status. Two of these call sites did `await fetch(...)` and **never looked at the result**, so a 403 or a 500 was indistinguishable from a successful save.

## Two tests were pinning the vulnerability as correct

`SET-015`'s `POST /api/settings` and `POST /api/settings/import` asserted a status in `[200,400,401,403]`. That passed **only because CSRF was disabled** — both would have gone red on this fix. They now send `OCS-APIRequest: true`, the legitimate API-client posture `ci-seed.sh` already uses.

A **new companion test is the positive control**: the same write with no token must be refused with `412`. Without it, re-adding `@NoCSRFRequired` would make the suite green again and nothing would notice.

## Measured, not assumed (NC 34, dev container)

- `CrossSiteRequestForgeryException` **and** `StrictCookieMissingException` both map to `412` — the control asserts the right code either way.
- `Request::passesCSRFCheck()` returns `true` unconditionally when `OCS-APIRequest` is present, and `cookieCheckRequired()` returns `false` for it → **`ci-seed.sh`'s basic-auth seeding is unaffected**.
- `SecurityMiddleware` sets `$authorized = isAdminUser()` for `#[AuthorizedAdminSetting]` → a plain admin still passes.

## A regression this change caused, and fixed

`updatePublishingOptions()` and `manualImport()` declared their auth posture **only** via `@NoCSRFRequired`. Dropping it left them with no declared posture at all — **gate-5 route-auth went PASS → 2 findings**. Both now carry `#[AuthorizedAdminSetting(OpenCatalogiAdmin)]`, matching `update()`/`create()`, and gate-5 is back to PASS.

Read-only GETs (`index`, `load`, `getPublishingOptions`, `getVersionInfo`, `wooReadiness#report`) **keep** `@NoCSRFRequired`: a CSRF token protects state change, and cross-origin reads are already prevented by the same-origin policy.

## Gate evidence

`[hydra-gates] gate package: 48c88ba1e0d049f8f38538c33e790d3e603c55d0`, `--scope-to-diff --base origin/development`:

| gate | before | after |
|---|---|---|
| gate-48 csrf-cochange | **FAIL** | **PASS** |
| gate-5 route-auth | PASS → FAIL(2) mid-change | **PASS** |
| gate-47 security-change-has-tests | PASS | PASS |

Every other gate's finding **count** is byte-identical to `origin/development` (compared by count, not verdict).

Also verified: `php -l` clean; PHPCS 0 errors (1 pre-existing class-level `@spec` warning); `eslint` 0 errors; `SettingsControllerTest` + `WooReadinessControllerTest` = **25 tests / 59 assertions OK**, run under **PHP 8.3** in a container because the host PHP is 8.2 and the repo floor is 8.3.