### PR TITLE
fix(spec): point 26 @spec tags at canonical specs that exist

### DIFF
--- a/lib/Controller/CatalogiController.php
+++ b/lib/Controller/CatalogiController.php
@@ -178,7 +178,7 @@ class CatalogiController extends Controller
      * @NoCSRFRequired
      * @PublicPage
      *
-     * @spec openspec/changes/retrofit-2026-05-25-cross-origin-api-access/tasks.md#task-1
+     * @spec openspec/specs/cross-origin-api-access/spec.md#requirement-answer-cors-preflight-requests-on-public-api-controllers-cor-001
      */
     public function preflightedCors(): Response
     {

--- a/lib/Controller/DirectoryController.php
+++ b/lib/Controller/DirectoryController.php
@@ -145,7 +145,7 @@ class DirectoryController extends Controller
      * @NoCSRFRequired
      * @PublicPage
      *
-     * @spec openspec/changes/retrofit-2026-05-25-cross-origin-api-access/tasks.md#task-1
+     * @spec openspec/specs/cross-origin-api-access/spec.md#requirement-answer-cors-preflight-requests-on-public-api-controllers-cor-001
      */
     public function preflightedCors(): Response
     {

--- a/lib/Controller/GlossaryController.php
+++ b/lib/Controller/GlossaryController.php
@@ -184,7 +184,7 @@ class GlossaryController extends Controller
      * @NoCSRFRequired
      * @PublicPage
      *
-     * @spec openspec/changes/retrofit-2026-05-25-cross-origin-api-access/tasks.md#task-1
+     * @spec openspec/specs/cross-origin-api-access/spec.md#requirement-answer-cors-preflight-requests-on-public-api-controllers-cor-001
      */
     public function preflightedCors(): Response
     {

--- a/lib/Controller/MenusController.php
+++ b/lib/Controller/MenusController.php
@@ -176,7 +176,7 @@ class MenusController extends Controller
      * @NoCSRFRequired
      * @PublicPage
      *
-     * @spec openspec/changes/retrofit-2026-05-25-cross-origin-api-access/tasks.md#task-1
+     * @spec openspec/specs/cross-origin-api-access/spec.md#requirement-answer-cors-preflight-requests-on-public-api-controllers-cor-001
      */
     public function preflightedCors(): Response
     {

--- a/lib/Controller/PagesController.php
+++ b/lib/Controller/PagesController.php
@@ -185,7 +185,7 @@ class PagesController extends Controller
      * @NoCSRFRequired
      * @PublicPage
      *
-     * @spec openspec/changes/retrofit-2026-05-25-cross-origin-api-access/tasks.md#task-1
+     * @spec openspec/specs/cross-origin-api-access/spec.md#requirement-answer-cors-preflight-requests-on-public-api-controllers-cor-001
      */
     public function preflightedCors(): Response
     {

--- a/lib/Controller/PublicationsController.php
+++ b/lib/Controller/PublicationsController.php
@@ -408,7 +408,7 @@ class PublicationsController extends Controller
      * @NoCSRFRequired
      * @PublicPage
      *
-     * @spec openspec/changes/retrofit-2026-05-25-cross-origin-api-access/tasks.md#task-1
+     * @spec openspec/specs/cross-origin-api-access/spec.md#requirement-answer-cors-preflight-requests-on-public-api-controllers-cor-001
      */
     public function preflightedCors(): Response
     {

--- a/lib/Controller/SearchController.php
+++ b/lib/Controller/SearchController.php
@@ -190,7 +190,7 @@ class SearchController extends Controller
      * @NoAdminRequired
      * @NoCSRFRequired
      *
-     * @spec openspec/changes/retrofit-2026-05-25-search/tasks.md#task-5
+     * @spec openspec/specs/federation/spec.md#requirement-retrieve-a-single-publication-by-id-from-local-or-federated-sources-fed-002
      */
     public function show(string $id): JSONResponse
     {
@@ -216,7 +216,7 @@ class SearchController extends Controller
      * @NoAdminRequired
      * @NoCSRFRequired
      *
-     * @spec openspec/changes/retrofit-2026-05-25-search/tasks.md#task-6
+     * @spec openspec/specs/federation/spec.md#requirement-retrieve-publication-attachments-from-local-or-federated-sources-fed-005
      */
     public function attachments(string $id): JSONResponse
     {
@@ -242,7 +242,7 @@ class SearchController extends Controller
      * @NoAdminRequired
      * @NoCSRFRequired
      *
-     * @spec openspec/changes/retrofit-2026-05-25-search/tasks.md#task-7
+     * @spec openspec/specs/federation/spec.md#requirement-download-publication-files-from-local-or-federated-sources-fed-006
      */
     public function download(string $id): DataDownloadResponse|JSONResponse
     {
@@ -269,7 +269,7 @@ class SearchController extends Controller
      * @NoAdminRequired
      * @NoCSRFRequired
      *
-     * @spec openspec/changes/retrofit-2026-05-25-search/tasks.md#task-8
+     * @spec openspec/specs/federation/spec.md#requirement-retrieve-outgoing-relations-uses-with-federation-support-fed-003
      */
     public function uses(string $id): JSONResponse
     {
@@ -296,7 +296,7 @@ class SearchController extends Controller
      * @NoAdminRequired
      * @NoCSRFRequired
      *
-     * @spec openspec/changes/retrofit-2026-05-25-search/tasks.md#task-9
+     * @spec openspec/specs/federation/spec.md#requirement-retrieve-incoming-relations-used-by-with-federation-support-fed-004
      */
     public function used(string $id): JSONResponse
     {

--- a/lib/Controller/ThemesController.php
+++ b/lib/Controller/ThemesController.php
@@ -171,7 +171,7 @@ class ThemesController extends Controller
      * @NoCSRFRequired
      * @PublicPage
      *
-     * @spec openspec/changes/retrofit-2026-05-25-cross-origin-api-access/tasks.md#task-1
+     * @spec openspec/specs/cross-origin-api-access/spec.md#requirement-answer-cors-preflight-requests-on-public-api-controllers-cor-001
      */
     public function preflightedCors(): Response
     {

--- a/lib/Controller/UiController.php
+++ b/lib/Controller/UiController.php
@@ -33,7 +33,7 @@ use OCP\IRequest;
  *
  * @SuppressWarnings(PHPMD.TooManyPublicMethods)
  *
- * @spec openspec/changes/retrofit-2026-05-25-spa-deep-link-routing/tasks.md#task-1
+ * @spec openspec/specs/spa-deep-link-routing/spec.md#requirement-serve-the-spa-shell-for-every-top-level-deep-link-route-spa-001
  */
 class UiController extends Controller
 {
@@ -89,7 +89,7 @@ class UiController extends Controller
      * @NoAdminRequired
      * @NoCSRFRequired
      *
-     * @spec openspec/changes/retrofit-2026-05-25-spa-deep-link-routing/tasks.md#task-1
+     * @spec openspec/specs/spa-deep-link-routing/spec.md#requirement-serve-the-spa-shell-for-every-top-level-deep-link-route-spa-001
      */
     public function dashboard(): TemplateResponse
     {
@@ -105,7 +105,7 @@ class UiController extends Controller
      * @NoAdminRequired
      * @NoCSRFRequired
      *
-     * @spec openspec/changes/retrofit-2026-05-25-spa-deep-link-routing/tasks.md#task-1
+     * @spec openspec/specs/spa-deep-link-routing/spec.md#requirement-serve-the-spa-shell-for-every-top-level-deep-link-route-spa-001
      */
     public function catalogi(): TemplateResponse
     {
@@ -121,7 +121,7 @@ class UiController extends Controller
      * @NoAdminRequired
      * @NoCSRFRequired
      *
-     * @spec openspec/changes/retrofit-2026-05-25-spa-deep-link-routing/tasks.md#task-1
+     * @spec openspec/specs/spa-deep-link-routing/spec.md#requirement-serve-the-spa-shell-for-every-top-level-deep-link-route-spa-001
      */
     public function publicationsIndex(): TemplateResponse
     {
@@ -137,7 +137,7 @@ class UiController extends Controller
      * @NoAdminRequired
      * @NoCSRFRequired
      *
-     * @spec openspec/changes/retrofit-2026-05-25-spa-deep-link-routing/tasks.md#task-1
+     * @spec openspec/specs/spa-deep-link-routing/spec.md#requirement-serve-the-spa-shell-for-every-top-level-deep-link-route-spa-001
      */
     public function publicationsPage(): TemplateResponse
     {
@@ -153,7 +153,7 @@ class UiController extends Controller
      * @NoAdminRequired
      * @NoCSRFRequired
      *
-     * @spec openspec/changes/retrofit-2026-05-25-spa-deep-link-routing/tasks.md#task-1
+     * @spec openspec/specs/spa-deep-link-routing/spec.md#requirement-serve-the-spa-shell-for-every-top-level-deep-link-route-spa-001
      */
     public function search(): TemplateResponse
     {
@@ -169,7 +169,7 @@ class UiController extends Controller
      * @NoAdminRequired
      * @NoCSRFRequired
      *
-     * @spec openspec/changes/retrofit-2026-05-25-spa-deep-link-routing/tasks.md#task-1
+     * @spec openspec/specs/spa-deep-link-routing/spec.md#requirement-serve-the-spa-shell-for-every-top-level-deep-link-route-spa-001
      */
     public function organizations(): TemplateResponse
     {
@@ -185,7 +185,7 @@ class UiController extends Controller
      * @NoAdminRequired
      * @NoCSRFRequired
      *
-     * @spec openspec/changes/retrofit-2026-05-25-spa-deep-link-routing/tasks.md#task-1
+     * @spec openspec/specs/spa-deep-link-routing/spec.md#requirement-serve-the-spa-shell-for-every-top-level-deep-link-route-spa-001
      */
     public function themes(): TemplateResponse
     {
@@ -201,7 +201,7 @@ class UiController extends Controller
      * @NoAdminRequired
      * @NoCSRFRequired
      *
-     * @spec openspec/changes/retrofit-2026-05-25-spa-deep-link-routing/tasks.md#task-1
+     * @spec openspec/specs/spa-deep-link-routing/spec.md#requirement-serve-the-spa-shell-for-every-top-level-deep-link-route-spa-001
      */
     public function glossary(): TemplateResponse
     {
@@ -217,7 +217,7 @@ class UiController extends Controller
      * @NoAdminRequired
      * @NoCSRFRequired
      *
-     * @spec openspec/changes/retrofit-2026-05-25-spa-deep-link-routing/tasks.md#task-1
+     * @spec openspec/specs/spa-deep-link-routing/spec.md#requirement-serve-the-spa-shell-for-every-top-level-deep-link-route-spa-001
      */
     public function pages(): TemplateResponse
     {
@@ -233,7 +233,7 @@ class UiController extends Controller
      * @NoAdminRequired
      * @NoCSRFRequired
      *
-     * @spec openspec/changes/retrofit-2026-05-25-spa-deep-link-routing/tasks.md#task-1
+     * @spec openspec/specs/spa-deep-link-routing/spec.md#requirement-serve-the-spa-shell-for-every-top-level-deep-link-route-spa-001
      */
     public function menus(): TemplateResponse
     {
@@ -249,7 +249,7 @@ class UiController extends Controller
      * @NoAdminRequired
      * @NoCSRFRequired
      *
-     * @spec openspec/changes/retrofit-2026-05-25-spa-deep-link-routing/tasks.md#task-1
+     * @spec openspec/specs/spa-deep-link-routing/spec.md#requirement-serve-the-spa-shell-for-every-top-level-deep-link-route-spa-001
      */
     public function directory(): TemplateResponse
     {

--- a/src/modals/directory/FederationAddDirectoryModal.vue
+++ b/src/modals/directory/FederationAddDirectoryModal.vue
@@ -62,7 +62,7 @@ export default {
 		 * POST the peer directory URL to /api/listings/add.
 		 *
 		 * @return {Promise<void>}
-		 * @spec openspec/specs/federation/spec.md#requirement-federated-directory-visibility
+		 * @spec openspec/specs/dashboard/spec.md#requirement-add-a-new-listing-from-a-url-admin-only-dir-005
 		 */
 		async submit() {
 			const trimmed = this.url.trim()

--- a/src/views/search/FederationSearch.vue
+++ b/src/views/search/FederationSearch.vue
@@ -66,7 +66,7 @@ export default {
 		 *
 		 * @param {{query: string, facets: object}} payload Event payload.
 		 * @return {Promise<void>}
-		 * @spec openspec/specs/federation/spec.md#requirement-federated-search-visibility
+		 * @spec openspec/specs/search/spec.md#requirement-search-frontend-store-calls-the-federation-endpoint-sch-or-004
 		 */
 		onSearch(payload) {
 			const query = typeof payload === 'string' ? payload : (payload?.query ?? '')


### PR DESCRIPTION
**gate-46 spec-anchor-existence: 26 findings from 9 targets → 0.**

`[hydra-gates] gate package: 48c88ba1e0d049f8f38538c33e790d3e603c55d0`, full-repository run. `gate-16` spec-coverage stays PASS, every other gate's finding **count** is unchanged, and the runner's **stderr is empty**.

## The shape of the problem

Every one of the 26 findings was a tag pointing into a **change directory**. Change dirs are transient — they get archived — which is exactly how 26 tags went stale at once. A `@spec` tag belongs on the canonical `openspec/specs/{capability}` spec, so these are retargeted there rather than having the change dirs resurrected.

**Nothing was excluded and no tag was deleted.** Deleting a tag to stop the gate looking is the one outcome worse than the finding itself.

## The mapping

| tags | target | why |
|---|---|---|
| 7× `preflightedCors()` (Catalogi, Directory, Glossary, Menus, Pages, Publications, Themes) | `specs/cross-origin-api-access` **COR-001** | the requirement is precisely "Answer CORS preflight requests on public API controllers" |
| 12× `UiController` | `specs/spa-deep-link-routing` **SPA-001** | "Serve the SPA shell for every top-level deep-link route" |
| `SearchController::show / attachments / download / uses / used` | `specs/federation` **FED-002 / 005 / 006 / 003 / 004** | per-method, see below |
| `FederationSearch.onSearch` | `specs/search` **SCH-OR-004** | "search frontend store calls the federation endpoint" — what this handler triggers |
| `FederationAddDirectoryModal.submit` | `specs/dashboard` **DIR-005** | "Add a new listing from a URL (admin-only)"; that requirement's own scenarios are written against `POST /api/listings/add`, the exact call this method makes |

### Why the five SearchController methods went to the federation spec
FED-002…006 are written "**from local OR federated sources**", and these five are the *local* half of that capability — so each method got its own matching requirement rather than five tags aimed at one convenient anchor.

**SCH-OR-003 was deliberately not used**: it names `SearchController::index` specifically, so it would have been the wrong target for these five.

## How I know the anchors resolve

Each anchor was verified **before** the tags were edited, by calling the gate's own `check_spec_anchors.has_anchor()` against it — and the old broken anchor (`#requirement-federated-search-visibility`) was run through the same function as a **positive control**, returning `MISS`, so a passing result could not be vacuous.

## Verification
- `php -l` clean
- PHPCS **0 errors**. The 8 remaining warnings are **pre-existing and untouched**: they are *class*-level tags carrying a spec path without a `#requirement` anchor, whereas every line changed here is *method*-level.