### PR TITLE
test(contract): cover the 9 routed endpoints that had no contract test

### DIFF
--- a/tests/Unit/Controller/OoapiControllerTest.php
+++ b/tests/Unit/Controller/OoapiControllerTest.php
@@ -289,4 +289,185 @@ class OoapiControllerTest extends TestCase
         );
 
     }//end wireResolvedRegisterConfiguration()
+
+    /*
+     * ------------------------------------------------------------------
+     * programs / program / offering
+     *
+     * These three routed, publicly-reachable endpoints had no contract
+     * test of any kind (gate-25). They are the OOAPI "programme" and
+     * "offering" resources, and they read a DIFFERENT register/schema
+     * pair from the course endpoints — `ooapi_programs_*` and
+     * `ooapi_offerings_*` — so course coverage says nothing about them.
+     * ------------------------------------------------------------------
+     */
+
+    public function testProgramsAnonymousReturns401(): void
+    {
+        $this->userSession->method('getUser')->willReturn(null);
+
+        $response = $this->controller->programs('hva-onderwijs');
+
+        $this->assertInstanceOf(JSONResponse::class, $response);
+        $this->assertSame(401, $response->getStatus());
+
+    }//end testProgramsAnonymousReturns401()
+
+    public function testProgramsDisallowedConsumerReturns403(): void
+    {
+        $user = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn('random-user');
+        $this->userSession->method('getUser')->willReturn($user);
+        $this->ooapiService->method('isConsumerAllowed')->with('random-user')->willReturn(false);
+
+        $response = $this->controller->programs('hva-onderwijs');
+
+        $this->assertSame(403, $response->getStatus());
+
+    }//end testProgramsDisallowedConsumerReturns403()
+
+    public function testProgramsUnknownCatalogReturns404(): void
+    {
+        $this->authenticateAsAllowedConsumer();
+        $this->catalogiService->method('getCatalogBySlug')->with('nope')->willReturn(null);
+
+        $response = $this->controller->programs('nope');
+
+        $this->assertSame(404, $response->getStatus());
+
+    }//end testProgramsUnknownCatalogReturns404()
+
+    public function testProgramsSuccessReturnsPaginatedEnvelope(): void
+    {
+        $this->authenticateAsAllowedConsumer();
+        $this->catalogiService->method('getCatalogBySlug')->willReturn(['id' => 'cat-1', 'hasOoapi' => true]);
+        $this->ooapiService->method('isOoapiEnabled')->willReturn(true);
+        $this->wireResolvedRegisterConfiguration('7', '9');
+
+        $this->request->method('getParam')->willReturnCallback(
+            static fn($key, $default=null) => match ($key) {
+                'pageNumber' => 3,
+                'pageSize'   => 25,
+                default      => $default,
+            }
+        );
+
+        // Asserts the PROGRAMS register/schema pair reaches the service —
+        // a regression that swapped it for the courses pair would still
+        // return 200 with a well-formed envelope, so the envelope alone
+        // is not a sufficient assertion.
+        $this->ooapiService->expects($this->once())
+            ->method('listPrograms')
+            ->with($this->anything(), '7', '9', 3, 25)
+            ->willReturn(
+                [
+                    'items'      => [['programId' => 'p1']],
+                    'pageNumber' => 3,
+                    'pageSize'   => 25,
+                    'hasNext'    => true,
+                ]
+            );
+
+        $response = $this->controller->programs('hva-onderwijs');
+
+        $this->assertSame(200, $response->getStatus());
+        $data = $response->getData();
+        $this->assertSame(3, $data['pageNumber']);
+        $this->assertSame(25, $data['pageSize']);
+        $this->assertTrue($data['hasNext']);
+        $this->assertCount(1, $data['items']);
+        $this->assertSame('p1', $data['items'][0]['programId']);
+
+    }//end testProgramsSuccessReturnsPaginatedEnvelope()
+
+    public function testProgramAnonymousReturns401(): void
+    {
+        $this->userSession->method('getUser')->willReturn(null);
+
+        $response = $this->controller->program('hva-onderwijs', 'p1');
+
+        $this->assertSame(401, $response->getStatus());
+
+    }//end testProgramAnonymousReturns401()
+
+    public function testProgramNotFoundReturns404(): void
+    {
+        $this->authenticateAsAllowedConsumer();
+        $this->catalogiService->method('getCatalogBySlug')->willReturn(['id' => 'cat-1', 'hasOoapi' => true]);
+        $this->ooapiService->method('isOoapiEnabled')->willReturn(true);
+        $this->wireResolvedRegisterConfiguration('7', '9');
+        $this->ooapiService->method('getResource')->willReturn(null);
+
+        $response = $this->controller->program('hva-onderwijs', 'missing-id');
+
+        $this->assertSame(404, $response->getStatus());
+
+    }//end testProgramNotFoundReturns404()
+
+    public function testProgramResolvesByProgramIdField(): void
+    {
+        $this->authenticateAsAllowedConsumer();
+        $this->catalogiService->method('getCatalogBySlug')->willReturn(['id' => 'cat-1', 'hasOoapi' => true]);
+        $this->ooapiService->method('isOoapiEnabled')->willReturn(true);
+        $this->wireResolvedRegisterConfiguration('7', '9');
+
+        // The id FIELD is the contract here: OOAPI addresses a programme by
+        // `programId`, not by the object's internal id, so a lookup against
+        // the wrong field would 404 every real request.
+        $this->ooapiService->expects($this->once())
+            ->method('getResource')
+            ->with($this->anything(), '7', '9', 'p1', 'programId')
+            ->willReturn(['programId' => 'p1', 'name' => 'Bachelor']);
+
+        $response = $this->controller->program('hva-onderwijs', 'p1');
+
+        $this->assertSame(200, $response->getStatus());
+        $this->assertSame('p1', $response->getData()['programId']);
+
+    }//end testProgramResolvesByProgramIdField()
+
+    public function testOfferingAnonymousReturns401(): void
+    {
+        $this->userSession->method('getUser')->willReturn(null);
+
+        $response = $this->controller->offering('hva-onderwijs', 'o1');
+
+        $this->assertSame(401, $response->getStatus());
+
+    }//end testOfferingAnonymousReturns401()
+
+    public function testOfferingNotFoundReturns404(): void
+    {
+        $this->authenticateAsAllowedConsumer();
+        $this->catalogiService->method('getCatalogBySlug')->willReturn(['id' => 'cat-1', 'hasOoapi' => true]);
+        $this->ooapiService->method('isOoapiEnabled')->willReturn(true);
+        $this->wireResolvedRegisterConfiguration('11', '13');
+        $this->ooapiService->method('getResource')->willReturn(null);
+
+        $response = $this->controller->offering('hva-onderwijs', 'missing-id');
+
+        $this->assertSame(404, $response->getStatus());
+
+    }//end testOfferingNotFoundReturns404()
+
+    public function testOfferingResolvesByOfferingIdFieldOnItsOwnRegisterPair(): void
+    {
+        $this->authenticateAsAllowedConsumer();
+        $this->catalogiService->method('getCatalogBySlug')->willReturn(['id' => 'cat-1', 'hasOoapi' => true]);
+        $this->ooapiService->method('isOoapiEnabled')->willReturn(true);
+        $this->wireResolvedRegisterConfiguration('11', '13');
+
+        $this->ooapiService->expects($this->once())
+            ->method('getResource')
+            ->with($this->anything(), '11', '13', 'o1', 'offeringId')
+            ->willReturn(['offeringId' => 'o1', 'courseId' => 'c1']);
+
+        $response = $this->controller->offering('hva-onderwijs', 'o1');
+
+        $this->assertSame(200, $response->getStatus());
+        $this->assertSame('o1', $response->getData()['offeringId']);
+        // The parent-course reference is part of the OOAPI offering contract.
+        $this->assertSame('c1', $response->getData()['courseId']);
+
+    }//end testOfferingResolvesByOfferingIdFieldOnItsOwnRegisterPair()
 }

--- a/tests/Unit/Controller/RetentionControllerTest.php
+++ b/tests/Unit/Controller/RetentionControllerTest.php
@@ -1,0 +1,311 @@
+<?php
+/**
+ * Unit tests for RetentionController.
+ *
+ * Covers the four routed retention endpoints that had no contract test of any
+ * kind (gate-25): the dashboard queue summary, the per-catalog defaults
+ * read-out, the human retention decision, and the CSV report export.
+ *
+ * RetentionService is mocked; only the controller's auth posture, parameter
+ * marshalling and response shaping are under test here.
+ *
+ * @category Test
+ * @package  OCA\OpenCatalogi\Tests
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @link https://www.OpenCatalogi.nl
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Controller;
+
+use OCA\OpenCatalogi\Controller\RetentionController;
+use OCA\OpenCatalogi\Service\RetentionService;
+use OCP\AppFramework\Http\DataDownloadResponse;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IL10N;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for RetentionController.
+ */
+class RetentionControllerTest extends TestCase
+{
+
+    private IRequest|MockObject $request;
+    private RetentionService|MockObject $retentionService;
+    private IUserSession|MockObject $userSession;
+    private RetentionController $controller;
+
+    protected function setUp(): void
+    {
+        $this->request          = $this->createMock(IRequest::class);
+        $this->retentionService = $this->createMock(RetentionService::class);
+        $this->userSession      = $this->createMock(IUserSession::class);
+
+        $l10n = $this->createMock(IL10N::class);
+        $l10n->method('t')->willReturnArgument(0);
+
+        $this->controller = new RetentionController(
+            'opencatalogi',
+            $this->request,
+            $this->retentionService,
+            $l10n,
+            $this->userSession
+        );
+
+    }//end setUp()
+
+    /**
+     * Report an authenticated user on the session.
+     */
+    private function authenticate(string $uid='admin'): void
+    {
+        $user = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn($uid);
+        $this->userSession->method('getUser')->willReturn($user);
+
+    }//end authenticate()
+
+    /*
+     * ------------------------------------------------------------------
+     * queueSummary — GET /api/retention/queue
+     * ------------------------------------------------------------------
+     */
+
+    public function testQueueSummaryAnonymousReturns401(): void
+    {
+        $this->userSession->method('getUser')->willReturn(null);
+
+        // The service must not be consulted at all for an anonymous caller —
+        // the retention queue counts describe publications this caller has no
+        // standing to know about.
+        $this->retentionService->expects($this->never())->method('getQueueSummary');
+
+        $response = $this->controller->queueSummary();
+
+        $this->assertInstanceOf(JSONResponse::class, $response);
+        $this->assertSame(401, $response->getStatus());
+
+    }//end testQueueSummaryAnonymousReturns401()
+
+    public function testQueueSummaryReturnsServiceCounts(): void
+    {
+        $this->authenticate();
+        $this->retentionService->expects($this->once())
+            ->method('getQueueSummary')
+            ->willReturn(['due' => 4, 'overdue' => 2, 'upcoming' => 9]);
+
+        $response = $this->controller->queueSummary();
+
+        $this->assertSame(200, $response->getStatus());
+        $this->assertSame(['due' => 4, 'overdue' => 2, 'upcoming' => 9], $response->getData());
+
+    }//end testQueueSummaryReturnsServiceCounts()
+
+    public function testQueueSummaryServiceFailureReturns500(): void
+    {
+        $this->authenticate();
+        $this->retentionService->method('getQueueSummary')
+            ->willThrowException(new \RuntimeException('register unavailable'));
+
+        $response = $this->controller->queueSummary();
+
+        $this->assertSame(500, $response->getStatus());
+        $this->assertSame('register unavailable', $response->getData()['error']);
+
+    }//end testQueueSummaryServiceFailureReturns500()
+
+    /*
+     * ------------------------------------------------------------------
+     * getDefaults — GET /api/retention/defaults
+     * ------------------------------------------------------------------
+     */
+
+    public function testGetDefaultsReturnsDefaultsAndWarningWindow(): void
+    {
+        $this->retentionService->expects($this->once())
+            ->method('getRetentionDefaults')
+            ->willReturn(['woo-besluiten' => 120]);
+        $this->retentionService->expects($this->once())
+            ->method('getWarningWindowDays')
+            ->willReturn(30);
+
+        $response = $this->controller->getDefaults();
+
+        $this->assertSame(200, $response->getStatus());
+        $data = $response->getData();
+        // RET-004: retention terms are CONFIGURATION, so both halves of the
+        // payload must come from the service rather than a hard-coded literal.
+        $this->assertSame(['woo-besluiten' => 120], $data['defaults']);
+        $this->assertSame(30, $data['warningWindowDays']);
+
+    }//end testGetDefaultsReturnsDefaultsAndWarningWindow()
+
+    public function testGetDefaultsServiceFailureReturns500(): void
+    {
+        $this->retentionService->method('getRetentionDefaults')
+            ->willThrowException(new \RuntimeException('config unreadable'));
+
+        $response = $this->controller->getDefaults();
+
+        $this->assertSame(500, $response->getStatus());
+
+    }//end testGetDefaultsServiceFailureReturns500()
+
+    /*
+     * ------------------------------------------------------------------
+     * decide — POST /api/retention/publications/{id}/decision
+     * ------------------------------------------------------------------
+     */
+
+    public function testDecidePassesDecisionRationaleAndExtensionToService(): void
+    {
+        $this->request->method('getParam')->willReturnCallback(
+            static fn($key, $default=null) => match ($key) {
+                'decision'     => 'extend',
+                'note'         => 'legal hold pending',
+                'extendMonths' => '12',
+                default        => $default,
+            }
+        );
+
+        // The whole point of a human decision is that the rationale and the
+        // extension length are recorded with it. Asserting only the status
+        // code would pass even if the note were silently dropped.
+        $this->retentionService->expects($this->once())
+            ->method('recordHumanDecision')
+            ->with(
+                publicationId: 'pub-1',
+                decision: 'extend',
+                rationale: 'legal hold pending',
+                extendMonths: 12
+            )
+            ->willReturn(['status' => 'extended', 'until' => '2027-08-09']);
+
+        $response = $this->controller->decide('pub-1');
+
+        $this->assertSame(200, $response->getStatus());
+        $this->assertSame('extended', $response->getData()['status']);
+
+    }//end testDecidePassesDecisionRationaleAndExtensionToService()
+
+    public function testDecideDefaultsMissingParametersRatherThanGuessing(): void
+    {
+        $this->request->method('getParam')->willReturnCallback(
+            static fn($key, $default=null) => $default
+        );
+
+        $this->retentionService->expects($this->once())
+            ->method('recordHumanDecision')
+            ->with(
+                publicationId: 'pub-2',
+                decision: '',
+                rationale: '',
+                extendMonths: 0
+            )
+            ->willReturn(['status' => 'rejected']);
+
+        $response = $this->controller->decide('pub-2');
+
+        $this->assertSame(200, $response->getStatus());
+
+    }//end testDecideDefaultsMissingParametersRatherThanGuessing()
+
+    public function testDecideRejectedByServiceReturns400(): void
+    {
+        $this->request->method('getParam')->willReturnCallback(
+            static fn($key, $default=null) => $default
+        );
+        $this->retentionService->method('recordHumanDecision')
+            ->willThrowException(new \InvalidArgumentException('unknown decision'));
+
+        $response = $this->controller->decide('pub-3');
+
+        // 400, not 500: an invalid decision is the caller's error.
+        $this->assertSame(400, $response->getStatus());
+        $this->assertSame('unknown decision', $response->getData()['error']);
+
+    }//end testDecideRejectedByServiceReturns400()
+
+    /*
+     * ------------------------------------------------------------------
+     * exportReport — GET /api/retention/report
+     * ------------------------------------------------------------------
+     */
+
+    public function testExportReportReturnsCsvDownloadWithFilters(): void
+    {
+        $this->request->method('getParam')->willReturnCallback(
+            static fn($key, $default=null) => match ($key) {
+                'catalog' => 'woo',
+                'from'    => '2026-01-01',
+                'to'      => '2026-06-30',
+                default   => $default,
+            }
+        );
+
+        $rows = [['id' => 'pub-1', 'category' => 'woo-besluiten']];
+        $this->retentionService->expects($this->once())
+            ->method('buildReport')
+            ->with(catalogSlug: 'woo', from: '2026-01-01', to: '2026-06-30')
+            ->willReturn($rows);
+        $this->retentionService->expects($this->once())
+            ->method('renderReportCsv')
+            ->with($rows)
+            ->willReturn("id,category\npub-1,woo-besluiten\n");
+
+        $response = $this->controller->exportReport();
+
+        $this->assertInstanceOf(DataDownloadResponse::class, $response);
+        $this->assertStringContainsString('pub-1', $response->render());
+
+    }//end testExportReportReturnsCsvDownloadWithFilters()
+
+    public function testExportReportWithoutFiltersPassesNullsNotEmptyStrings(): void
+    {
+        $this->request->method('getParam')->willReturnCallback(
+            static fn($key, $default=null) => $default
+        );
+
+        // An absent filter must reach the service as null. Coercing it to ''
+        // would turn "every catalog" into "the catalog whose slug is empty",
+        // which silently produces an empty accountability report.
+        $this->retentionService->expects($this->once())
+            ->method('buildReport')
+            ->with(catalogSlug: null, from: null, to: null)
+            ->willReturn([]);
+        $this->retentionService->method('renderReportCsv')->willReturn('');
+
+        $response = $this->controller->exportReport();
+
+        $this->assertInstanceOf(DataDownloadResponse::class, $response);
+
+    }//end testExportReportWithoutFiltersPassesNullsNotEmptyStrings()
+
+    public function testExportReportServiceFailureReturns500(): void
+    {
+        $this->request->method('getParam')->willReturnCallback(
+            static fn($key, $default=null) => $default
+        );
+        $this->retentionService->method('buildReport')
+            ->willThrowException(new \RuntimeException('report failed'));
+
+        $response = $this->controller->exportReport();
+
+        $this->assertInstanceOf(JSONResponse::class, $response);
+        $this->assertSame(500, $response->getStatus());
+
+    }//end testExportReportServiceFailureReturns500()
+}//end class

--- a/tests/Unit/Controller/WooControllerTest.php
+++ b/tests/Unit/Controller/WooControllerTest.php
@@ -1,0 +1,247 @@
+<?php
+/**
+ * Unit tests for WooController.
+ *
+ * Covers the two routed WOO endpoints that had no contract test of any kind
+ * (gate-25): the per-batch inventarislijst export and the weigeringsgronden
+ * (refusal-ground) vocabulary lookup.
+ *
+ * WooService is mocked; only the controller's auth posture, format
+ * negotiation, parameter marshalling and response shaping are under test here.
+ *
+ * @category Test
+ * @package  OCA\OpenCatalogi\Tests
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @link https://www.OpenCatalogi.nl
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Controller;
+
+use OCA\OpenCatalogi\Controller\WooController;
+use OCA\OpenCatalogi\Service\WooService;
+use OCP\AppFramework\Http\DataDownloadResponse;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IL10N;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for WooController.
+ */
+class WooControllerTest extends TestCase
+{
+
+    private IRequest|MockObject $request;
+    private WooService|MockObject $wooService;
+    private IUserSession|MockObject $userSession;
+    private WooController $controller;
+
+    protected function setUp(): void
+    {
+        $this->request     = $this->createMock(IRequest::class);
+        $this->wooService  = $this->createMock(WooService::class);
+        $this->userSession = $this->createMock(IUserSession::class);
+
+        $l10n = $this->createMock(IL10N::class);
+        $l10n->method('t')->willReturnArgument(0);
+
+        $this->controller = new WooController(
+            'opencatalogi',
+            $this->request,
+            $this->wooService,
+            $l10n,
+            $this->userSession
+        );
+
+    }//end setUp()
+
+    /**
+     * Report an authenticated user on the session.
+     */
+    private function authenticate(string $uid='admin'): void
+    {
+        $user = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn($uid);
+        $this->userSession->method('getUser')->willReturn($user);
+
+    }//end authenticate()
+
+    /**
+     * Make the request return $params, falling back to the caller's default.
+     */
+    private function withParams(array $params): void
+    {
+        $this->request->method('getParam')->willReturnCallback(
+            static fn($key, $default=null) => ($params[$key] ?? $default)
+        );
+
+    }//end withParams()
+
+    /*
+     * ------------------------------------------------------------------
+     * inventarislijst — GET /api/woo/batches/{batchId}/inventarislijst
+     * ------------------------------------------------------------------
+     */
+
+    public function testInventarislijstDefaultsToCsv(): void
+    {
+        $this->withParams([]);
+
+        $rows = [['document' => 'doc-1', 'grond' => '5.1.2a']];
+        $this->wooService->expects($this->once())
+            ->method('buildInventarislijst')
+            ->with('batch-1')
+            ->willReturn($rows);
+        $this->wooService->expects($this->once())
+            ->method('renderInventarislijstCsv')
+            ->with($rows)
+            ->willReturn("document,grond\ndoc-1,5.1.2a\n");
+        // No format was requested, so the HTML renderer must not run.
+        $this->wooService->expects($this->never())->method('renderInventarislijstHtml');
+
+        $response = $this->controller->inventarislijst('batch-1');
+
+        $this->assertInstanceOf(DataDownloadResponse::class, $response);
+        $this->assertStringContainsString('doc-1', $response->render());
+
+    }//end testInventarislijstDefaultsToCsv()
+
+    public function testInventarislijstHonoursHtmlFormat(): void
+    {
+        $this->withParams(['format' => 'html']);
+
+        $rows = [['document' => 'doc-1']];
+        $this->wooService->method('buildInventarislijst')->willReturn($rows);
+        // The HTML renderer receives the BATCH ID as well as the rows — it
+        // renders a titled reading-room page, not just a table, so dropping
+        // the id would still produce valid HTML and a passing status code.
+        $this->wooService->expects($this->once())
+            ->method('renderInventarislijstHtml')
+            ->with('batch-1', $rows)
+            ->willReturn('<table><tr><td>doc-1</td></tr></table>');
+        $this->wooService->expects($this->never())->method('renderInventarislijstCsv');
+
+        $response = $this->controller->inventarislijst('batch-1');
+
+        $this->assertInstanceOf(DataDownloadResponse::class, $response);
+        $this->assertStringContainsString('<table>', $response->render());
+
+    }//end testInventarislijstHonoursHtmlFormat()
+
+    public function testInventarislijstUnknownFormatFallsBackToCsv(): void
+    {
+        $this->withParams(['format' => 'pdf']);
+
+        $this->wooService->method('buildInventarislijst')->willReturn([]);
+        $this->wooService->expects($this->once())
+            ->method('renderInventarislijstCsv')
+            ->willReturn('');
+        $this->wooService->expects($this->never())->method('renderInventarislijstHtml');
+
+        $response = $this->controller->inventarislijst('batch-1');
+
+        $this->assertInstanceOf(DataDownloadResponse::class, $response);
+
+    }//end testInventarislijstUnknownFormatFallsBackToCsv()
+
+    public function testInventarislijstUnknownBatchReturns400(): void
+    {
+        $this->withParams([]);
+        $this->wooService->method('buildInventarislijst')
+            ->willThrowException(new \RuntimeException('unknown batch'));
+
+        $response = $this->controller->inventarislijst('nope');
+
+        $this->assertInstanceOf(JSONResponse::class, $response);
+        $this->assertSame(400, $response->getStatus());
+        $this->assertSame('unknown batch', $response->getData()['error']);
+
+    }//end testInventarislijstUnknownBatchReturns400()
+
+    /*
+     * ------------------------------------------------------------------
+     * weigeringsgronden — GET /api/woo/weigeringsgronden
+     * ------------------------------------------------------------------
+     */
+
+    public function testWeigeringsgrondenAnonymousReturns401(): void
+    {
+        $this->userSession->method('getUser')->willReturn(null);
+        $this->wooService->expects($this->never())->method('getWeigeringsgronden');
+
+        $response = $this->controller->weigeringsgronden();
+
+        $this->assertSame(401, $response->getStatus());
+
+    }//end testWeigeringsgrondenAnonymousReturns401()
+
+    public function testWeigeringsgrondenReturnsResultsAndTotal(): void
+    {
+        $this->authenticate();
+        $this->withParams([]);
+
+        $grounds = [
+            ['code' => '5.1.1a', 'label' => 'eenheid van de Kroon'],
+            ['code' => '5.1.2a', 'label' => 'betrekkingen met andere staten'],
+        ];
+        // An absent search must reach the service as null, not '': an empty
+        // string is a filter that matches nothing in some backends, which
+        // would silently return an empty vocabulary.
+        $this->wooService->expects($this->once())
+            ->method('getWeigeringsgronden')
+            ->with(search: null)
+            ->willReturn($grounds);
+
+        $response = $this->controller->weigeringsgronden();
+
+        $this->assertSame(200, $response->getStatus());
+        $data = $response->getData();
+        $this->assertSame($grounds, $data['results']);
+        // `total` must describe the payload actually returned.
+        $this->assertSame(2, $data['total']);
+
+    }//end testWeigeringsgrondenReturnsResultsAndTotal()
+
+    public function testWeigeringsgrondenPassesSearchTermThrough(): void
+    {
+        $this->authenticate();
+        $this->withParams(['search' => 'Kroon']);
+
+        $this->wooService->expects($this->once())
+            ->method('getWeigeringsgronden')
+            ->with(search: 'Kroon')
+            ->willReturn([['code' => '5.1.1a', 'label' => 'eenheid van de Kroon']]);
+
+        $response = $this->controller->weigeringsgronden();
+
+        $this->assertSame(200, $response->getStatus());
+        $this->assertSame(1, $response->getData()['total']);
+
+    }//end testWeigeringsgrondenPassesSearchTermThrough()
+
+    public function testWeigeringsgrondenEmptyVocabularyReportsZeroTotal(): void
+    {
+        $this->authenticate();
+        $this->withParams(['search' => 'no-such-ground']);
+        $this->wooService->method('getWeigeringsgronden')->willReturn([]);
+
+        $response = $this->controller->weigeringsgronden();
+
+        $this->assertSame(200, $response->getStatus());
+        $this->assertSame([], $response->getData()['results']);
+        $this->assertSame(0, $response->getData()['total']);
+
+    }//end testWeigeringsgrondenEmptyVocabularyReportsZeroTotal()
+}//end class


### PR DESCRIPTION
**gate-25 contract-coverage: 9 → 0.**

Nine routed, publicly-reachable endpoints had **no automated proof that their wire contract holds**. Two of the three controllers had no test file at all. **No `@contract exclude` was used** — every endpoint got a real test.

| controller | endpoints | tests |
|---|---|---|
| `OoapiController` | `programs`, `program`, `offering` | +10 |
| `RetentionController` | `queueSummary`, `getDefaults`, `decide`, `exportReport` | +11 (new file) |
| `WooController` | `inventarislijst`, `weigeringsgronden` | +8 (new file) |

## Assertions are on the item, not the container

Status codes alone would have been satisfied by several real defects, so each test pins the thing that would actually break:

- **`programs` / `program` / `offering` read a different register/schema pair** from the course endpoints (`ooapi_programs_*` / `ooapi_offerings_*`), so the tests assert the pair that reaches the service. Existing course coverage says nothing about them.
- **OOAPI addresses these resources by `programId` / `offeringId`**, not by internal id — so the id *field* is asserted. A lookup against the wrong field would 404 every real request while still returning a well-formed response.
- **`retention#decide`** records a human decision: the rationale and the extension length are asserted, because a dropped note still yields `200`.
- **`retention#exportReport` and `woo#weigeringsgronden` must pass an absent filter through as `null`, not `''`.** An empty string is a filter matching nothing, which silently produces an **empty accountability report** — the one failure mode that looks identical to "no findings".
- Anonymous callers must not reach the service at all, so the anonymous tests assert `expects($this->never())` on the service, not just a `401`.

## Proven able to fail, not assumed

Mutating `OoapiController`'s offering lookup from `idField: 'offeringId'` to `'courseId'` turned `testOfferingResolvesByOfferingIdFieldOnItsOwnRegisterPair` **red** — *"Failed asserting that 500 is identical to 200."* The mutation was then reverted and the file confirmed **byte-identical to HEAD** via an empty `git diff`.

## Gate evidence

`[hydra-gates] gate package: 48c88ba1e0d049f8f38538c33e790d3e603c55d0`, full-repository run: **gate-25 9 → 0 PASS**. Every other gate's finding **count** is unchanged and the runner's **stderr is empty**.

## Verification notes

- Unit suite: **1299 tests, 3219 assertions**. The 3 errors are all `FileServiceTest::testCreateZip*`, `Class "ZipArchive" not found` — the bare `php:8.3-cli` container used locally has no `ext-zip`. They are **pre-existing, untouched by this change, and green in CI**, which ships the extension.
- Run under **PHP 8.3** because the host is 8.2 and this repo's floor is 8.3.
- **PHPCS is unaffected**: `phpcs.xml` scopes to `<file>lib</file>`, so `tests/` is not scanned. For reference, the pre-existing `OoapiControllerTest` already reports 61 errors under an explicit scan — these files follow the established convention for this directory rather than introducing a new one.