### PR TITLE
fix(security): stop getCatalogFilters() deriving a scope from an unscoped sweep

### DIFF
--- a/lib/Service/CatalogiService.php
+++ b/lib/Service/CatalogiService.php
@@ -445,27 +445,9 @@ class CatalogiService
         // Get catalogs using searchObjects (handles deleted field correctly).
         $catalogs = $this->getObjectService()->searchObjects(query: $query, _rbac: false, _multitenancy: false);
 
-        // Initialize arrays to store unique registers and schemas.
-        $uniqueRegisters = [];
-        $uniqueSchemas   = [];
-
-        // Iterate over each catalog to extract registers and schemas.
-        foreach ($catalogs as $catalog) {
-            $catalog = $catalog->jsonSerialize();
-            // Check if registers is an array and merge unique values.
-            if (isset($catalog['registers']) === true && is_array($catalog['registers']) === true) {
-                $uniqueRegisters = array_merge($uniqueRegisters, $catalog['registers']);
-            }
-
-            // Check if schemas is an array and merge unique values.
-            if (isset($catalog['schemas']) === true && is_array($catalog['schemas']) === true) {
-                $uniqueSchemas = array_merge($uniqueSchemas, $catalog['schemas']);
-            }
-        }
-
         // Remove duplicate values and assign to class properties.
-        $this->availableRegisters = array_unique($uniqueRegisters);
-        $this->availableSchemas   = array_unique($uniqueSchemas);
+        $this->availableRegisters = $this->collectUnique($catalogs, 'registers');
+        $this->availableSchemas   = $this->collectUnique($catalogs, 'schemas');
 
         return [
             'registers' => array_values($this->availableRegisters),
@@ -473,6 +455,35 @@ class CatalogiService
         ];
 
     }//end getCatalogFilters()
+
+    /**
+     * Collect the unique values of one array-valued property across catalogs.
+     *
+     * Extracted from getCatalogFilters() so the fail-closed guard added there
+     * does not push that method over PHPMD's cyclomatic-complexity threshold.
+     * A baseline entry would have been the wrong repair: it is scoped to
+     * (rule, file) and would licence every future violation of that rule in
+     * this file, including ones nobody has looked at.
+     *
+     * @param array<int,mixed> $catalogs The catalog objects returned by the search.
+     * @param string           $property The array-valued property to collect ('registers' | 'schemas').
+     *
+     * @return array<int,mixed> The de-duplicated union of that property's values.
+     */
+    private function collectUnique(array $catalogs, string $property): array
+    {
+        $collected = [];
+
+        foreach ($catalogs as $catalog) {
+            $catalog = $catalog->jsonSerialize();
+            if (isset($catalog[$property]) === true && is_array($catalog[$property]) === true) {
+                $collected = array_merge($collected, $catalog[$property]);
+            }
+        }
+
+        return array_unique($collected);
+
+    }//end collectUnique()
 
     /**
      * Get the list of available registers.

--- a/lib/Service/CatalogiService.php
+++ b/lib/Service/CatalogiService.php
@@ -386,6 +386,43 @@ class CatalogiService
         $schema   = $this->config->getValueString($this->appName, 'catalog_schema', '');
         $register = $this->config->getValueString($this->appName, 'catalog_register', '');
 
+        // FAIL CLOSED. getCatalogBySlug() — the sibling method in this same class
+        // — already refuses when either key is empty; this method did not, and the
+        // asymmetry is the bug.
+        //
+        // An empty key does NOT fall through to "no scope" harmlessly. It is put
+        // into the query verbatim, and `??` only falls through on null, so
+        // MagicMapper receives '' and casts it: `find((int) '')` is `find(0)`,
+        // which resolves nothing, leaves $register/$schema null, and so SKIPS the
+        // `if ($register !== null && $schema !== null)` scoped branch entirely —
+        // falling through to the cross-table path. Combined with the
+        // `_rbac: false` below, an unconfigured instance therefore ran an
+        // UNSCOPED, RBAC-DISABLED sweep of every object on the instance in order
+        // to derive a catalog scope. That is the same degradation shape as #828
+        // (GET /api/listings): an unresolved scope becoming NO scope rather than
+        // a refusal.
+        //
+        // Returning empty arrays is the correct refusal here rather than an
+        // exception, because that is already the contract callers handle:
+        // PublicationService::setObjectServiceContext() checks
+        // `empty($allowedRegisters) || empty($allowedSchemas)` and returns
+        // without querying, explicitly to "refuse to do a platform-wide scan".
+        if ($schema === '' || $register === '') {
+            $this->logger->error(
+                'Catalog schema or register not configured — refusing to derive a catalog scope from an unscoped search',
+                [
+                    'schema'   => $schema,
+                    'register' => $register,
+                ]
+            );
+            $this->availableRegisters = [];
+            $this->availableSchemas   = [];
+            return [
+                'registers' => [],
+                'schemas'   => [],
+            ];
+        }
+
         // Setup the base query for searchObjects.
         $query = [
             '@self' => [

--- a/tests/Unit/Service/CatalogiServiceTest.php
+++ b/tests/Unit/Service/CatalogiServiceTest.php
@@ -142,6 +142,68 @@ class CatalogiServiceTest extends TestCase
     // ──────────────────────────────────────────────────────────
     // getCatalogFilters
     // ──────────────────────────────────────────────────────────
+
+    /**
+     * An unconfigured catalog register/schema must NOT be turned into an
+     * unscoped search.
+     *
+     * The empty string does not fall through to "no filter" harmlessly: it is
+     * put into the query verbatim, MagicMapper casts it with `(int) ''` = 0,
+     * that resolves no register, and the scoped branch is skipped — so the
+     * search ran across the whole instance with `_rbac: false`. This is the
+     * same degradation shape as #828 on GET /api/listings.
+     *
+     * The assertion is that the ObjectService is NEVER consulted, not merely
+     * that the result is empty: an unscoped search that happens to return
+     * nothing is indistinguishable from a refusal by its return value alone.
+     *
+     * @return void
+     */
+    public function testGetCatalogFiltersRefusesWhenRegisterIsUnconfigured(): void
+    {
+        $this->config->method('getValueString')
+            ->willReturnMap(
+                [
+                    ['opencatalogi', 'catalog_schema', '', 'schema-1'],
+                    ['opencatalogi', 'catalog_register', '', ''],
+                ]
+            );
+
+        $objectService = $this->createMock(ObjectService::class);
+        $objectService->expects($this->never())->method('searchObjects');
+        $this->injectObjectService($objectService);
+
+        $result = $this->service->getCatalogFilters();
+
+        $this->assertSame(['registers' => [], 'schemas' => []], $result);
+
+    }//end testGetCatalogFiltersRefusesWhenRegisterIsUnconfigured()
+
+    /**
+     * The same refusal when the SCHEMA half is missing.
+     *
+     * @return void
+     */
+    public function testGetCatalogFiltersRefusesWhenSchemaIsUnconfigured(): void
+    {
+        $this->config->method('getValueString')
+            ->willReturnMap(
+                [
+                    ['opencatalogi', 'catalog_schema', '', ''],
+                    ['opencatalogi', 'catalog_register', '', 'register-1'],
+                ]
+            );
+
+        $objectService = $this->createMock(ObjectService::class);
+        $objectService->expects($this->never())->method('searchObjects');
+        $this->injectObjectService($objectService);
+
+        $result = $this->service->getCatalogFilters();
+
+        $this->assertSame(['registers' => [], 'schemas' => []], $result);
+
+    }//end testGetCatalogFiltersRefusesWhenSchemaIsUnconfigured()
+
     public function testGetCatalogFiltersWithoutCatalogId(): void
     {
         $this->config->method('getValueString')


### PR DESCRIPTION
Found by **auditing for siblings of #828** (`GET /api/listings` returning every object on the instance when the register was unconfigured). The tell named in that fix — *"a sibling method in the same class that DOES refuse"* — matches here exactly:

`CatalogiService::getCatalogBySlug()` already returns `null` when `catalog_schema` / `catalog_register` are empty. **`getCatalogFilters()`, 30 lines away, did not.**

## The empty key does not fall through to "no filter" harmlessly

1. it is placed into the query verbatim as `'@self' => ['register' => '']`;
2. `MagicMapper` reads it with `??`, which **only falls through on `null`**, so it receives `''` rather than `null`;
3. it then casts: `find((int) '')` is `find(0)`, which resolves nothing;
4. `$register`/`$schema` stay `null`, so the `if ($register !== null && $schema !== null)` **scoped branch is skipped** and execution falls through to the cross-table path.

Combined with the **`_rbac: false`** on the `searchObjects()` call below it, an unconfigured instance therefore ran an **unscoped, RBAC-disabled sweep of every object on the instance** in order to work out its catalog scope.

## Blast radius — measured, not assumed

The only consumer, `PublicationService::setObjectServiceContext()`, **already** checks `empty($allowedRegisters) || empty($allowedSchemas)` and returns without querying, explicitly to *"refuse to do a platform-wide scan"*.

So this is a **correctness and fail-mode defect, not a disclosure** — the sweep's results never reach a caller. It is reported as such rather than as a second #828.

Returning empty arrays is the right refusal precisely because that is the contract callers already handle.

## Why gate-50 did not find this

gate-50 **passes** on this tree. Its documented limitation is that it cannot see a config read whose app id is a **plain variable** — and every read here is `$this->config->getValueString($this->appName, ...)`. **A gate-50 zero is not evidence of absence**, which is why this was audited by hand.

## Audited and found already safe — deliberately unchanged

- **`Glossary` / `Pages` / `Menus` / `Themes` / `Catalogi` controllers' `@PublicPage index()`.** These *look* like the #828 shape (conditional `if (empty(...))` filter building) but the shared `ResolvesRegisterConfiguration` trait throws `MissingConfigException` when either key is empty and every `index()` 503s on it — so the unscoped branch is **unreachable**. Their `empty()` guards are dead defensive code, not a live path.
- **`ListingsController::destroy()`** — refuses explicitly (HTTP 409).
- **`PublicationService::setObjectServiceContext()`** — refuses explicitly.

## Verification

The two new tests assert the ObjectService is **never consulted**, not merely that the result is empty — an unscoped search that happens to return nothing is indistinguishable from a refusal by its return value alone.

**Proven able to fail**: replacing the guard condition with `if (false)` turns both tests red; restored and re-verified green.

`[hydra-gates] gate package: 48c88ba1e0d049f8f38538c33e790d3e603c55d0` — gate-47 `security-change-has-tests` **PASS**, gate-50 **PASS**. Unit suite **1301 tests / 3229 assertions, 0 failures, 0 errors**. PHPCS **0 errors** on the changed file.