### PR TITLE
docs(spec): close gate-16 — @spec traceability for 55 methods (54 → 0)

### DIFF
--- a/lib/Service/OoapiService.php
+++ b/lib/Service/OoapiService.php
@@ -378,6 +378,8 @@ class OoapiService
      * @param int                  $pageSize The requested page size.
      *
      * @return array{items: array<int, array<string, mixed>>, pageNumber: int, pageSize: int, hasNext: bool} The paginated course collection.
+     *
+     * @spec openspec/specs/ooapi-catalog-publication/spec.md#requirement-per-catalog-ooapi-5-0-resource-endpoints-ooapi-001
      */
     public function listCourses(array $catalog, string $register, string $schema, int $page, int $pageSize): array
     {
@@ -402,6 +404,8 @@ class OoapiService
      * @param int                  $pageSize The requested page size.
      *
      * @return array{items: array<int, array<string, mixed>>, pageNumber: int, pageSize: int, hasNext: bool} The paginated program collection.
+     *
+     * @spec openspec/specs/ooapi-catalog-publication/spec.md#requirement-per-catalog-ooapi-5-0-resource-endpoints-ooapi-001
      */
     public function listPrograms(array $catalog, string $register, string $schema, int $page, int $pageSize): array
     {
@@ -428,6 +432,8 @@ class OoapiService
      * @param int                  $pageSize The requested page size.
      *
      * @return array{items: array<int, array<string, mixed>>, pageNumber: int, pageSize: int, hasNext: bool} The paginated offering collection.
+     *
+     * @spec openspec/specs/ooapi-catalog-publication/spec.md#requirement-offerings-nest-under-their-course-ooapi-006
      */
     public function listOfferings(array $catalog, string $register, string $schema, ?string $courseId, int $page, int $pageSize): array
     {

--- a/src/components/tabs/AppTabs.vue
+++ b/src/components/tabs/AppTabs.vue
@@ -117,6 +117,7 @@ provide(TABS_CONTEXT, {
 	 *
 	 * @param {object} tab `{ uid, title, titleSlot, el, active }`.
 	 * @return {void}
+	 * @spec openspec/specs/generic-object-modals/spec.md#requirement-provide-shared-object-presentation-components-gom-005
 	 */
 	register(tab) {
 		tabs.value = [...tabs.value, tab]
@@ -135,6 +136,7 @@ provide(TABS_CONTEXT, {
 	 *
 	 * @param {number|string} uid The tab's unique id.
 	 * @return {void}
+	 * @spec openspec/specs/generic-object-modals/spec.md#requirement-provide-shared-object-presentation-components-gom-005
 	 */
 	unregister(uid) {
 		tabs.value = tabs.value.filter((t) => t.uid !== uid)

--- a/src/components/widgets/ThemePreviewWidget.vue
+++ b/src/components/widgets/ThemePreviewWidget.vue
@@ -62,13 +62,21 @@ export default {
 		}
 	},
 	computed: {
-		/** The resolved object-context bag from inject (either shape) or {}. */
+		/**
+		 * The resolved object-context bag from inject (either shape) or {}.
+		 *
+		 * @spec openspec/specs/content-management/spec.md#requirement-theme-management-ui-cms-038
+		 */
 		ctx() {
 			const inj = this.cnObjectContext && (this.cnObjectContext.value || this.cnObjectContext)
 			const holder = this.cnDetailObjectContext && this.cnDetailObjectContext.value
 			return inj || holder || {}
 		},
-		/** The current theme object, when the detail page has loaded one. */
+		/**
+		 * The current theme object, when the detail page has loaded one.
+		 *
+		 * @spec openspec/specs/content-management/spec.md#requirement-theme-management-ui-cms-038
+		 */
 		theme() {
 			return (this.ctx && this.ctx.object) || {}
 		},
@@ -76,12 +84,18 @@ export default {
 		 * Colour-picker declarations. Guarded so CnThemePreview never
 		 * receives `undefined` — falls back to a built-in default set
 		 * when the manifest content carries none.
+		 *
+		 * @spec openspec/specs/content-management/spec.md#requirement-theme-management-ui-cms-038
 		 */
 		pickers() {
 			const configured = this.content && Array.isArray(this.content.pickers) ? this.content.pickers : []
 			return configured.length > 0 ? configured : this.defaultPickers
 		},
-		/** Reset-button defaults map, derived from whichever picker set is active. */
+		/**
+		 * Reset-button defaults map, derived from whichever picker set is active.
+		 *
+		 * @spec openspec/specs/content-management/spec.md#requirement-theme-management-ui-cms-038
+		 */
 		defaults() {
 			if (this.content && this.content.defaults && typeof this.content.defaults === 'object') {
 				return this.content.defaults
@@ -91,15 +105,27 @@ export default {
 				return acc
 			}, {})
 		},
-		/** Initial colour map, guarded to always be a plain object. */
+		/**
+		 * Initial colour map, guarded to always be a plain object.
+		 *
+		 * @spec openspec/specs/content-management/spec.md#requirement-theme-management-ui-cms-038
+		 */
 		value() {
 			return (this.content && typeof this.content.value === 'object' && this.content.value) || {}
 		},
-		/** Sample-preview title — prefers the loaded theme's own title. */
+		/**
+		 * Sample-preview title — prefers the loaded theme's own title.
+		 *
+		 * @spec openspec/specs/content-management/spec.md#requirement-theme-management-ui-cms-038
+		 */
 		sampleTitle() {
 			return this.theme.title || this.content.title || t('opencatalogi', 'Theme preview')
 		},
-		/** Sample-preview body text — prefers the loaded theme's summary/description. */
+		/**
+		 * Sample-preview body text — prefers the loaded theme's summary/description.
+		 *
+		 * @spec openspec/specs/content-management/spec.md#requirement-theme-management-ui-cms-038
+		 */
 		sampleBodyText() {
 			return this.theme.summary || this.theme.description || this.content.description
 				|| t('opencatalogi', 'This is how publications with this theme look.')

--- a/src/composables/useChartColors.js
+++ b/src/composables/useChartColors.js
@@ -29,6 +29,7 @@ function readCssVar(name, fallback) {
  * dashboard previously hardcoded when a variable isn't defined (e.g. an older
  * Nextcloud core without one of the newer semantic tokens).
  * @return {string[]} An ordered list of resolved color strings.
+ * @spec openspec/specs/frontend-theming/spec.md#requirement-all-frontend-colors-come-from-nc-css-variables-thm-001
  */
 export function useCategoricalChartColors() {
 	return [
@@ -45,6 +46,7 @@ export function useCategoricalChartColors() {
 /**
  * Resolve the single accent color used by the traffic (API read-requests) chart.
  * @return {string[]} A single-entry color list, matching ApexCharts' `colors` shape.
+ * @spec openspec/specs/frontend-theming/spec.md#requirement-all-frontend-colors-come-from-nc-css-variables-thm-001
  */
 export function useAccentChartColor() {
 	return [readCssVar('--color-primary-element', '#079cff')]

--- a/src/modals/directory/FederationAddDirectoryModal.vue
+++ b/src/modals/directory/FederationAddDirectoryModal.vue
@@ -33,14 +33,29 @@ export default {
 		}
 	},
 	computed: {
-		// Manifest-v2 uses a `federation…` prefix so the flag never collides
-		// with the legacy `AddDirectoryModal` (which keys on `'addDirectory'`)
-		// if both shells ever coexist.
+		/**
+		 * Whether the add-directory modal is the active navigation-store modal.
+		 *
+		 * Manifest-v2 uses a `federation…` prefix so the flag never collides
+		 * with the legacy `AddDirectoryModal` (which keys on `'addDirectory'`)
+		 * if both shells ever coexist.
+		 *
+		 * @return {boolean} True when this modal should render.
+		 * @spec openspec/specs/retrofit-2026-05-26-directory-federation/spec.md#requirement-directory-listing-modals-req-dir-003
+		 */
 		isOpen() {
 			return navigationStore.modal === 'federationAddDirectory'
 		},
 	},
 	watch: {
+		/**
+		 * Reset the form whenever the modal transitions to open, so a previous
+		 * submission's URL, error or result never leaks into the next use.
+		 *
+		 * @param {boolean} open The new open state.
+		 * @return {void}
+		 * @spec openspec/specs/retrofit-2026-05-26-directory-federation/spec.md#requirement-directory-listing-modals-req-dir-003
+		 */
 		isOpen(open) {
 			if (open) {
 				this.reset()
@@ -49,12 +64,24 @@ export default {
 	},
 	methods: {
 		t,
+		/**
+		 * Clear the form back to its pristine state each time the modal opens.
+		 *
+		 * @return {void}
+		 * @spec openspec/specs/retrofit-2026-05-26-directory-federation/spec.md#requirement-directory-listing-modals-req-dir-003
+		 */
 		reset() {
 			this.url = ''
 			this.submitting = false
 			this.error = null
 			this.result = null
 		},
+		/**
+		 * Close the modal on completion or cancel.
+		 *
+		 * @return {void}
+		 * @spec openspec/specs/retrofit-2026-05-26-directory-federation/spec.md#requirement-directory-listing-modals-req-dir-003
+		 */
 		close() {
 			navigationStore.setModal(null)
 		},

--- a/src/modals/generic/UploadFiles.vue
+++ b/src/modals/generic/UploadFiles.vue
@@ -451,6 +451,12 @@ export default {
 			}
 		}, { immediate: true })
 	},
+	/**
+	 * Tear down the dialog watcher and the pending duplicate-file warning timer.
+	 *
+	 * @return {void}
+	 * @spec openspec/specs/retrofit-2026-05-26-object-modals/spec.md#requirement-object-file-attachment-management-req-objm-004
+	 */
 	unmounted() {
 		if (this._uploadFilesDialogUnwatch) try { this._uploadFilesDialogUnwatch() } catch (e) {}
 		// The duplicate-warning timeout writes `this.duplicateWarning` 5s later;

--- a/src/modals/menuItem/MenuItemForm.vue
+++ b/src/modals/menuItem/MenuItemForm.vue
@@ -62,11 +62,17 @@ export default {
 		}
 	},
 	computed: {
-		/** @return {object|null} The active menu whose items are edited. */
+		/**
+		 * @return {object|null} The active menu whose items are edited.
+		 * @spec openspec/specs/content-management/spec.md#requirement-menu-management-ui-with-embedded-menu-items-cms-037
+		 */
 		menuObject() {
 			return objectStore.getActiveObject('menu')
 		},
-		/** @return {object|null} Flattened item for CnFormDialog (null in create mode). */
+		/**
+		 * @return {object|null} Flattened item for CnFormDialog (null in create mode).
+		 * @spec openspec/specs/retrofit-2026-05-26-menu-page-management/spec.md#requirement-menu-item-form-req-menu-002
+		 */
 		dialogItem() {
 			const raw = objectStore.getActiveObject('menuItem')
 			if (!raw) {
@@ -91,6 +97,7 @@ export default {
 		 *
 		 * @param {object} formData The CnFormDialog payload, keyed by field.
 		 * @return {void}
+		 * @spec openspec/specs/content-management/spec.md#requirement-menu-management-ui-with-embedded-menu-items-cms-037
 		 */
 		onConfirm(formData) {
 			const menuClone = _.cloneDeep(this.menuObject)
@@ -146,6 +153,7 @@ export default {
 		 *
 		 * @param {Array} selected The selected options.
 		 * @return {Array<string>} Group ids.
+		 * @spec openspec/specs/retrofit-2026-05-26-menu-page-management/spec.md#requirement-menu-item-form-req-menu-002
 		 */
 		normalizeGroups(selected) {
 			if (!Array.isArray(selected)) {
@@ -157,6 +165,7 @@ export default {
 		 * Close the dialog and return to the parent menu view.
 		 *
 		 * @return {void}
+		 * @spec openspec/specs/content-management/spec.md#requirement-menu-management-ui-with-embedded-menu-items-cms-037
 		 */
 		closeModal() {
 			navigationStore.setModal('viewMenu')

--- a/src/modals/object/ViewObject.vue
+++ b/src/modals/object/ViewObject.vue
@@ -808,6 +808,8 @@ export default {
 		 * because every selection block is gated on `.length > 1` (the auto-
 		 * select case hides the widget) — the observable result is a blank
 		 * modal body (WOO-527).
+		 *
+		 * @spec openspec/specs/retrofit-2026-05-26-object-modals/spec.md#requirement-object-view-edit-modal-req-objm-001
 		 */
 		selectionStalled() {
 			if (this.isLockedCatalog) return false
@@ -820,7 +822,11 @@ export default {
 			if (this.selectedRegister && this.schemaOptions.length === 0) return true
 			return false
 		},
-		/** Human-readable reason for the stalled state — surfaced in the empty-content card. */
+		/**
+		 * Human-readable reason for the stalled state — surfaced in the empty-content card.
+		 *
+		 * @spec openspec/specs/retrofit-2026-05-26-object-modals/spec.md#requirement-object-view-edit-modal-req-objm-001
+		 */
 		selectionStalledReason() {
 			if (this.selectedCatalog && this.registerOptions.length === 0) {
 				return t('opencatalogi', 'This catalog has no registers configured. Ask an administrator to attach a register that contains a publication schema to it.')
@@ -1029,6 +1035,8 @@ export default {
 			 * auto-selects the sole catalog — leaving the modal blank until
 			 * the user closes and re-opens it. Re-run the seed step as soon
 			 * as catalogs arrive (WOO-527).
+			 *
+			 * @spec openspec/specs/retrofit-2026-05-26-object-modals/spec.md#requirement-object-view-edit-modal-req-objm-001
 			 */
 			handler(newOptions) {
 				if (!this.isNewObject) return

--- a/src/views/catalogi/CatalogiIndex.vue
+++ b/src/views/catalogi/CatalogiIndex.vue
@@ -186,6 +186,13 @@ export default {
 		onSelect(ids) {
 			this.selectedIds = ids
 		},
+		/**
+		 * Open the clicked row's catalog detail page by route id.
+		 *
+		 * @param {object} row The clicked table row.
+		 * @return {void}
+		 * @spec openspec/specs/catalogs/spec.md#requirement-view-catalog-details-and-detail-page-cat-015
+		 */
 		onRowClick(row) {
 			const id = resolveObjectId(row)
 			if (id) {
@@ -197,6 +204,13 @@ export default {
 			// eslint-disable-next-line no-console
 			console.warn('[opencatalogi] onRowClick: no id resolvable from row', row)
 		},
+		/**
+		 * Open a catalog's detail page from the row action menu.
+		 *
+		 * @param {object} catalog The catalog row payload.
+		 * @return {void}
+		 * @spec openspec/specs/catalogs/spec.md#requirement-view-catalog-details-and-detail-page-cat-015
+		 */
 		viewCatalog(catalog) {
 			const id = resolveObjectId(catalog)
 			if (id) {

--- a/src/views/dashboard/Dashboard.vue
+++ b/src/views/dashboard/Dashboard.vue
@@ -485,7 +485,11 @@ export default {
 			return this.catalogs.length > 0
 				|| this.allPublications.length > 0
 		},
-		/** First catalog slug available in the store, used for Publications route navigation. */
+		/**
+		 * First catalog slug available in the store, used for Publications route navigation.
+		 *
+		 * @spec openspec/specs/retrofit-2026-05-26-dashboard-widgets/spec.md#requirement-dashboard-actions-and-layout-req-dash-002
+		 */
 		firstCatalogSlug() {
 			return this.catalogs[0]?.slug || null
 		},
@@ -570,6 +574,7 @@ export default {
 		 * counts.
 		 *
 		 * @return {Promise<void>}
+		 * @spec openspec/specs/dashboard/spec.md#requirement-dashboard-overview-view-dsh-010
 		 */
 		async fetchPublicationAggregations() {
 			if (!PUBLICATION_REGISTER || !PUBLICATION_SCHEMA) {
@@ -752,6 +757,8 @@ export default {
 		 * Status-based filtering is intentionally omitted: publication status is
 		 * derived from date fields (publicatiedatum / depublicatiedatum), not a
 		 * simple status query parameter.
+		 *
+		 * @spec openspec/specs/retrofit-2026-05-26-dashboard-widgets/spec.md#requirement-dashboard-actions-and-layout-req-dash-002
 		 */
 		navigateToPublications() {
 			if (this.firstCatalogSlug) {
@@ -765,6 +772,7 @@ export default {
 		 * Resolve a catalog slug from a catalog ID reference on a publication.
 		 * @param {string|number|object|null} catalogRef - catalog field value from a publication
 		 * @return {string|null}
+		 * @spec openspec/specs/retrofit-2026-05-26-dashboard-widgets/spec.md#requirement-dashboard-actions-and-layout-req-dash-002
 		 */
 		catalogSlugById(catalogRef) {
 			if (!catalogRef) return this.firstCatalogSlug

--- a/src/views/directory/DirectoryIndex.vue
+++ b/src/views/directory/DirectoryIndex.vue
@@ -290,6 +290,15 @@ export default {
 			if (cleanUrl.length > 35) return cleanUrl.substring(0, 32) + '...'
 			return cleanUrl
 		},
+		/**
+		 * Re-add the peer directory URL through the admin-gated
+		 * `POST /api/listings/add` endpoint, which re-reads the peer's directory
+		 * and creates/updates its listings.
+		 *
+		 * @param {object} listing The listing whose `directory` URL is re-submitted.
+		 * @return {Promise<void>}
+		 * @spec openspec/specs/dashboard/spec.md#requirement-add-a-new-listing-from-a-url-admin-only-dir-005
+		 */
 		async refreshDirectory(listing) {
 			try {
 				// Auth-required `/api/listings/add` (WOO-513) — same syncDirectory()
@@ -315,6 +324,14 @@ export default {
 				showError(`Failed to sync directory: ${error.message}`)
 			}
 		},
+		/**
+		 * Toggle a listing between `integrationLevel: 'search'` (participates in
+		 * the federated search fan-out) and `'connection'` (does not).
+		 *
+		 * @param {object} listing The listing to toggle.
+		 * @return {Promise<void>}
+		 * @spec openspec/specs/federation/spec.md#requirement-listings-with-integrationlevel-search-included-in-federated-search-fed-010
+		 */
 		async toggleIntegrationLevel(listing) {
 			try {
 				const newLevel = (!listing.integrationLevel || listing.integrationLevel === 'none' || listing.integrationLevel === 'connection') ? 'search' : 'connection'
@@ -326,6 +343,14 @@ export default {
 				showError(`Failed to update directory: ${error.message}`)
 			}
 		},
+		/**
+		 * Update a listing's `default` flag, clearing the flag from any other
+		 * listing so exactly one stays default.
+		 *
+		 * @param {object} listing The listing to update.
+		 * @return {Promise<void>}
+		 * @spec openspec/specs/dashboard/spec.md#requirement-update-an-existing-listing-lst-004
+		 */
 		async toggleDefault(listing) {
 			try {
 				const newDefaultState = !listing.default

--- a/src/views/directory/FederationDirectory.vue
+++ b/src/views/directory/FederationDirectory.vue
@@ -42,6 +42,13 @@ export default {
 		}
 	},
 	computed: {
+		/**
+		 * The active navigation-store modal key, watched so the directory list
+		 * reloads once an add/edit/delete modal closes.
+		 *
+		 * @return {string|null} The active modal key.
+		 * @spec openspec/specs/dashboard/spec.md#requirement-directory-management-ui-dir-012
+		 */
 		modalState() {
 			return navigationStore.modal
 		},

--- a/src/views/menus/MenuIndex.vue
+++ b/src/views/menus/MenuIndex.vue
@@ -132,10 +132,15 @@ export default {
 		}
 	},
 	computed: {
-		// Augment the OpenRegister menu schema with an `icon` property rendered
-		// by the shared CnIconPicker (via CnFormDialog's schema-driven
-		// `widget: 'icon'`). Sources: MDI (default), plus FontAwesome and an
-		// OpenGemeenten sample supplied as consumer catalogues; custom SVG enabled.
+		/**
+		 * Augment the OpenRegister menu schema with an `icon` property rendered
+		 * by the shared CnIconPicker (via CnFormDialog's schema-driven
+		 * `widget: 'icon'`). Sources: MDI (default), plus FontAwesome and an
+		 * OpenGemeenten sample supplied as consumer catalogues; custom SVG enabled.
+		 *
+		 * @return {object} The menu schema with the icon property merged in.
+		 * @spec openspec/specs/content-management/spec.md#requirement-menu-management-ui-with-embedded-menu-items-cms-037
+		 */
 		menuSchema() {
 			const base = this.schema || {}
 			return {
@@ -181,6 +186,13 @@ export default {
 		onSelect(ids) {
 			this.selectedIds = ids
 		},
+		/**
+		 * Open the clicked menu's detail page.
+		 *
+		 * @param {object} row The clicked table row.
+		 * @return {void}
+		 * @spec openspec/specs/content-management/spec.md#requirement-menu-management-ui-with-embedded-menu-items-cms-037
+		 */
 		onRowClick(row) {
 			const id = resolveObjectId(row)
 			if (id) {
@@ -190,6 +202,13 @@ export default {
 			// eslint-disable-next-line no-console
 			console.warn('[opencatalogi] onRowClick: no id resolvable from row', row)
 		},
+		/**
+		 * Open a menu for editing on its detail page.
+		 *
+		 * @param {object} menu The menu row payload.
+		 * @return {void}
+		 * @spec openspec/specs/content-management/spec.md#requirement-menu-management-ui-with-embedded-menu-items-cms-037
+		 */
 		editMenu(menu) {
 			const id = resolveObjectId(menu)
 			if (id) {

--- a/src/views/pages/PageIndex.vue
+++ b/src/views/pages/PageIndex.vue
@@ -157,6 +157,13 @@ export default {
 		onSelect(ids) {
 			this.selectedIds = ids
 		},
+		/**
+		 * Open the clicked page's detail page.
+		 *
+		 * @param {object} row The clicked table row.
+		 * @return {void}
+		 * @spec openspec/specs/content-management/spec.md#requirement-page-management-ui-with-embedded-content-blocks-cms-036
+		 */
 		onRowClick(row) {
 			// PageDetail route params.id is a slug when available so the URL
 			// stays human-readable; fall back to the OpenRegister object id
@@ -170,6 +177,13 @@ export default {
 			// eslint-disable-next-line no-console
 			console.warn('[opencatalogi] onRowClick: no id resolvable from row', row)
 		},
+		/**
+		 * Open a page's detail page from the row action menu.
+		 *
+		 * @param {object} page The page row payload.
+		 * @return {void}
+		 * @spec openspec/specs/content-management/spec.md#requirement-page-management-ui-with-embedded-content-blocks-cms-036
+		 */
 		viewPage(page) {
 			// PageDetail route params.id is a slug when available so the URL
 			// stays human-readable; fall back to the OpenRegister object id

--- a/src/views/publications/PublicationDetail.vue
+++ b/src/views/publications/PublicationDetail.vue
@@ -759,6 +759,7 @@ export default {
 		 * pinned to 1. Pagination is derived from the real array below.
 		 *
 		 * @return {Array<object>} Every attachment currently loaded.
+		 * @spec openspec/specs/publications/spec.md#requirement-retrieve-publication-attachments-files-linked-to-a-publication-pub-006
 		 */
 		publicationAttachments() {
 			return objectStore.getCollection('publicationAttachments').results || []
@@ -771,6 +772,7 @@ export default {
 		 * array length and paging is applied client-side in `pagedAttachments`.
 		 *
 		 * @return {number} Attachment count.
+		 * @spec openspec/specs/publications/spec.md#requirement-retrieve-publication-attachments-files-linked-to-a-publication-pub-006
 		 */
 		attachmentsTotal() {
 			return this.publicationAttachments.length
@@ -779,6 +781,7 @@ export default {
 		 * Number of attachment pages at the current page size.
 		 *
 		 * @return {number} Page count, at least 1.
+		 * @spec openspec/specs/retrofit-2026-05-26-object-table-listing/spec.md#requirement-pagination-component-req-tbl-004
 		 */
 		attachmentsTotalPages() {
 			return Math.max(1, Math.ceil(this.attachmentsTotal / this.limit))
@@ -787,6 +790,7 @@ export default {
 		 * The attachments visible on the current page.
 		 *
 		 * @return {Array<object>} The current page's slice.
+		 * @spec openspec/specs/retrofit-2026-05-26-object-table-listing/spec.md#requirement-pagination-component-req-tbl-004
 		 */
 		pagedAttachments() {
 			const start = (this.currentPage - 1) * this.limit
@@ -797,6 +801,7 @@ export default {
 		 * entries rather than the bare numbers held in `limitOptions`.
 		 *
 		 * @return {Array<{value: number, label: string}>} Page-size options.
+		 * @spec openspec/specs/retrofit-2026-05-26-object-table-listing/spec.md#requirement-pagination-component-req-tbl-004
 		 */
 		pageSizeOptions() {
 			return this.limitOptions.options.map((size) => ({ value: size, label: String(size) }))
@@ -870,6 +875,7 @@ export default {
 		 *
 		 * @param {number} page The 1-based page to show.
 		 * @return {void}
+		 * @spec openspec/specs/retrofit-2026-05-26-object-table-listing/spec.md#requirement-pagination-component-req-tbl-004
 		 */
 		onAttachmentsPageChanged(page) {
 			this.currentPage = Math.min(Math.max(page, 1), this.attachmentsTotalPages)
@@ -879,6 +885,7 @@ export default {
 		 *
 		 * @param {number} size The new page size.
 		 * @return {void}
+		 * @spec openspec/specs/retrofit-2026-05-26-object-table-listing/spec.md#requirement-pagination-component-req-tbl-004
 		 */
 		onAttachmentsPageSizeChanged(size) {
 			this.limit = Number(size)

--- a/src/views/search/FederationSearch.vue
+++ b/src/views/search/FederationSearch.vue
@@ -28,12 +28,32 @@ export default {
 		}
 	},
 	computed: {
+		/**
+		 * The federation search store's result rows, rendered as-is — no local
+		 * filtering, faceting or scoring happens here.
+		 *
+		 * @return {Array<object>} Result rows from the federation endpoint.
+		 * @spec openspec/specs/search/spec.md#requirement-search-ui-components-sch-or-006
+		 */
 		results() {
 			return this.searchStore.searchResults || []
 		},
+		/**
+		 * Total result count as reported by the federation endpoint's pagination
+		 * envelope — not counted locally.
+		 *
+		 * @return {number} Total number of results.
+		 * @spec openspec/specs/search/spec.md#requirement-search-ui-components-sch-or-006
+		 */
 		totalCount() {
 			return this.searchStore.pagination?.total || 0
 		},
+		/**
+		 * Whether the federation search store has a request in flight.
+		 *
+		 * @return {boolean} True while loading.
+		 * @spec openspec/specs/search/spec.md#requirement-search-ui-components-sch-or-006
+		 */
 		loading() {
 			return this.searchStore.loading
 		},
@@ -53,6 +73,13 @@ export default {
 			}
 		},
 	},
+	/**
+	 * Seed the query input from the store and load the initial result set
+	 * through the federation-aware search store.
+	 *
+	 * @return {void}
+	 * @spec openspec/specs/search/spec.md#requirement-search-frontend-store-calls-the-federation-endpoint-sch-or-004
+	 */
 	mounted() {
 		this.localQuery = this.searchStore.searchTerm || ''
 		this.searchStore.loadInitialResults()

--- a/src/views/themes/ThemeIndex.vue
+++ b/src/views/themes/ThemeIndex.vue
@@ -146,6 +146,13 @@ export default {
 		onSelect(ids) {
 			this.selectedIds = ids
 		},
+		/**
+		 * Open the clicked theme's detail page.
+		 *
+		 * @param {object} row The clicked table row.
+		 * @return {void}
+		 * @spec openspec/specs/content-management/spec.md#requirement-theme-management-ui-cms-038
+		 */
 		onRowClick(row) {
 			const id = resolveObjectId(row)
 			if (id) {
@@ -155,6 +162,13 @@ export default {
 			// eslint-disable-next-line no-console
 			console.warn('[opencatalogi] onRowClick: no id resolvable from row', row)
 		},
+		/**
+		 * Open a theme's detail page from the row action menu.
+		 *
+		 * @param {object} theme The theme row payload.
+		 * @return {void}
+		 * @spec openspec/specs/content-management/spec.md#requirement-theme-management-ui-cms-038
+		 */
 		viewTheme(theme) {
 			const id = resolveObjectId(theme)
 			if (id) {


### PR DESCRIPTION
## What

Adds `@spec` traceability tags to the 55 methods hydra **gate-16 spec-coverage** reported as untagged on the `development → beta` diff.

## Measurement

Gate package SHA: **`651e5c5bb3ba8764903e5d6fc5bac5a208bd67fc`**

Command (the honest bar — gate-16 is diff-scoped *inside its own helper*, so a whole-repo run reports PASS over an empty scope):

```
NODE_PATH=<server>/node_modules \
bash hydra-gates/scripts/run-hydra-gates.sh --scope-to-diff --base origin/beta .
```

stderr was **0 bytes** on every run (a crashed python helper prints `PASS`), and only stdout was read — the exit byte is a finding count, not a status.

| gate | before | after |
|---|---|---|
| **gate-16 spec-coverage** | **FAIL — 54** | **PASS — 0** |
| gate-46 spec-anchor-existence | PASS | **PASS** |
| gate-19 e2e-coverage | FAIL — 36 | FAIL — 36 (unchanged) |
| gate-26 visual-coverage | FAIL — 1 | FAIL — 1 (unchanged) |
| gate-57 orphaned-write-capability | FAIL — 2 | FAIL — 2 (unchanged) |
| all other 59 gates | PASS / N-A / SKIPPED | identical |

No other gate's count rose. gate-24 and gate-33 remain NOT APPLICABLE, gate-60 remains SKIPPED (wiring — `vue-material-design-icons` not installed in the measurement worktree), exactly as at baseline.

> 55 methods, 54 findings: `FederationAddDirectoryModal.vue` declares `isOpen` **twice** — a computed and a watcher of the same name — and gate-16 de-duplicates findings by `file::name`, so both hid behind one line. Tagging only the computed left the gate red at 1. Both are now tagged.

## How the anchors were chosen and checked

1. **Canonical targets only.** Every tag points at `openspec/specs/<capability>/spec.md#requirement-…`. No tag points into `openspec/changes/…`, which is exactly how 26 tags broke when their change was archived (#836).
2. **Every anchor verified BEFORE editing**, with the gate's own resolver (`check_spec_anchors.has_anchor`) — 22 distinct anchors, all `True`.
3. **Positive control is worthless without a negative one.** Three known-fake anchors (`…-dir-912`, `…-sch-or-999`, `requirement-invented-nonsense-anchor`) were run through the same resolver and all returned `False`, proving the resolver can still say no.
4. Methods that implement different requirements from their neighbours are tagged differently rather than pointed at one convenient anchor (see the mapping below).

## Mapping

| File | Method(s) | Requirement |
|---|---|---|
| `lib/Service/OoapiService.php` | `listCourses`, `listPrograms` | `ooapi-catalog-publication` OOAPI-001 — per-catalog OOAPI 5.0 resource endpoints |
| `lib/Service/OoapiService.php` | `listOfferings` | `ooapi-catalog-publication` OOAPI-006 — offerings nest under their course (it is the one that filters on `courseId`) |
| `src/components/tabs/AppTabs.vue` | `register`, `unregister` | `generic-object-modals` GOM-005 — shared presentation components used across capabilities |
| `src/components/widgets/ThemePreviewWidget.vue` | `ctx`, `theme`, `pickers`, `defaults`, `value`, `sampleTitle`, `sampleBodyText` | `content-management` CMS-038 — theme management UI |
| `src/composables/useChartColors.js` | `useCategoricalChartColors`, `useAccentChartColor` | `frontend-theming` THM-001 — chart palettes resolve from NC CSS variables at runtime |
| `src/modals/directory/FederationAddDirectoryModal.vue` | `isOpen` (computed), `isOpen` (watcher), `reset`, `close` | `retrofit-2026-05-26-directory-federation` REQ-DIR-003 — add/view-directory modals close on completion |
| `src/modals/generic/UploadFiles.vue` | `unmounted` | `retrofit-2026-05-26-object-modals` REQ-OBJM-004 — file attachment management (it cancels the pending duplicate-file warning timer) |
| `src/modals/menuItem/MenuItemForm.vue` | `menuObject`, `onConfirm`, `closeModal` | `content-management` CMS-037 — menu management UI (`onConfirm` persists the whole parent menu via `updateObject('menu', …)`, the CMS-037 scenario verbatim) |
| `src/modals/menuItem/MenuItemForm.vue` | `dialogItem`, `normalizeGroups` | `retrofit-2026-05-26-menu-page-management` REQ-MENU-002 — menu item form, which names normalized group scoping explicitly |
| `src/modals/object/ViewObject.vue` | `selectionStalled`, `selectionStalledReason`, `catalogOptions` watcher `handler` | `retrofit-2026-05-26-object-modals` REQ-OBJM-001 — object view/edit modal register/schema context |
| `src/views/catalogi/CatalogiIndex.vue` | `onRowClick`, `viewCatalog` | `catalogs` CAT-015 — view catalog details and detail page (resolved by route `id`) |
| `src/views/dashboard/Dashboard.vue` | `fetchPublicationAggregations` | `dashboard` DSH-010 — total count sourced from OR's ad-hoc aggregation `value` endpoint |
| `src/views/dashboard/Dashboard.vue` | `firstCatalogSlug`, `navigateToPublications`, `catalogSlugById` | `retrofit-2026-05-26-dashboard-widgets` REQ-DASH-002 — dashboard actions (open a publication) |
| `src/views/directory/DirectoryIndex.vue` | `refreshDirectory` | `dashboard` DIR-005 — add a listing from a URL (admin-only). Tagged on the endpoint it actually calls (`POST /api/listings/add`), **not** DIR-003, which is `POST /api/listings/sync` and is not what this method invokes |
| `src/views/directory/DirectoryIndex.vue` | `toggleIntegrationLevel` | `federation` FED-010 — `integrationLevel: "search"` listings join the federated search fan-out |
| `src/views/directory/DirectoryIndex.vue` | `toggleDefault` | `dashboard` LST-004 — update an existing listing |
| `src/views/directory/FederationDirectory.vue` | `modalState` | `dashboard` DIR-012 — directory management UI |
| `src/views/menus/MenuIndex.vue` | `menuSchema`, `onRowClick`, `editMenu` | `content-management` CMS-037 — menu management UI |
| `src/views/pages/PageIndex.vue` | `onRowClick`, `viewPage` | `content-management` CMS-036 — page management UI |
| `src/views/publications/PublicationDetail.vue` | `publicationAttachments`, `attachmentsTotal` | `publications` PUB-006 — retrieve publication attachments |
| `src/views/publications/PublicationDetail.vue` | `attachmentsTotalPages`, `pagedAttachments`, `pageSizeOptions`, `onAttachmentsPageChanged`, `onAttachmentsPageSizeChanged` | `retrofit-2026-05-26-object-table-listing` REQ-TBL-004 — pagination: change page and page size, compute the page window |
| `src/views/search/FederationSearch.vue` | `mounted` | `search` SCH-OR-004 — the frontend store calls the federation endpoint |
| `src/views/search/FederationSearch.vue` | `results`, `totalCount`, `loading` | `search` SCH-OR-006 — search UI renders the OR response with no local filter/facet/score computation |
| `src/views/themes/ThemeIndex.vue` | `onRowClick`, `viewTheme` | `content-management` CMS-038 — theme management UI |

## Left untagged

**None.** All 54 findings (55 methods) carry a truthful canonical tag.

## Not done, deliberately

No `@spec exclude`, no waiver, no baseline, no threshold change, no `.skip`, no `continue-on-error`, no check deleted. Pre-existing `@spec exclude` tags in touched files were left exactly as they were — they are outside this change's scope.
