### PR TITLE
fix(gates): close gate-45, clear the redundant half of gate-57

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -726,3 +726,39 @@
     gap: 3px;
   }
 }
+
+/**
+ * Reduced-motion fallback (WCAG 2.2 AA, Success Criterion 2.3.3 Animation
+ * from Interactions; hydra gate-45).
+ *
+ * Three rules in this stylesheet animate: `.card` (transform), 
+ * `.nestedCardHeader` (background-color) and `.toggleButton` (all). Only one
+ * of them produces actual MOVEMENT — `.card:hover` scales the card — and that
+ * is the one a motion-sensitive user needs suppressed, so the transform is
+ * neutralised here as well as its transition. The colour transitions are
+ * dropped for consistency; a colour change is not movement, but an instant
+ * change is never worse for the user this block exists to serve.
+ *
+ * Scoped to the three selectors that actually declare motion rather than
+ * written as a blanket `*, *::before, *::after { transition: none !important }`.
+ * A global override reaches into every Nextcloud core component and every
+ * nc-vue component rendered inside this app, disabling transitions this
+ * stylesheet never introduced and cannot reason about.
+ */
+@media (prefers-reduced-motion: reduce) {
+  .card {
+    transition: none;
+  }
+
+  .card:hover {
+    transform: none;
+  }
+
+  .nestedCardHeader {
+    transition: none;
+  }
+
+  .toggleButton {
+    transition: none;
+  }
+}

--- a/lib/Service/FileService.php
+++ b/lib/Service/FileService.php
@@ -50,15 +50,12 @@ use OCP\IUserSession;
 use OCP\Lock\LockedException;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
-use RecursiveDirectoryIterator;
-use RecursiveIteratorIterator;
 use RuntimeException;
 use Twig\Environment;
 use Twig\Error\LoaderError;
 use Twig\Error\RuntimeError;
 use Twig\Error\SyntaxError;
 use Twig\Loader\FilesystemLoader;
-use ZipArchive;
 
 /**
  * Service for handling file operations in OpenCatalogi.
@@ -556,94 +553,4 @@ class FileService
         return $mpdf;
 
     }//end createPdf()
-
-    /**
-     * Creates a ZIP archive at the $tempZip location using the
-     * $tempFolder location as input for the ZIP archive.
-     * Please use "unlink(filename: $tempZip);" or the downloadZip()
-     * function after calling this function to clean up temporary files.
-     *
-     * @param string $inputFolder The (tmp) location used as input for creating the ZIP archive.
-     * @param string $tempZip     The tmp location where the ZIP will
-     *                            be saved. Please start this with
-     *                            '/tmp/..' and end with
-     *                            '../zipName.zip'.
-     *
-     * @return string|null Returns null if created successfully and a string in case of an error.
-     *
-     * @spec openspec/specs/file-management/spec.md
-     */
-    public function createZip(string $inputFolder, string $tempZip): ?string
-    {
-        // Create ZIP archive.
-        $zip = new ZipArchive();
-        if ($zip->open(filename: $tempZip, flags: (ZipArchive::CREATE | ZipArchive::OVERWRITE)) !== true) {
-            return "failed to create ZIP archive";
-        }
-
-        $files = new RecursiveIteratorIterator(
-            iterator: new RecursiveDirectoryIterator($inputFolder),
-            mode: RecursiveIteratorIterator::LEAVES_ONLY
-        );
-
-        foreach ($files as $file) {
-            // Skip directories (they would be added automatically).
-            if ($file->isDir() === false) {
-                $filePath     = $file->getRealPath();
-                $relativePath = substr(string: $filePath, offset: (strlen(string: $inputFolder) + 1));
-
-                // Add file to zip.
-                $zip->addFile(filepath: $filePath, entryname: $relativePath);
-            }
-        }
-
-        $zip->close();
-
-        return null;
-
-    }//end createZip()
-
-    /**
-     * A function that outputs a downloadable ZIP to the response body of the current api request.
-     * Can best be used after creating a ZIP archive with the createZip() function.
-     *
-     * @param string      $tempZip     The tmp location where the ZIP is saved.
-     *                                 Note that "unlink(filename: $tempZip);"
-     *                                 will be called at the end of this
-     *                                 function.                    function.
-     * @param string|null $inputFolder The tmp location used as input
-     *                                 for creating the ZIP archive.
-     *                                 Will unlink all files in this
-     *                                 folder and remove this folder at
-     *                                 the end of this function.
-     *
-     * @return void
-     *
-     * @spec openspec/specs/file-management/spec.md
-     */
-    public function downloadZip(string $tempZip, ?string $inputFolder=null): void
-    {
-        // Send the ZIP file to the client for download.
-        header(header: 'Content-Type: application/zip');
-        header(header: 'Content-disposition: attachment; filename='.basename($tempZip));
-        header(header: 'Content-Length: '.filesize($tempZip));
-        readfile(filename: $tempZip);
-
-        // Cleanup temporary files.
-        if ($inputFolder !== null) {
-            $globResult = glob("$inputFolder/*.*");
-            if ($globResult === false) {
-                $globResult = [];
-            }
-
-            foreach ($globResult as $file) {
-                unlink($file);
-            }
-
-            rmdir(directory: $inputFolder);
-        }
-
-        unlink(filename: $tempZip);
-
-    }//end downloadZip()
 }//end class

--- a/tests/Unit/Service/FileServiceTest.php
+++ b/tests/Unit/Service/FileServiceTest.php
@@ -1094,91 +1094,17 @@ class FileServiceTest extends \PHPUnit\Framework\TestCase
 
     }//end testDeleteFileGuestUser()
 
-    /**
-     * Creates a ZIP archive containing all files in the input folder.
-     *
-     * @return void
-     */
-    public function testCreateZipSuccess(): void
-    {
-        $inputFolder = sys_get_temp_dir().'/test_zip_input_'.uniqid();
-        mkdir($inputFolder, 0777, true);
-        file_put_contents("$inputFolder/file1.txt", 'Hello');
-        file_put_contents("$inputFolder/file2.txt", 'World');
-
-        $tempZip = sys_get_temp_dir().'/test_output_'.uniqid().'.zip';
-
-        $result = $this->fileService->createZip($inputFolder, $tempZip);
-
-        $this->assertNull($result);
-        $this->assertFileExists($tempZip);
-
-        $zip = new \ZipArchive();
-        $zip->open($tempZip);
-        $this->assertSame(2, $zip->numFiles);
-        $zip->close();
-
-        unlink("$inputFolder/file1.txt");
-        unlink("$inputFolder/file2.txt");
-        rmdir($inputFolder);
-        unlink($tempZip);
-
-    }//end testCreateZipSuccess()
-
-    /**
-     * Handles an empty input folder without errors.
-     *
-     * @return void
-     */
-    public function testCreateZipEmptyFolder(): void
-    {
-        $inputFolder = sys_get_temp_dir().'/test_zip_empty_'.uniqid();
-        mkdir($inputFolder, 0777, true);
-
-        $tempZip = sys_get_temp_dir().'/test_empty_'.uniqid().'.zip';
-
-        $result = @$this->fileService->createZip($inputFolder, $tempZip);
-
-        $this->assertNull($result);
-
-        rmdir($inputFolder);
-        if (file_exists($tempZip) === true) {
-            unlink($tempZip);
-        }
-
-    }//end testCreateZipEmptyFolder()
-
-    /**
-     * Includes files from sub-directories.
-     *
-     * @return void
-     */
-    public function testCreateZipWithSubdirectory(): void
-    {
-        $inputFolder = sys_get_temp_dir().'/test_zip_subdir_'.uniqid();
-        mkdir("$inputFolder/subdir", 0777, true);
-        file_put_contents("$inputFolder/root.txt", 'root');
-        file_put_contents("$inputFolder/subdir/nested.txt", 'nested');
-
-        $tempZip = sys_get_temp_dir().'/test_subdir_'.uniqid().'.zip';
-
-        $result = $this->fileService->createZip($inputFolder, $tempZip);
-
-        $this->assertNull($result);
-
-        $zip = new \ZipArchive();
-        $zip->open($tempZip);
-        $this->assertSame(2, $zip->numFiles);
-        $zip->close();
-
-        unlink("$inputFolder/root.txt");
-        unlink("$inputFolder/subdir/nested.txt");
-        rmdir("$inputFolder/subdir");
-        rmdir($inputFolder);
-        unlink($tempZip);
-
-    }//end testCreateZipWithSubdirectory()
-
+    // The three testCreateZip* cases that stood here were removed with the
+    // methods they called. `FileService::createZip()` / `downloadZip()` are
+    // REMOVED requirements FIL-012 / FIL-013 / FIL-014 in
+    // openspec/specs/file-management/spec.md ("ZIP generation is the
+    // responsibility of the download-service spec"), and the live download
+    // path uses OpenRegister's FileService::createObjectFilesZip() instead.
+    //
+    // The tests are not lost coverage. Each one built a temp folder, called
+    // the wrapper, and asserted on ext-zip's own output — they exercised PHP's
+    // ZipArchive through a pass-through, and asserted nothing about
+    // opencatalogi behaviour that survives the deletion.
     // phpcs:enable CustomSniffs.Functions.NamedParameters
 
 }//end class


### PR DESCRIPTION
Full-scope `workflow_dispatch` run [31393744933](https://github.com/ConductionNL/opencatalogi/actions/runs/31393744933) reported 4 red gates on `development`: gate-19 (41), gate-26 (12), gate-45 (1), gate-57 (2). This closes gate-45 and half of gate-57.

## gate-45 prefers-reduced-motion 1 → 0

`css/main.css` animates three rules and guarded none: `.card` (transform), `.nestedCardHeader` (background-color), `.toggleButton` (all). Only one produces actual **movement** — `.card:hover` scales the card — so the transform is neutralised as well as its transition (WCAG 2.2 AA, SC 2.3.3).

Scoped to the three selectors that actually declare motion, **not** a blanket `*, *::before, *::after { transition: none !important }`. A global override reaches into every Nextcloud core and nc-vue component rendered inside this app, disabling transitions this stylesheet never introduced and cannot reason about — a bigger behavioural change than the finding, dressed as a smaller one.

## gate-57 orphaned-write-capability 2 → 1

`FileService::createZip()` had zero production callers. The gate's docstring names two remedies and warns against the wrong one: wire it, or delete it when the capability is **already live elsewhere**. It is, and the spec says so outright.

`openspec/specs/file-management/spec.md` records **FIL-012 / FIL-013 / FIL-014 as REMOVED** requirements — *"ZIP generation is the responsibility of the download-service spec"*. The code was never deleted with them. The live download path (`publications#download`, `search#download`, `federation#publicationDownload` → `PublicationService::download()`) uses OpenRegister's `FileService::createObjectFilesZip()` via DI, per ADR-022. The local wrapper is a pre-adoption leftover.

Removed: `createZip()`, its only companion `downloadZip()` (also zero callers, reachable only via `createZip()`'s docblock), and three now-unused imports.

The three `testCreateZip*` cases go with them. **Not lost coverage**: each built a temp folder, called the pass-through, and asserted on ext-zip's own output — they exercised PHP's `ZipArchive`, not opencatalogi behaviour, and there is nothing left to call.

## Both directions

Full-scope `hydra-gates --full` over the whole tree:

| | gate-45 | gate-57 | gate-26 | gate-19 |
|---|---|---|---|---|
| before | **FAIL 1** | **FAIL 2** | FAIL 12 | FAIL 41 |
| after | PASS | FAIL 1 | FAIL 12 | FAIL 41 |

`phpcs` over `lib/` is byte-identical either side: **0 errors, 107 warnings, 47 files**, before and after.

## Deliberately still red

gate-57's remaining finding, `DownloadService::createPublicationFile()`. **It must not be deleted** — `openspec/specs/download-service/spec.md` *requires* the capability (DWN-OR-003 "metadata PDF generation remains as a rendering step"; DWN-OR-001's scenario "ZIP contains the metadata PDF and all OR attachments").

What the gate has actually surfaced is that the requirement was **never implemented end to end**:

- nothing calls the method;
- the live ZIP path never renders a metadata PDF;
- the method saves to Nextcloud user storage, which DWN-OR-003 explicitly forbids;
- the Twig template it renders, `publication.html.twig`, **does not exist** in `lib/Templates` (only `test.html.twig` does) — so it could not have run even if it were wired.

Closing it means implementing DWN-OR-001/003: a feature whose runtime behaviour needs a live instance to verify, not a gate fix. Left visible rather than papered over with an exclude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)