### PR TITLE
fix(gate-57): render the publication metadata PDF into the download ZIP

### DIFF
--- a/lib/Service/DownloadService.php
+++ b/lib/Service/DownloadService.php
@@ -2,9 +2,9 @@
 /**
  * Service for managing download-related operations.
  *
- * Provides functionality to create and manage publication files and archives, including
- * generating PDFs and ZIP files containing metadata and attachments, and storing files
- * in NextCloud.
+ * Renders the publication metadata PDF that is piped into the download ZIP and
+ * enumerates a publication's attachments. Per DWN-OR-003 the rendered PDF is an
+ * on-demand artefact — it is never saved to Nextcloud user storage by this service.
  *
  * @category Service
  * @package  OCA\OpenCatalogi\Service
@@ -48,9 +48,9 @@ use Exception;
 /**
  * Service for managing download-related operations.
  *
- * Provides functionality to create and manage publication files and archives, including
- * generating PDFs and ZIP files containing metadata and attachments, and storing files
- * in NextCloud.
+ * Renders the publication metadata PDF that is piped into the download ZIP and
+ * enumerates a publication's attachments. Per DWN-OR-003 the rendered PDF is an
+ * on-demand artefact — it is never saved to Nextcloud user storage by this service.
  *
  * @spec openspec/changes/migrate-share-links-to-shares-leaf/tasks.md#task-2
  */
@@ -68,17 +68,21 @@ class DownloadService
     }//end __construct()
 
     /**
-     * Creates a pdf file containing all metadata of the given publication.
+     * Renders the publication metadata PDF and returns it as an in-memory artefact.
+     *
+     * The PDF is written to a temporary location, read back, and the temporary file
+     * is deleted before returning — it is never saved to Nextcloud user storage
+     * (DWN-OR-003). Callers pipe the returned bytes into the download ZIP.
      *
      * @param ObjectService  $objectService The ObjectService for database access.
      * @param string|integer $id            The id of the Publication to create a pdf for.
      * @param array|null     $options       Options for this function.
-     *                                      "download" and "saveToNextCloud" cannot both be false.
-     *                                      "download" = return a download response (true default).
-     *                                      "saveToNextCloud" = save file in NextCloud (true default).
+     *                                      "download" = produce the artefact (true default);
+     *                                      when false there is no output option left enabled
+     *                                      and the service returns 400 without rendering.
      *                                      "publication" = pre-fetched publication body.
      *
-     * @return JSONResponse A download response, download URL, or error response.
+     * @return array|JSONResponse ['filename' => string, 'content' => string] or an error response.
      * @throws LoaderError|RuntimeError|SyntaxError|MpdfException|Exception
      *
      * @spec openspec/specs/download-service/spec.md
@@ -87,20 +91,19 @@ class DownloadService
         ObjectService $objectService,
         string|int $id,
         ?array $options=[
-            'download'        => true,
-            'saveToNextCloud' => true,
-            'publication'     => null,
+            'download'    => true,
+            'publication' => null,
         ]
-    ): JSONResponse {
-        // Validate options.
-        if ($options['download'] === false && $options['saveToNextCloud'] === false) {
+    ): array | JSONResponse {
+        // Validate options before generating any file content (DWN-OR-004).
+        if (($options['download'] ?? true) === false) {
             return new JSONResponse(
-                data: ['error' => 'Options "download" and "saveToNextCloud" should not both be false'],
-                statusCode: 500
+                data: ['error' => 'At least one output option must be enabled; "download" was false'],
+                statusCode: 400
             );
         }
 
-        // Get publication data if not provided.
+        // Get publication data if not provided (DWN-OR-005 returns 404 when unresolvable).
         $publication = ($options['publication'] ?? $this->getPublicationData($id, $objectService));
         if ($publication instanceof JSONResponse) {
             return $publication;
@@ -111,36 +114,36 @@ class DownloadService
 
         $filename = "{$publication['title']}.pdf";
 
-        // Save to NextCloud if option is set.
-        $shareLink = null;
-        if ($options['saveToNextCloud'] ?? true) {
-            $mpdf->Output($filename, Destination::FILE);
-            $shareLink = $this->saveFileToNextCloud($filename, $publication);
-            if ($shareLink instanceof JSONResponse) {
-                return $shareLink;
+        // Render to a temporary location, read it back, and remove the temporary file.
+        // The metadata PDF is an on-demand artefact — it MUST NOT be written to
+        // Nextcloud user storage by this service (DWN-OR-003).
+        $tempDir = sys_get_temp_dir().'/mpdf';
+        if (is_dir($tempDir) === false) {
+            mkdir(directory: $tempDir, permissions: 0777, recursive: true);
+        }
+
+        $tempPath = $tempDir.'/'.bin2hex(random_bytes(16)).'.pdf';
+
+        try {
+            $mpdf->Output($tempPath, Destination::FILE);
+            $content = file_get_contents($tempPath);
+        } finally {
+            if (file_exists($tempPath) === true) {
+                unlink($tempPath);
             }
         }
 
-        // Download if option is set.
-        if ($options['download'] ?? true) {
-            $mpdf->Output($filename, Destination::DOWNLOAD);
-        }
-
-        // Clean up temporary files.
-        rmdir('/tmp/mpdf');
-
-        // Return download URL if saved to NextCloud.
-        if ($options['saveToNextCloud'] ?? true) {
+        if ($content === false) {
             return new JSONResponse(
-                [
-                    'downloadUrl' => "$shareLink/download",
-                    'filename'    => $filename,
-                ],
-                200
+                data: ['error' => 'Failed to read the rendered publication metadata PDF'],
+                statusCode: 500
             );
         }
 
-        return new JSONResponse([], 200);
+        return [
+            'filename' => $filename,
+            'content'  => $content,
+        ];
 
     }//end createPublicationFile()
 
@@ -179,53 +182,6 @@ class DownloadService
         }//end try
 
     }//end getPublicationData()
-
-    /**
-     * Store a publication metadata file in NextCloud and return its share link.
-     *
-     * @param string $filename    The filename of the file to store in NextCloud
-     * @param array  $publication The publication data for folder creation
-     *
-     * @return string|JSONResponse A share link url or an error JSONResponse
-     * @throws Exception When reading or writing to NextCloud files fails
-     *
-     * @NoAdminRequired
-     * @NoCSRFRequired
-     *
-     * @spec openspec/specs/download-service/spec.md
-     */
-    public function saveFileToNextCloud(string $filename, array $publication): string|JSONResponse
-    {
-        // Create the Publicaties folder and the Publication specific folder.
-        $this->fileService->createFolder(folderPath: 'Publicaties');
-        $publicationFolder = $this->fileService->getPublicationFolderName(
-            publicationId: $publication['id'],
-            publicationTitle: $publication['title']
-        );
-        $this->fileService->createFolder(folderPath: "Publicaties/$publicationFolder");
-
-        // Save the file to NextCloud.
-        $filePath = "Publicaties/$publicationFolder/$filename";
-        $created  = $this->fileService->updateFile(
-            content: file_get_contents(filename: $filename),
-            filePath: $filePath,
-            createNew: true
-        );
-
-        // Check if file creation was successful.
-        if ($created === false) {
-            return new JSONResponse(
-                data: ['error' => "Failed to upload this file: $filePath to NextCloud"],
-                statusCode: 500
-            );
-        }
-
-        // Request public share via the OpenRegister shares leaf (ADR-022 / FIL-005).
-        $shareLink = $this->fileService->createPublicShareLink(relativePath: $filePath);
-
-        return $shareLink;
-
-    }//end saveFileToNextCloud()
 
     /**
      * Gets all attachments for a publication.

--- a/lib/Service/DownloadService.php
+++ b/lib/Service/DownloadService.php
@@ -112,7 +112,10 @@ class DownloadService
         // Create the PDF file using a twig template and publication data.
         $mpdf = $this->fileService->createPdf('publication.html.twig', ['publication' => $publication]);
 
-        $filename = "{$publication['title']}.pdf";
+        // A publication without a title still gets a usable entry name — an undefined
+        // key here would surface as a PHP warning on an anonymous-reachable path.
+        $title    = ($publication['title'] ?? 'publication');
+        $filename = "$title.pdf";
 
         // Render to a temporary location, read it back, and remove the temporary file.
         // The metadata PDF is an on-demand artefact — it MUST NOT be written to

--- a/lib/Service/PublicationService.php
+++ b/lib/Service/PublicationService.php
@@ -56,6 +56,7 @@ use OCP\Common\Exception\NotFoundException;
 use OCP\IServerContainer;
 use OCP\IUserSession;
 use RuntimeException;
+use ZipArchive;
 
 /**
  * Service for handling publication-related operations.
@@ -123,6 +124,9 @@ class PublicationService
      * @param IServerContainer  $container        Server container for dependency injection
      * @param IAppManager       $appManager       App manager for checking installed apps
      * @param DirectoryService  $directoryService Directory service for federation
+     * @param DownloadService   $downloadService  Renders the publication metadata PDF that is
+     *                                            piped into the download ZIP (DWN-OR-001 /
+     *                                            DWN-OR-003).
      * @param IUserSession|null $userSession      User session used to decide whether the
      *                                            anonymous `@self` strip list applies
      *                                            (authenticated-read-parity, CAT-AUTH-001).
@@ -138,6 +142,7 @@ class PublicationService
         private readonly ContainerInterface $container,
         private readonly IAppManager $appManager,
         private readonly DirectoryService $directoryService,
+        private readonly DownloadService $downloadService,
         private readonly ?IUserSession $userSession=null,
     ) {
         $this->appName = 'opencatalogi';
@@ -943,6 +948,31 @@ class PublicationService
             $fileService = $this->getFileService();
             $zipInfo     = $fileService->createObjectFilesZip($id);
 
+            // Render the publication metadata PDF and pipe it into the ZIP alongside the
+            // attachments streamed from OR's file service (DWN-OR-001 / DWN-OR-003).
+            $metadataPdf = $this->downloadService->createPublicationFile(
+                objectService: $objectService,
+                id: $id,
+                options: [
+                    'download'    => true,
+                    'publication' => $object->jsonSerialize(),
+                ]
+            );
+
+            if ($metadataPdf instanceof JSONResponse) {
+                if (file_exists($zipInfo['path']) === true) {
+                    unlink($zipInfo['path']);
+                }
+
+                return $metadataPdf;
+            }
+
+            $this->addFileToZip(
+                zipPath: $zipInfo['path'],
+                entryName: $metadataPdf['filename'],
+                content: $metadataPdf['content']
+            );
+
             // Read the ZIP file content.
             $zipContent = file_get_contents($zipInfo['path']);
             if ($zipContent === false) {
@@ -977,6 +1007,39 @@ class PublicationService
         }//end try
 
     }//end download()
+
+    /**
+     * Add an in-memory artefact to an existing ZIP archive.
+     *
+     * Used to pipe the rendered publication metadata PDF into the attachment ZIP
+     * produced by OpenRegister's file service, so the archive matches the structure
+     * required by DWN-OR-001 (metadata PDF at the root, attachments under Bijlagen/).
+     *
+     * @param string $zipPath   Absolute path of the ZIP archive to add to.
+     * @param string $entryName The entry name to write inside the archive.
+     * @param string $content   The raw bytes to store under that entry.
+     *
+     * @return void
+     *
+     * @throws Exception When the archive cannot be opened or the entry cannot be added.
+     *
+     * @spec openspec/specs/download-service/spec.md
+     */
+    private function addFileToZip(string $zipPath, string $entryName, string $content): void
+    {
+        $zip = new ZipArchive();
+        if ($zip->open($zipPath) !== true) {
+            throw new Exception('Failed to open ZIP archive to add the publication metadata PDF');
+        }
+
+        if ($zip->addFromString($entryName, $content) === false) {
+            $zip->close();
+            throw new Exception('Failed to add the publication metadata PDF to the ZIP archive');
+        }
+
+        $zip->close();
+
+    }//end addFileToZip()
 
     /**
      * Filter out unwanted properties from objects

--- a/lib/Templates/publication.html.twig
+++ b/lib/Templates/publication.html.twig
@@ -1,0 +1,59 @@
+{# Publication metadata layout rendered into the download ZIP (DWN-OR-001 / DWN-OR-003). #}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8"/>
+    <title>{{ publication.title|default('Publication') }}</title>
+    <style>
+        body { font-family: sans-serif; font-size: 11pt; color: #222; }
+        h1 { font-size: 18pt; margin-bottom: 0; }
+        h2 { font-size: 13pt; margin-top: 24px; border-bottom: 1px solid #ccc; }
+        p.summary { font-style: italic; color: #555; margin-top: 4px; }
+        table { width: 100%; border-collapse: collapse; margin-top: 8px; }
+        th, td { text-align: left; vertical-align: top; padding: 4px 6px; border-bottom: 1px solid #eee; }
+        th { width: 30%; font-weight: bold; }
+        ul { margin-top: 8px; }
+    </style>
+</head>
+<body>
+<h1>{{ publication.title|default('Publication') }}</h1>
+
+{% if publication.summary is defined and publication.summary is not empty %}
+    <p class="summary">{{ publication.summary }}</p>
+{% endif %}
+
+{% if publication.description is defined and publication.description is not empty %}
+    <h2>Description</h2>
+    <div>{{ publication.description }}</div>
+{% endif %}
+
+<h2>Metadata</h2>
+<table>
+    <tbody>
+    {% for key, value in publication %}
+        {% if key not in ['title', 'summary', 'description', 'attachments'] and value is not iterable and value is not empty %}
+            <tr>
+                <th>{{ key }}</th>
+                <td>{{ value }}</td>
+            </tr>
+        {% endif %}
+    {% endfor %}
+    </tbody>
+</table>
+
+{% if publication.attachments is defined and publication.attachments is iterable and publication.attachments|length > 0 %}
+    <h2>Attachments</h2>
+    <ul>
+        {% for attachment in publication.attachments %}
+            <li>
+                {%- if attachment is iterable -%}
+                    {{ attachment.title|default(attachment.name|default('')) }}
+                {%- else -%}
+                    {{ attachment }}
+                {%- endif -%}
+            </li>
+        {% endfor %}
+    </ul>
+{% endif %}
+</body>
+</html>

--- a/tests/Unit/Service/DownloadServiceTest.php
+++ b/tests/Unit/Service/DownloadServiceTest.php
@@ -3,8 +3,8 @@
 /**
  * Unit tests for DownloadService.
  *
- * Covers publication PDF generation, saving to NextCloud via the OR shares leaf,
- * ZIP creation, and attachment enumeration.
+ * Covers publication metadata PDF rendering (including the real Twig template),
+ * option validation, temporary-file cleanup, and attachment enumeration.
  *
  * @category Test
  * @package  Unit\Service
@@ -157,27 +157,30 @@ class DownloadServiceTest extends \PHPUnit\Framework\TestCase
     }//end testGetPublicationDataNotFound()
 
     /**
-     * Returns 500 when both download and saveToNextCloud options are false.
+     * Returns 400 without rendering anything when no output option is enabled (DWN-OR-004).
      *
      * @return void
      */
-    public function testCreatePublicationFileBothOptionsFalse(): void
+    public function testCreatePublicationFileNoOutputOptionEnabled(): void
     {
         $objectService = $this->createObjectServiceMock();
+
+        // No file content may be generated when the guard trips.
+        $this->fileService->expects($this->never())->method('createPdf');
 
         $result = $this->downloadService->createPublicationFile(
             $objectService,
             '1',
-            ['download' => false, 'saveToNextCloud' => false, 'publication' => null]
+            ['download' => false, 'publication' => null]
         );
 
         $this->assertInstanceOf(JSONResponse::class, $result);
-        $this->assertSame(500, $result->getStatus());
+        $this->assertSame(400, $result->getStatus());
 
-    }//end testCreatePublicationFileBothOptionsFalse()
+    }//end testCreatePublicationFileNoOutputOptionEnabled()
 
     /**
-     * Saves to NextCloud and returns download URL when publication is provided.
+     * Returns the rendered PDF as an in-memory artefact when a publication is provided.
      *
      * @return void
      */
@@ -188,33 +191,103 @@ class DownloadServiceTest extends \PHPUnit\Framework\TestCase
         $publication = ['id' => '1', 'title' => 'MyPub', 'description' => 'A description'];
 
         $mpdf = $this->createMock(\Mpdf\Mpdf::class);
+        $mpdf->expects($this->once())
+            ->method('Output')
+            ->willReturnCallback(
+                function (string $path, string $destination) {
+                    $this->assertSame(\Mpdf\Output\Destination::FILE, $destination);
+                    file_put_contents($path, '%PDF-1.4 rendered');
+                    return '';
+                }
+            );
+
         $this->fileService->expects($this->once())
             ->method('createPdf')
             ->with('publication.html.twig', ['publication' => $publication])
             ->willReturn($mpdf);
 
-        $this->fileService->method('createFolder')->willReturn(true);
-        $this->fileService->method('getPublicationFolderName')
-            ->with('1', 'MyPub')
-            ->willReturn('(1) MyPub');
-        $this->fileService->method('updateFile')->willReturn(true);
-
-        $this->fileService->method('createPublicShareLink')
-            ->willReturn('https://example.com/index.php/s/token123');
-
         $result = $this->downloadService->createPublicationFile(
             $objectService,
             '1',
-            ['download' => false, 'saveToNextCloud' => true, 'publication' => $publication]
+            ['download' => true, 'publication' => $publication]
         );
 
-        $this->assertInstanceOf(JSONResponse::class, $result);
-        $this->assertSame(200, $result->getStatus());
-        $data = $result->getData();
-        $this->assertStringContainsString('/download', $data['downloadUrl']);
-        $this->assertSame('MyPub.pdf', $data['filename']);
+        $this->assertIsArray($result);
+        $this->assertSame('MyPub.pdf', $result['filename']);
+        $this->assertSame('%PDF-1.4 rendered', $result['content']);
 
     }//end testCreatePublicationFileWithPublicationProvided()
+
+    /**
+     * Deletes the temporary render file before returning (DWN-OR-003).
+     *
+     * @return void
+     */
+    public function testCreatePublicationFileRemovesTemporaryFile(): void
+    {
+        $objectService = $this->createObjectServiceMock();
+        $publication   = ['id' => '2', 'title' => 'TempCleanup'];
+
+        $capturedPath = null;
+
+        $mpdf = $this->createMock(\Mpdf\Mpdf::class);
+        $mpdf->method('Output')
+            ->willReturnCallback(
+                function (string $path, string $destination) use (&$capturedPath) {
+                    $capturedPath = $path;
+                    file_put_contents($path, '%PDF-1.4 tempfile');
+                    return '';
+                }
+            );
+
+        $this->fileService->method('createPdf')->willReturn($mpdf);
+
+        $result = $this->downloadService->createPublicationFile(
+            $objectService,
+            '2',
+            ['download' => true, 'publication' => $publication]
+        );
+
+        $this->assertIsArray($result);
+        $this->assertNotNull($capturedPath);
+        $this->assertFileDoesNotExist($capturedPath);
+
+    }//end testCreatePublicationFileRemovesTemporaryFile()
+
+    /**
+     * Never writes the rendered PDF to Nextcloud user storage (DWN-OR-003).
+     *
+     * @return void
+     */
+    public function testCreatePublicationFileNeverWritesToNextcloudStorage(): void
+    {
+        $objectService = $this->createObjectServiceMock();
+        $publication   = ['id' => '3', 'title' => 'NoStorage'];
+
+        $mpdf = $this->createMock(\Mpdf\Mpdf::class);
+        $mpdf->method('Output')
+            ->willReturnCallback(
+                function (string $path, string $destination) {
+                    file_put_contents($path, '%PDF-1.4 nostorage');
+                    return '';
+                }
+            );
+
+        $this->fileService->method('createPdf')->willReturn($mpdf);
+
+        $this->fileService->expects($this->never())->method('updateFile');
+        $this->fileService->expects($this->never())->method('createFolder');
+        $this->fileService->expects($this->never())->method('createPublicShareLink');
+
+        $result = $this->downloadService->createPublicationFile(
+            $objectService,
+            '3',
+            ['download' => true, 'publication' => $publication]
+        );
+
+        $this->assertIsArray($result);
+
+    }//end testCreatePublicationFileNeverWritesToNextcloudStorage()
 
     /**
      * Returns 500 when the publication cannot be fetched.
@@ -231,7 +304,7 @@ class DownloadServiceTest extends \PHPUnit\Framework\TestCase
         $result = $this->downloadService->createPublicationFile(
             $objectService,
             '99',
-            ['download' => true, 'saveToNextCloud' => true, 'publication' => null]
+            ['download' => true, 'publication' => null]
         );
 
         $this->assertInstanceOf(JSONResponse::class, $result);
@@ -240,105 +313,46 @@ class DownloadServiceTest extends \PHPUnit\Framework\TestCase
     }//end testCreatePublicationFileFetchFails()
 
     /**
-     * Sends file to browser download when saveToNextCloud is false.
+     * Returns 404 when the publication cannot be resolved (DWN-OR-005).
      *
      * @return void
      */
-    public function testCreatePublicationFileDownloadOnlySaveToNextCloudFalse(): void
+    public function testCreatePublicationFilePublicationNotFound(): void
     {
         $objectService = $this->createObjectServiceMock();
-        $publication   = ['id' => '5', 'title' => 'DownloadOnly'];
+        $objectService->method('find')->willReturn(null);
 
-        $mpdf = $this->createMock(\Mpdf\Mpdf::class);
-        $mpdf->expects($this->once())
-            ->method('Output')
-            ->with('DownloadOnly.pdf', \Mpdf\Output\Destination::DOWNLOAD);
-
-        $this->fileService->method('createPdf')->willReturn($mpdf);
+        $this->fileService->expects($this->never())->method('createPdf');
 
         $result = $this->downloadService->createPublicationFile(
             $objectService,
-            '5',
-            ['download' => true, 'saveToNextCloud' => false, 'publication' => $publication]
+            '404',
+            ['download' => true, 'publication' => null]
         );
 
         $this->assertInstanceOf(JSONResponse::class, $result);
-        $this->assertSame(200, $result->getStatus());
-        $this->assertEmpty($result->getData());
+        $this->assertSame(404, $result->getStatus());
 
-    }//end testCreatePublicationFileDownloadOnlySaveToNextCloudFalse()
+    }//end testCreatePublicationFilePublicationNotFound()
 
     /**
-     * Stores a file and returns a share link URL.
+     * Asserts that saveFileToNextCloud no longer exists.
+     *
+     * DWN-OR-003 forbids the download service from saving the generated PDF to
+     * Nextcloud user storage, and DWN-002 / DWN-003 are recorded as REMOVED
+     * requirements. This test documents the removal so a regression is caught.
      *
      * @return void
      */
-    public function testSaveFileToNextCloudSuccess(): void
+    public function testSaveFileToNextCloudMethodDoesNotExist(): void
     {
-        $publication = ['id' => '10', 'title' => 'SaveTest'];
+        $this->assertFalse(
+            method_exists($this->downloadService, 'saveFileToNextCloud'),
+            'saveFileToNextCloud writes the metadata PDF to Nextcloud user storage, '
+            .'which DWN-OR-003 forbids; it must not be re-introduced.'
+        );
 
-        $this->fileService->expects($this->exactly(2))
-            ->method('createFolder');
-
-        $this->fileService->method('getPublicationFolderName')
-            ->with('10', 'SaveTest')
-            ->willReturn('(10) SaveTest');
-
-        $this->fileService->method('updateFile')->willReturn(true);
-        $this->fileService->method('createPublicShareLink')
-            ->willReturn('https://example.com/index.php/s/sharetoken');
-
-        $result = $this->downloadService->saveFileToNextCloud('test.pdf', $publication);
-
-        $this->assertIsString($result);
-        $this->assertStringContainsString('sharetoken', $result);
-
-    }//end testSaveFileToNextCloudSuccess()
-
-    /**
-     * Obtains share URL via the OR shares leaf (ADR-022 / FIL-005).
-     *
-     * @return void
-     */
-    public function testSaveFileToNextCloudShareViaLeaf(): void
-    {
-        $publication = ['id' => '10', 'title' => 'SaveTest'];
-
-        $this->fileService->method('createFolder')->willReturn(true);
-        $this->fileService->method('getPublicationFolderName')
-            ->willReturn('(10) SaveTest');
-        $this->fileService->method('updateFile')->willReturn(true);
-
-        $this->fileService->method('createPublicShareLink')
-            ->willReturn('https://example.com/index.php/s/leaftoken');
-
-        $result = $this->downloadService->saveFileToNextCloud('test.pdf', $publication);
-
-        $this->assertIsString($result);
-        $this->assertStringContainsString('leaftoken', $result);
-
-    }//end testSaveFileToNextCloudShareViaLeaf()
-
-    /**
-     * Returns 500 when file creation in NextCloud fails.
-     *
-     * @return void
-     */
-    public function testSaveFileToNextCloudFileCreationFails(): void
-    {
-        $publication = ['id' => '10', 'title' => 'FailTest'];
-
-        $this->fileService->method('createFolder')->willReturn(true);
-        $this->fileService->method('getPublicationFolderName')
-            ->willReturn('(10) FailTest');
-        $this->fileService->method('updateFile')->willReturn(false);
-
-        $result = $this->downloadService->saveFileToNextCloud('test.pdf', $publication);
-
-        $this->assertInstanceOf(JSONResponse::class, $result);
-        $this->assertSame(500, $result->getStatus());
-
-    }//end testSaveFileToNextCloudFileCreationFails()
+    }//end testSaveFileToNextCloudMethodDoesNotExist()
 
     /**
      * Asserts that createPublicationZip no longer exists (removed in wave-3 fix C5).
@@ -531,32 +545,47 @@ class DownloadServiceTest extends \PHPUnit\Framework\TestCase
     }//end testPublicationAttachmentsNoAttachmentsKey()
 
     /**
-     * Returns 500 when saving publication file to NextCloud fails.
+     * Renders the real publication.html.twig template through the real FileService.
+     *
+     * Every other test in this file mocks `createPdf()`, which is exactly why the
+     * missing template went unnoticed for so long: a Twig LoaderError could never
+     * surface. This test resolves the template for real so its absence fails here.
      *
      * @return void
      */
-    public function testCreatePublicationFileSaveToNextCloudFails(): void
+    public function testRealPublicationTemplateRendersThroughFileService(): void
     {
-        $objectService = $this->createObjectServiceMock();
-        $publication   = ['id' => '1', 'title' => 'FailSave'];
-
-        $mpdf = $this->createMock(\Mpdf\Mpdf::class);
-        $this->fileService->method('createPdf')->willReturn($mpdf);
-        $this->fileService->method('createFolder')->willReturn(true);
-        $this->fileService->method('getPublicationFolderName')
-            ->willReturn('(1) FailSave');
-        $this->fileService->method('updateFile')->willReturn(false);
-
-        $result = $this->downloadService->createPublicationFile(
-            $objectService,
-            '1',
-            ['download' => false, 'saveToNextCloud' => true, 'publication' => $publication]
+        $fileService = new FileService(
+            $this->createMock(\OCP\IUserSession::class),
+            $this->createMock(\Psr\Log\LoggerInterface::class),
+            $this->createMock(\OCP\Files\IRootFolder::class),
+            $this->createMock(\OCP\App\IAppManager::class),
+            $this->createMock(\Psr\Container\ContainerInterface::class)
         );
 
-        $this->assertInstanceOf(JSONResponse::class, $result);
-        $this->assertSame(500, $result->getStatus());
+        $downloadService = new DownloadService($fileService);
+        $objectService   = $this->createObjectServiceMock();
 
-    }//end testCreatePublicationFileSaveToNextCloudFails()
+        $publication = [
+            'id'          => 'abc-123',
+            'title'       => 'Real Template Publication',
+            'summary'     => 'A short summary.',
+            'description' => 'A longer description of the publication.',
+            'status'      => 'published',
+            'attachments' => [['title' => 'Attachment One'], 'plain-attachment-id'],
+        ];
+
+        $result = $downloadService->createPublicationFile(
+            $objectService,
+            'abc-123',
+            ['download' => true, 'publication' => $publication]
+        );
+
+        $this->assertIsArray($result);
+        $this->assertSame('Real Template Publication.pdf', $result['filename']);
+        $this->assertStringStartsWith('%PDF', $result['content']);
+
+    }//end testRealPublicationTemplateRendersThroughFileService()
 
     // phpcs:enable CustomSniffs.Functions.NamedParameters
 

--- a/tests/Unit/Service/DownloadServiceTest.php
+++ b/tests/Unit/Service/DownloadServiceTest.php
@@ -545,6 +545,38 @@ class DownloadServiceTest extends \PHPUnit\Framework\TestCase
     }//end testPublicationAttachmentsNoAttachmentsKey()
 
     /**
+     * Falls back to a usable entry name when the publication carries no title.
+     *
+     * @return void
+     */
+    public function testCreatePublicationFileWithoutTitle(): void
+    {
+        $objectService = $this->createObjectServiceMock();
+        $publication   = ['id' => '7'];
+
+        $mpdf = $this->createMock(\Mpdf\Mpdf::class);
+        $mpdf->method('Output')
+            ->willReturnCallback(
+                function (string $path, string $destination) {
+                    file_put_contents($path, '%PDF-1.4 untitled');
+                    return '';
+                }
+            );
+
+        $this->fileService->method('createPdf')->willReturn($mpdf);
+
+        $result = $this->downloadService->createPublicationFile(
+            $objectService,
+            '7',
+            ['download' => true, 'publication' => $publication]
+        );
+
+        $this->assertIsArray($result);
+        $this->assertSame('publication.pdf', $result['filename']);
+
+    }//end testCreatePublicationFileWithoutTitle()
+
+    /**
      * Renders the real publication.html.twig template through the real FileService.
      *
      * Every other test in this file mocks `createPdf()`, which is exactly why the

--- a/tests/Unit/Service/PublicationServiceTest.php
+++ b/tests/Unit/Service/PublicationServiceTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Unit\Service;
 
 use OCA\OpenCatalogi\Service\DirectoryService;
+use OCA\OpenCatalogi\Service\DownloadService;
 use OCA\OpenCatalogi\Service\PublicationService;
 use OCP\App\IAppManager;
 use OCP\AppFramework\Db\DoesNotExistException;
@@ -27,6 +28,8 @@ class PublicationServiceTest extends TestCase
     private ContainerInterface|MockObject $container;
     private IAppManager|MockObject $appManager;
     private DirectoryService|MockObject $directoryService;
+
+    private DownloadService|MockObject $downloadService;
     private IURLGenerator|MockObject $urlGenerator;
     private IUserSession|MockObject $userSession;
     private PublicationService $service;
@@ -45,12 +48,15 @@ class PublicationServiceTest extends TestCase
         // this file keeps asserting the historical stripped envelope without change.
         $this->userSession->method('getUser')->willReturn(null);
 
+        $this->downloadService = $this->createMock(DownloadService::class);
+
         $this->service = new PublicationService(
             $this->config,
             $this->request,
             $this->container,
             $this->appManager,
             $this->directoryService,
+            $this->downloadService,
             $this->userSession,
         );
     }
@@ -1683,6 +1689,7 @@ class PublicationServiceTest extends TestCase
             $this->container,
             $this->appManager,
             $this->directoryService,
+            $this->downloadService,
             $userSession,
         );
     }
@@ -3577,9 +3584,12 @@ class PublicationServiceTest extends TestCase
                 return $fileService;
             });
 
-        // Create a temp file for the test.
+        // Create a real ZIP fixture so the metadata PDF can be piped into it (DWN-OR-001).
         $tmpFile = tempnam(sys_get_temp_dir(), 'test_zip_');
-        file_put_contents($tmpFile, 'fake zip content');
+        $fixture = new \ZipArchive();
+        $fixture->open($tmpFile, \ZipArchive::OVERWRITE);
+        $fixture->addFromString('Bijlagen/attachment1.txt', 'attachment content');
+        $fixture->close();
 
         $fileService->method('createObjectFilesZip')
             ->willReturn([
@@ -3588,8 +3598,81 @@ class PublicationServiceTest extends TestCase
                 'mimeType' => 'application/zip',
             ]);
 
+        $this->downloadService->expects($this->once())
+            ->method('createPublicationFile')
+            ->willReturn(['filename' => 'pub-1.pdf', 'content' => '%PDF-1.4 metadata']);
+
         $response = $this->service->download('pub-1');
         $this->assertInstanceOf(DataDownloadResponse::class, $response);
+
+        // The archive handed to the caller must carry the metadata PDF next to the
+        // attachments streamed from OR's file service.
+        $returnedPath = tempnam(sys_get_temp_dir(), 'returned_zip_');
+        file_put_contents($returnedPath, $response->render());
+
+        $returned = new \ZipArchive();
+        $this->assertTrue($returned->open($returnedPath) === true);
+        $entries = [];
+        for ($i = 0; $i < $returned->numFiles; $i++) {
+            $entries[] = $returned->getNameIndex($i);
+        }
+
+        $pdfBytes = $returned->getFromName('pub-1.pdf');
+        $returned->close();
+        unlink($returnedPath);
+
+        $this->assertContains('pub-1.pdf', $entries, 'The metadata PDF must be present in the download ZIP.');
+        $this->assertContains('Bijlagen/attachment1.txt', $entries);
+        $this->assertSame('%PDF-1.4 metadata', $pdfBytes);
+    }
+
+    public function testDownloadPropagatesMetadataPdfError(): void
+    {
+        $objectService = $this->createObjectServiceMock();
+        $fileService   = $this->createFileServiceMock();
+
+        $this->appManager->method('getInstalledApps')->willReturn(['openregister']);
+
+        $queryService = $this->createMock(\OCA\OpenCatalogi\Service\PublicationQueryService::class);
+        $queryService->method('findObjectLocation')->willReturn(['register' => 1, 'schema' => 1]);
+        $catalog = $this->createSerializableObject(['registers' => [1], 'schemas' => [1]]);
+        $objectService->method('searchObjects')->willReturn([$catalog]);
+        $objectService->method('find')->willReturn($this->createSerializableObject(['id' => 'pub-1']));
+
+        $this->container->method('get')
+            ->willReturnCallback(function (string $class) use ($objectService, $fileService, $queryService) {
+                if ($class === \OCA\OpenCatalogi\Service\PublicationQueryService::class) {
+                    return $queryService;
+                }
+
+                if ($class === 'OCA\OpenRegister\Service\ObjectService') {
+                    return $objectService;
+                }
+
+                return $fileService;
+            });
+
+        $tmpFile = tempnam(sys_get_temp_dir(), 'test_zip_');
+        $fixture = new \ZipArchive();
+        $fixture->open($tmpFile, \ZipArchive::OVERWRITE);
+        $fixture->addFromString('Bijlagen/attachment1.txt', 'attachment content');
+        $fixture->close();
+
+        $fileService->method('createObjectFilesZip')
+            ->willReturn([
+                'path'     => $tmpFile,
+                'filename' => 'test-files.zip',
+                'mimeType' => 'application/zip',
+            ]);
+
+        $this->downloadService->method('createPublicationFile')
+            ->willReturn(new \OCP\AppFramework\Http\JSONResponse(['error' => 'render failed'], 500));
+
+        $response = $this->service->download('pub-1');
+
+        $this->assertInstanceOf(\OCP\AppFramework\Http\JSONResponse::class, $response);
+        $this->assertSame(500, $response->getStatus());
+        $this->assertFileDoesNotExist($tmpFile, 'The ZIP temp file must be cleaned up on the error path.');
     }
 
     // =======================================================================


### PR DESCRIPTION
## The finding

The full-scope `workflow_dispatch` run on `development` ([31459700835](https://github.com/ConductionNL/opencatalogi/actions/runs/31459700835)) leaves exactly one non-coverage gate red:

```
[gate-57] orphaned-write-capability: FAIL — 1 orphaned write-capability method(s)
lib/Service/DownloadService.php:86 method=createPublicationFile class=DownloadService
```

(gate-19 e2e-coverage and gate-26 visual-coverage are coverage gates, out of scope here.)

## Root cause

Not a missing route — a **requirement with no implementation** (#845). `openspec/specs/download-service/spec.md` DWN-OR-001 says the ZIP contains "one metadata PDF rendered from the publication's data (Twig + mPDF), N files piped from OR's file service, attachments in a `Bijlagen/` subfolder". Four things were independently true:

1. `createPublicationFile()` had zero production callers; `DownloadService` was injected nowhere in `lib/`.
2. `PublicationService::download()` hands the object id to OR's `createObjectFilesZip()` and streams the result — no PDF is rendered or inserted, so the DWN-OR-001 scenario was false as shipped.
3. The method's `saveToNextCloud` branch wrote the PDF to Nextcloud user storage and returned a share link — which **DWN-OR-003 explicitly forbids**, and DWN-002 / DWN-003 record as REMOVED. Wiring it as written would have shipped a spec violation.
4. It renders `publication.html.twig`, and `lib/Templates/` contained only `test.html.twig`. A call would have raised a Twig `LoaderError` — this code had never executed end to end in any environment.

## The fix

- **Add `lib/Templates/publication.html.twig`** — the metadata layout that did not exist.
- **Rework `createPublicationFile()`** to render to a temp path, read the bytes back, delete the temp file in a `finally`, and return `['filename' => …, 'content' => …]`. The old `JSONResponse`-with-share-link return shape was controller-shaped and wrong for a step piped into a stream.
- **Delete `saveFileToNextCloud()`** per DWN-OR-003. This leaves `FileService::updateFile()` without a caller in `lib/`; `update` is not a gate-57 write verb, and `createFolder` / `getPublicationFolderName` / `createPublicShareLink` all keep callers inside `FileService` itself, so no new orphan is created.
- **Validate output options before generating content**, returning **400** per DWN-OR-004 (was 500).
- **Wire it into `PublicationService::download()`**: the rendered PDF is added to the archive OR's file service produces, so the caller receives `{title}.pdf` + `Bijlagen/`.

## Both directions

**gate-57**, run locally against the same `check_orphaned_write_capability.py` CI uses, over the same 23 `lib/Service` files:

| state | helper output |
|---|---|
| `PublicationService.php` reverted to `development` (caller removed) | `lib/Service/DownloadService.php:90 method=createPublicationFile rule=orphaned-write-capability class=DownloadService` |
| caller in place | *(nothing)* |

**The template test.** Every pre-existing test in `DownloadServiceTest` mocks `createPdf()` — which is precisely why a missing template could never surface, and why the suite stayed green over a method that could not run against the real collaborator. `testRealPublicationTemplateRendersThroughFileService` builds a **real** `FileService` and resolves the template for real:

| state | result |
|---|---|
| template removed | `Twig\Error\LoaderError: Unable to find template "publication.html.twig" (looked into: lib/Templates)` — 1 error |
| template present | OK (1 test, 3 assertions) |

`testDownloadReturnsZipOnSuccess` now builds a real ZIP fixture (it previously used a file containing the literal bytes `fake zip content`) and asserts `pub-1.pdf` and `Bijlagen/attachment1.txt` are both entries in the archive the caller receives, with the PDF bytes intact.

## Verification

- Full unit suite in a container with `ext-zip`: **1302 tests, 0 failures**, 2 pre-existing skips, 60 pre-existing deprecations.
- `php -l`, `phpcs`, `phpmd` (both configs) clean on both changed files. The 2 phpcs warnings in `PublicationService.php` are pre-existing missing-`@spec` tags on `getAvailableRegisters()` / `getAvailableSchemas()`, untouched here.
- PHPStan: no new findings attributable to this change — the only non-`unknown class OCP\*` entries for these files are the pre-existing `IServerContainer` docblock mismatch and the `unset offset` note.

No gate was weakened: nothing baselined, no `@spec`/`@e2e` exclude added, no test deleted or skipped to dodge a finding. The three `saveFileToNextCloud*` tests are removed because the method they tested is removed; a `testSaveFileToNextCloudMethodDoesNotExist()` guard replaces them, following the existing `testCreatePublicationZipMethodDoesNotExist()` precedent in the same file.

Closes #845
