### PR TITLE
fix(gate-26): cover the reachable page components, waive the unreachable ones, and unstrand OOAPI

### DIFF
--- a/lib/Settings/publication_register.json
+++ b/lib/Settings/publication_register.json
@@ -600,6 +600,13 @@
             "facetable": false,
             "title": "Has WOO Sitemap"
           },
+          "hasOoapi": {
+            "type": "boolean",
+            "description": "Whether this catalog publishes its course/program/offering data via the Open Onderwijs API (OOAPI 5.0). Read by OoapiService::isOoapiEnabled() to gate every /api/catalogs/{slug}/ooapi/v5/* route, and by DirectoryService to advertise ooapiEndpoint. Without this declaration the catalog schema's hardValidation strips the key, the toggle in CatalogModal.vue is silently discarded on save, and the whole OOAPI capability is unreachable — see #847.",
+            "default": false,
+            "facetable": false,
+            "title": "Has OOAPI 5.0 Publication"
+          },
           "published": {
             "type": "string",
             "description": "Publication date — when set to a date in the past, this catalog becomes publicly accessible",

--- a/src/views/directory/DirectoryIndex.vue
+++ b/src/views/directory/DirectoryIndex.vue
@@ -1,3 +1,23 @@
+<!--
+	UNREACHABLE COMPONENT — no visual baseline is possible.
+
+	Nothing imports this file: `src/registry.js` is the only place page
+	components are handed to CnAppRoot, and it does not list it. The `/directory`
+	route is a manifest `type: "custom"` page whose component is
+	`FederationDirectory`, so this view is superseded migration debris.
+	Confirmed by grepping the built bundle: its `name: 'DirectoryIndex'` option
+	occurs 0 times in `js/opencatalogi-main.js`, while the six wired views
+	(Dashboard, CatalogiIndex, CatalogDetailPage, WooBatchDetail,
+	FederationDirectory, FederationSearch) each occur once — webpack tree-shakes
+	it out entirely.
+
+	None of gate-26's three remedies fits an unreachable screen: it has no route
+	to baseline, no browser can drive it, and a bare waiver would claim "no
+	baseline needed" when the truth is "nothing can reach this". The reason below
+	therefore names the tracking issue, so this waiver expires with it.
+
+	@visual exclude Unreachable: imported by nothing, in no route, tree-shaken out of the shipped bundle; superseded by the manifest type:"custom" Directory page (FederationDirectory). Tracked in ConductionNL/opencatalogi#849.
+-->
 <template>
 	<CnIndexPage
 		ref="indexPage"

--- a/src/views/directory/FederationDirectory.vue
+++ b/src/views/directory/FederationDirectory.vue
@@ -262,8 +262,18 @@ export default {
 	/*
 	 * 56px clears NcAppNavigationToggle — per-header pattern documented at
 	 * nextcloud-vue/src/components/CnPageRenderer/CnPageRenderer.vue:993.
-	 * @visual exclude scoped copy of .viewHeaderTitleIndented for manifest-v2
-	 * directory shell; same 8-char CSS delta, same regression envelope.
+	 * This is a deliberately scoped copy of .viewHeaderTitleIndented for the
+	 * manifest-v2 directory shell; same 8-char CSS delta, same regression
+	 * envelope.
+	 *
+	 * (Reworded 2026-08-11: the previous phrasing put the words "@visual" and
+	 * "exclude" next to each other in ordinary prose. gate-26's
+	 * _VISUAL_EXCLUDE_RE scans the whole file text and does not require the
+	 * marker to be a directive, so that sentence was silently waiving this
+	 * page — a real, routed, shipped component — from visual coverage.
+	 * Measured: neutering those two words alone turned gate-26 from PASS into
+	 * "FAIL — 1" naming this file. The page is now covered for real by
+	 * tests/e2e/spec-coverage/page-components.spec.ts.)
 	 */
 	padding-inline-start: 56px;
 }

--- a/src/views/glossary/GlossaryIndex.vue
+++ b/src/views/glossary/GlossaryIndex.vue
@@ -1,3 +1,18 @@
+<!--
+	UNREACHABLE COMPONENT — no visual baseline is possible.
+
+	Nothing imports this file: `src/registry.js` is the only place page
+	components are handed to CnAppRoot, and it does not list it. `/glossary` is a
+	manifest `type: "index"` page rendered by nc-vue's generic CnIndexPage from
+	`src/manifest.json`, so this view is superseded migration debris. Confirmed
+	by grepping the built bundle: its `name: 'GlossaryIndex'` option occurs 0
+	times in `js/opencatalogi-main.js`, while the six wired views each occur once
+	— webpack tree-shakes it out entirely.
+
+	See src/views/directory/DirectoryIndex.vue for the full rationale.
+
+	@visual exclude Unreachable: imported by nothing, in no route, tree-shaken out of the shipped bundle; superseded by the manifest type:"index" Glossary page (CnIndexPage). Tracked in ConductionNL/opencatalogi#849.
+-->
 <template>
 	<CnIndexPage
 		ref="indexPage"

--- a/src/views/menus/MenuIndex.vue
+++ b/src/views/menus/MenuIndex.vue
@@ -1,3 +1,18 @@
+<!--
+	UNREACHABLE COMPONENT — no visual baseline is possible.
+
+	Nothing imports this file: `src/registry.js` is the only place page
+	components are handed to CnAppRoot, and it does not list it. `/menus` is a
+	manifest `type: "index"` page rendered by nc-vue's generic CnIndexPage from
+	`src/manifest.json`, so this view is superseded migration debris. Confirmed
+	by grepping the built bundle: its `name: 'MenuIndex'` option occurs 0 times
+	in `js/opencatalogi-main.js`, while the six wired views each occur once —
+	webpack tree-shakes it out entirely.
+
+	See src/views/directory/DirectoryIndex.vue for the full rationale.
+
+	@visual exclude Unreachable: imported by nothing, in no route, tree-shaken out of the shipped bundle; superseded by the manifest type:"index" Menus page (CnIndexPage). Tracked in ConductionNL/opencatalogi#849.
+-->
 <template>
 	<CnIndexPage
 		ref="indexPage"

--- a/src/views/organizations/OrganizationIndex.vue
+++ b/src/views/organizations/OrganizationIndex.vue
@@ -1,3 +1,18 @@
+<!--
+	UNREACHABLE COMPONENT — no visual baseline is possible.
+
+	Nothing imports this file: `src/registry.js` is the only place page
+	components are handed to CnAppRoot, and it does not list it. `/organizations`
+	is a manifest `type: "index"` page rendered by nc-vue's generic CnIndexPage
+	from `src/manifest.json`, so this view is superseded migration debris.
+	Confirmed by grepping the built bundle: its `name: 'OrganizationIndex'`
+	option occurs 0 times in `js/opencatalogi-main.js`, while the six wired views
+	each occur once — webpack tree-shakes it out entirely.
+
+	See src/views/directory/DirectoryIndex.vue for the full rationale.
+
+	@visual exclude Unreachable: imported by nothing, in no route, tree-shaken out of the shipped bundle; superseded by the manifest type:"index" Organizations page (CnIndexPage). Tracked in ConductionNL/opencatalogi#849.
+-->
 <template>
 	<CnIndexPage
 		ref="indexPage"

--- a/src/views/pages/PageIndex.vue
+++ b/src/views/pages/PageIndex.vue
@@ -1,3 +1,18 @@
+<!--
+	UNREACHABLE COMPONENT — no visual baseline is possible.
+
+	Nothing imports this file: `src/registry.js` is the only place page
+	components are handed to CnAppRoot, and it does not list it. `/pages` is a
+	manifest `type: "index"` page rendered by nc-vue's generic CnIndexPage from
+	`src/manifest.json`, so this view is superseded migration debris. Confirmed
+	by grepping the built bundle: its `name: 'PageIndex'` option occurs 0 times
+	in `js/opencatalogi-main.js`, while the six wired views each occur once —
+	webpack tree-shakes it out entirely.
+
+	See src/views/directory/DirectoryIndex.vue for the full rationale.
+
+	@visual exclude Unreachable: imported by nothing, in no route, tree-shaken out of the shipped bundle; superseded by the manifest type:"index" Pages page (CnIndexPage). Tracked in ConductionNL/opencatalogi#849.
+-->
 <template>
 	<CnIndexPage
 		ref="indexPage"

--- a/src/views/publications/PublicationDetail.vue
+++ b/src/views/publications/PublicationDetail.vue
@@ -1,3 +1,32 @@
+<!--
+	UNREACHABLE COMPONENT — no visual baseline is possible.
+
+	Nothing imports this file: `src/registry.js` is the only place page
+	components are handed to CnAppRoot, and it imports Dashboard and
+	CatalogDetailPage but not this one. `/publications/:catalogSlug/:id` is a
+	manifest `type: "detail"` page rendered by nc-vue's generic CnDetailPage from
+	`src/manifest.json`, so this view is superseded migration debris.
+	`tests/e2e/spec-coverage/usage-analytics-page.spec.ts:165` already records
+	the same conclusion for its "Statistics" tab and parks that assertion as
+	`test.fixme`.
+
+	Bundle check, with a positive control: `"PublicationDetail"` occurs 3 times
+	in `js/opencatalogi-main.js`, and there are exactly 3
+	`name: 'PublicationDetail'` ROUTE-name references in `src/` — so every
+	occurrence is a router push, none is this component registering itself.
+	(Control: `"CatalogDetailPage"` occurs once and that file IS imported by
+	`src/registry.js:35`.)
+
+	⚠️ This component was NOT in gate-26's finding list, and not because it was
+	covered. The only two occurrences of the string `PublicationDetail` anywhere
+	under `tests/e2e/` are in the prose of that `test.fixme` docblock — the
+	comment explaining that nothing mounts it is what certified it as covered.
+	Measured: neutering those two words alone took gate-26 from PASS to
+	`FAIL — 2` naming this file and UserSettings.vue. See
+	ConductionNL/opencatalogi#849 and ConductionNL/.github#358.
+
+	@visual exclude Unreachable: imported by nothing, in no route, absent from the shipped bundle; superseded by the manifest type:"detail" Publications page (CnDetailPage). Tracked in ConductionNL/opencatalogi#849.
+-->
 <script setup>
 import { navigationStore, objectStore, catalogStore } from '../../store/store.js'
 </script>

--- a/src/views/publications/PublicationList.vue
+++ b/src/views/publications/PublicationList.vue
@@ -1,3 +1,21 @@
+<!--
+	UNREACHABLE COMPONENT — no visual baseline is possible.
+
+	Nothing imports this file: `src/registry.js` is the only place page
+	components are handed to CnAppRoot, and it does not list it. (The single
+	`grep` hit outside this file is a prose comment in
+	`src/sidebars/dashboard/DashboardSideBar.vue`, not an import.)
+	`/publications/:catalogSlug` is a manifest `type: "index"` page rendered by
+	nc-vue's generic CnIndexPage from `src/manifest.json`, so this view is
+	superseded migration debris. Confirmed by grepping the built bundle: its
+	`name: 'PublicationList'` option occurs 0 times in
+	`js/opencatalogi-main.js`, while the six wired views each occur once —
+	webpack tree-shakes it out entirely.
+
+	See src/views/directory/DirectoryIndex.vue for the full rationale.
+
+	@visual exclude Unreachable: imported by nothing, in no route, tree-shaken out of the shipped bundle; superseded by the manifest type:"index" Publications page (CnIndexPage). Tracked in ConductionNL/opencatalogi#849.
+-->
 <script setup>
 import { navigationStore, objectStore, catalogStore } from '../../store/store.js'
 </script>

--- a/src/views/publications/PublicationTable.vue
+++ b/src/views/publications/PublicationTable.vue
@@ -1,3 +1,19 @@
+<!--
+	UNREACHABLE COMPONENT — no visual baseline is possible.
+
+	Nothing imports this file: `src/registry.js` is the only place page
+	components are handed to CnAppRoot, and it does not list it. The publications
+	table is drawn by nc-vue's generic CnIndexPage for the manifest
+	`type: "index"` Publications page, so this view is superseded migration
+	debris. Confirmed by grepping the built bundle: its
+	`name: 'PublicationTable'` option occurs 0 times in
+	`js/opencatalogi-main.js`, while the six wired views each occur once —
+	webpack tree-shakes it out entirely.
+
+	See src/views/directory/DirectoryIndex.vue for the full rationale.
+
+	@visual exclude Unreachable: imported by nothing, in no route, tree-shaken out of the shipped bundle; superseded by the manifest type:"index" Publications page (CnIndexPage). Tracked in ConductionNL/opencatalogi#849.
+-->
 <script setup>
 import { translate as t } from '@nextcloud/l10n'
 import { objectStore, navigationStore, catalogStore } from '../../store/store.js'

--- a/src/views/search/SearchIndex.vue
+++ b/src/views/search/SearchIndex.vue
@@ -1,3 +1,19 @@
+<!--
+	UNREACHABLE COMPONENT — no visual baseline is possible.
+
+	Nothing imports this file: `src/registry.js` is the only place page
+	components are handed to CnAppRoot, and it does not list it. `/search` is a
+	manifest `type: "custom"` page whose component is `FederationSearch`, so this
+	view is superseded migration debris. Confirmed by grepping the built bundle:
+	its `name: 'SearchIndex'` option occurs 0 times in `js/opencatalogi-main.js`,
+	while the six wired views each occur once — webpack tree-shakes it out
+	entirely. (The one raw substring hit in the bundle is `AddToSearchIndex`, a
+	highlight.js Mathematica keyword, not this component.)
+
+	See src/views/directory/DirectoryIndex.vue for the full rationale.
+
+	@visual exclude Unreachable: imported by nothing, in no route, tree-shaken out of the shipped bundle; superseded by the manifest type:"custom" Search page (FederationSearch). Tracked in ConductionNL/opencatalogi#849.
+-->
 <script setup>
 import { translate as t } from '@nextcloud/l10n'
 import { useSearchStore } from '../../store/modules/search.ts'

--- a/src/views/settings/UserSettings.vue
+++ b/src/views/settings/UserSettings.vue
@@ -1,3 +1,26 @@
+<!--
+	UNREACHABLE COMPONENT — no visual baseline is possible.
+
+	Nothing imports this file: `src/registry.js` is the only place page
+	components are handed to CnAppRoot, and it does not list it. The settings
+	dialog a user actually opens from the `SettingsMenu` nav entry is rendered by
+	the manifest app shell, not by this file.
+
+	Bundle check, with a positive control: `"UserSettings"` occurs **0** times in
+	`js/opencatalogi-main.js`, while every wired view occurs at least once
+	(`"CatalogDetailPage"` 1, `"Dashboard"` 7, `"FederationSearch"` 2) — webpack
+	tree-shakes it out entirely.
+
+	⚠️ This component was NOT in gate-26's finding list, and not because it was
+	covered. The only occurrence of the string `UserSettings` anywhere under
+	`tests/e2e/` is one docblock line in `gate19.spec.ts` reading
+	"WHEN UserSettings.vue renders"; the SET-017 test beneath it opens a settings
+	dialog that this file does not render. Measured: neutering that one word took
+	gate-26 from PASS to `FAIL — 2` naming this file and PublicationDetail.vue.
+	See ConductionNL/opencatalogi#849 and ConductionNL/.github#358.
+
+	@visual exclude Unreachable: imported by nothing, absent from the shipped bundle (0 occurrences, against 1-7 for every wired view); the settings dialog is rendered by the manifest app shell. Tracked in ConductionNL/opencatalogi#849.
+-->
 <template>
 	<NcAppSettingsDialog
 		:open="open"

--- a/src/views/shared/EntityDetailPage.vue
+++ b/src/views/shared/EntityDetailPage.vue
@@ -1,3 +1,20 @@
+<!--
+	UNREACHABLE COMPONENT — no visual baseline is possible.
+
+	Nothing imports this file: `src/registry.js` is the only place page
+	components are handed to CnAppRoot, and it does not list it. Every
+	`*Detail` route in `src/manifest.json` (`OrganizationDetail`, `ThemeDetail`,
+	`GlossaryDetail`, `PageDetail`, `MenuDetail`, `PublicationDetail`) is a
+	manifest `type: "detail"` page rendered by nc-vue's generic CnDetailPage, so
+	this shared view is superseded migration debris. Confirmed by grepping the
+	built bundle: its `name: 'EntityDetailPage'` option occurs 0 times in
+	`js/opencatalogi-main.js`, while the six wired views each occur once —
+	webpack tree-shakes it out entirely.
+
+	See src/views/directory/DirectoryIndex.vue for the full rationale.
+
+	@visual exclude Unreachable: imported by nothing, in no route, tree-shaken out of the shipped bundle; superseded by the manifest type:"detail" pages (CnDetailPage). Tracked in ConductionNL/opencatalogi#849.
+-->
 <script setup>
 import { translate as t } from '@nextcloud/l10n'
 import { objectStore, navigationStore } from '../../store/store.js'

--- a/src/views/themes/ThemeIndex.vue
+++ b/src/views/themes/ThemeIndex.vue
@@ -1,3 +1,18 @@
+<!--
+	UNREACHABLE COMPONENT — no visual baseline is possible.
+
+	Nothing imports this file: `src/registry.js` is the only place page
+	components are handed to CnAppRoot, and it does not list it. `/themes` is a
+	manifest `type: "index"` page rendered by nc-vue's generic CnIndexPage from
+	`src/manifest.json`, so this view is superseded migration debris. Confirmed
+	by grepping the built bundle: its `name: 'ThemeIndex'` option occurs 0 times
+	in `js/opencatalogi-main.js`, while the six wired views each occur once —
+	webpack tree-shakes it out entirely.
+
+	See src/views/directory/DirectoryIndex.vue for the full rationale.
+
+	@visual exclude Unreachable: imported by nothing, in no route, tree-shaken out of the shipped bundle; superseded by the manifest type:"index" Themes page (CnIndexPage). Tracked in ConductionNL/opencatalogi#849.
+-->
 <template>
 	<CnIndexPage
 		ref="indexPage"

--- a/tests/e2e/spec-coverage/ooapi-directory-advertisement.spec.ts
+++ b/tests/e2e/spec-coverage/ooapi-directory-advertisement.spec.ts
@@ -1,0 +1,194 @@
+/*
+ * SPDX-FileCopyrightText: 2026 OpenCatalogi Contributors
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * OOAPI-009 — the federation directory advertises a catalog's OOAPI 5.0 base
+ * endpoint (openspec/specs/ooapi-catalog-publication/spec.md).
+ *
+ * WHY THIS COULD NOT BE WRITTEN BEFORE
+ * -----------------------------------
+ * `DirectoryService::convertCatalogToListing()` populates `ooapiEndpoint` only
+ * when the catalog's `hasOoapi` is truthy. Until #847 the `catalog` schema did
+ * not declare `hasOoapi` at all, so OpenRegister's `hardValidation` stripped the
+ * key on every write and the flag could never be true on any instance. A test
+ * written then would have asserted an absence that was guaranteed for the wrong
+ * reason — the endpoint was missing because the feature was unreachable, not
+ * because the catalog had opted out. That is precisely the failure mode this
+ * suite exists to prevent, so the scenario was left uncovered until the schema
+ * was fixed.
+ *
+ * HOW THIS TEST AVOIDS THE SAME TRAP
+ * ----------------------------------
+ * A single "the endpoint is advertised" assertion could pass on a lucky fixture,
+ * and a single "it is not advertised" assertion is satisfied for free by a
+ * broken lookup, a mistyped field name, or an empty directory. So the two
+ * catalogs below differ in EXACTLY ONE field — `hasOoapi` — are created in the
+ * same run, and are read out of the SAME `/api/directory` response by the same
+ * locator. A selector that had stopped matching, or a field name that had been
+ * renamed, cannot produce a difference between them; only the OOAPI-009 rule
+ * actually working can.
+ *
+ * FIXTURES ARE MINTED, NOT BORROWED. The instance's own `publications` catalog
+ * is deliberately untouched: `spec-coverage/ooapi.spec.ts` asserts that a
+ * catalog with OOAPI switched off refuses every OOAPI route, and flipping a
+ * shared catalog's flag would make that suite's result a function of test order.
+ *
+ * Run:
+ *   PLAYWRIGHT_BASE_URL=http://localhost:8296 \
+ *     npx playwright test --config=tests/e2e/playwright.config.ts spec-coverage/ooapi-directory
+ */
+import { test, expect, type APIRequestContext } from '@playwright/test'
+
+const APP = '/index.php/apps/opencatalogi'
+const OR = '/index.php/apps/openregister/api'
+
+/** Run-scoped marker so a leaked fixture can never satisfy another run's assertions. */
+const RUN = `ooapi-adv-${Date.now()}`
+
+const ENABLED_SLUG = `${RUN}-on`
+const DISABLED_SLUG = `${RUN}-off`
+
+/** Ids created by this file, torn down in afterAll. */
+const created: string[] = []
+let catalogObjects = ''
+
+/**
+ * Resolve the numeric id of an OpenRegister register or schema by slug.
+ *
+ * Ids are assigned at import time and differ per instance; hardcoding one makes
+ * a suite pass or fail on the ordering of a register import.
+ *
+ * @param api An authenticated API request context.
+ * @param kind Either `registers` or `schemas`.
+ * @param slug The slug to resolve.
+ * @return The numeric id, as a string.
+ */
+async function idFor(api: APIRequestContext, kind: 'registers' | 'schemas', slug: string): Promise<string> {
+	const resp = await api.get(`${OR}/${kind}?_limit=200&limit=200`, {
+		headers: { 'OCS-APIRequest': 'true' },
+	})
+	expect(resp.status(), `GET ${OR}/${kind} must answer 200`).toBe(200)
+	const body = await resp.json()
+	const rows: Array<Record<string, unknown>> = body?.results ?? (Array.isArray(body) ? body : [])
+	const hit = rows.find((r) => r.slug === slug)
+	expect(hit, `${kind.slice(0, -1)} "${slug}" must exist — the register import is a precondition`).toBeTruthy()
+	return String(hit!.id)
+}
+
+/**
+ * Create a catalog fixture.
+ *
+ * @param api An authenticated API request context.
+ * @param slug The catalog slug.
+ * @param hasOoapi Whether OOAPI 5.0 publication is enabled for it.
+ * @return The created catalog's id.
+ */
+async function makeCatalog(api: APIRequestContext, slug: string, hasOoapi: boolean): Promise<string> {
+	const resp = await api.post(catalogObjects, {
+		headers: { 'OCS-APIRequest': 'true', 'Content-Type': 'application/json' },
+		data: {
+			title: slug,
+			slug,
+			summary: `OOAPI-009 fixture (hasOoapi=${hasOoapi})`,
+			listed: true,
+			status: 'stable',
+			hasOoapi,
+		},
+	})
+	expect(resp.status(), `creating catalog "${slug}" must succeed (got ${resp.status()})`).toBe(201)
+	const id = String((await resp.json()).id)
+	created.push(id)
+	return id
+}
+
+/**
+ * Fetch the federation directory listings.
+ *
+ * @param api An authenticated API request context.
+ * @return The listing rows.
+ */
+async function directoryListings(api: APIRequestContext): Promise<Array<Record<string, any>>> {
+	const resp = await api.get(`${APP}/api/directory`, { headers: { 'OCS-APIRequest': 'true' } })
+	expect(resp.status(), 'GET /api/directory must answer 200').toBe(200)
+	const body = await resp.json()
+	return body?.results ?? (Array.isArray(body) ? body : [])
+}
+
+/**
+ * Find this run's listing for a catalog id.
+ *
+ * @param rows The directory listing rows.
+ * @param id The catalog id.
+ * @return The matching row, or undefined.
+ */
+function listingFor(rows: Array<Record<string, any>>, id: string): Record<string, any> | undefined {
+	return rows.find((r) => String(r.catalog ?? r.id ?? '') === id)
+}
+
+test.describe('OOAPI 5.0 federation directory advertisement', () => {
+	let enabledId = ''
+	let disabledId = ''
+
+	test.beforeAll(async ({ playwright, baseURL, storageState }) => {
+		const api = await playwright.request.newContext({ baseURL, storageState })
+		const register = await idFor(api, 'registers', 'publication')
+		const schema = await idFor(api, 'schemas', 'catalog')
+		catalogObjects = `${OR}/objects/${register}/${schema}`
+
+		// PRECONDITION, asserted loudly: `hasOoapi` must survive a write at all.
+		// Before #847 it did not, and every assertion below would then have
+		// passed or failed for a reason unrelated to OOAPI-009.
+		enabledId = await makeCatalog(api, ENABLED_SLUG, true)
+		const readBack = await api.get(`${catalogObjects}/${enabledId}`, {
+			headers: { 'OCS-APIRequest': 'true' },
+		})
+		expect(readBack.status(), 'reading the fixture back must answer 200').toBe(200)
+		expect(
+			(await readBack.json()).hasOoapi,
+			'PRECONDITION: the catalog schema must declare `hasOoapi` (#847). If this is not true, '
+			+ 'OpenRegister strips the key and nothing below is a statement about OOAPI-009.',
+		).toBe(true)
+
+		disabledId = await makeCatalog(api, DISABLED_SLUG, false)
+		await api.dispose()
+	})
+
+	test.afterAll(async ({ playwright, baseURL, storageState }) => {
+		const api = await playwright.request.newContext({ baseURL, storageState })
+		for (const id of created.reverse()) {
+			await api.delete(`${catalogObjects}/${id}`, { headers: { 'OCS-APIRequest': 'true' } })
+		}
+		await api.dispose()
+	})
+
+	test(
+		// @e2e ooapi-catalog-publication::directory-entry-carries-the-ooapi-base-url
+		'OOAPI-009 — an OOAPI-enabled catalog advertises an absolute ooapiEndpoint, and an identical disabled one advertises none',
+		async ({ playwright, baseURL, storageState }) => {
+			const api = await playwright.request.newContext({ baseURL, storageState })
+			const rows = await directoryListings(api)
+
+			// Both fixtures must be IN the directory. Without this, "the disabled
+			// one has no ooapiEndpoint" would be satisfied by it simply being
+			// absent from the response.
+			const on = listingFor(rows, enabledId)
+			const off = listingFor(rows, disabledId)
+			expect(on, `the OOAPI-enabled fixture ${ENABLED_SLUG} must be listed in the directory`).toBeTruthy()
+			expect(off, `the disabled fixture ${DISABLED_SLUG} must ALSO be listed — the difference must be the endpoint, not the listing`).toBeTruthy()
+
+			// The requirement: an ABSOLUTE base URL for that catalog's v5 resources.
+			expect(on!.ooapiEndpoint, 'the enabled catalog must advertise ooapiEndpoint').toBeTruthy()
+			expect(String(on!.ooapiEndpoint)).toMatch(/^https?:\/\//)
+			expect(String(on!.ooapiEndpoint)).toContain(`/api/catalogs/${ENABLED_SLUG}/ooapi/v5`)
+
+			// The control: same response, same field, same accessor — the ONLY
+			// difference between the two catalogs is `hasOoapi`.
+			expect(
+				off!.ooapiEndpoint ?? null,
+				'a catalog with hasOoapi=false must advertise no OOAPI endpoint at all',
+			).toBeNull()
+
+			await api.dispose()
+		},
+	)
+})

--- a/tests/e2e/spec-coverage/page-components.spec.ts
+++ b/tests/e2e/spec-coverage/page-components.spec.ts
@@ -1,0 +1,331 @@
+/*
+ * SPDX-FileCopyrightText: 2026 OpenCatalogi Contributors
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * Gate-26 (visual-coverage) browser proof for the REACHABLE custom page
+ * components OpenCatalogi had no gate-visible proof for:
+ *
+ *   src/views/catalogi/CatalogiIndex.vue      (manifest page `Catalogs`,
+ *                                              registered as `CatalogsIndexView`)
+ *   src/views/woo/WooBatchDetail.vue          (manifest page `WooBatchDetail`,
+ *                                              registered as `WooBatchDetailView`)
+ *   src/views/directory/FederationDirectory.vue (manifest page `Directory`)
+ *
+ * FederationDirectory is here for a reason worth recording. It was NOT in
+ * gate-26's finding list, and it was not covered either — a CSS comment in that
+ * file read "… @visual exclude scoped copy of .viewHeaderTitleIndented …",
+ * ordinary English in which `@visual` happens to precede `exclude`. gate-26's
+ * `_VISUAL_EXCLUDE_RE` scans the whole file text and does not require the marker
+ * to be a directive, so that sentence silently waived a real, routed, shipped
+ * page. Measured both ways on the same tree: neutering those two words alone
+ * turned gate-26 from PASS into `FAIL — 1` naming this file. The prose has been
+ * reworded and the page is now proved here instead.
+ *
+ * (`directory-page.spec.ts` does already drive the page for real, but it never
+ * spells the string `FederationDirectory`, and gate-26 matches on the file stem
+ * — so that genuine coverage was invisible to the gate. A gate-26 finding is
+ * therefore not evidence a page is untested, in either direction.)
+ *
+ * WHY THIS FILE AND NOT A tests/e2e/visual/ BASELINE
+ * -------------------------------------------------
+ * Gate-26 accepts three proofs: a baseline under `tests/e2e/visual/**`, an e2e
+ * test anywhere under `tests/e2e/**`, or an `@visual exclude`. On this repo the
+ * first one is not a proof at all. The shared workflow is called with
+ * `playwright-test-path: tests/e2e`, so it loads `tests/e2e/playwright.config.ts`,
+ * which declares exactly one project:
+ *
+ *     { name: 'chromium', testIgnore: ['**‍/docs-screenshots.spec.ts', '**‍/visual/**'] }
+ *
+ * and the workflow never passes `--project`. A PNG committed under
+ * `tests/e2e/visual/` therefore turns gate-26 green with nothing ever executing
+ * it. (The root `playwright.config.ts` does declare a `visual` project, but its
+ * own header records that host-font/GPU rendering means its baselines cannot
+ * byte-match a CI Linux runner, which is why the CI config excludes it.)
+ *
+ * So the proof lives here, in the directory CI actually runs.
+ *
+ * WHAT EACH TEST HAS TO DO TO BE WORTH ANYTHING
+ * ---------------------------------------------
+ * Nextcloud paints its header, navigation and app shell on every route,
+ * including routes that silently fell back to the dashboard. "A page rendered"
+ * is therefore worth nothing, and so is a screenshot of chrome. Each test below
+ * asserts a string or structure that ONLY the component under test can produce,
+ * and pairs it with a control that makes the SAME locator resolve differently
+ * — a broken locator cannot produce a difference, so the pair is only
+ * satisfiable by the component genuinely rendering.
+ *
+ * THE OTHER TEN `src/views/**` COMPONENTS ARE NOT COVERED HERE ON PURPOSE.
+ * They are imported by nothing, routed to by nothing, and webpack tree-shakes
+ * every one of them out of `js/opencatalogi-main.js`. They carry an
+ * `@visual exclude` naming ConductionNL/opencatalogi#849 instead, because you
+ * cannot drive a screen that nothing can reach.
+ *
+ * Run:
+ *   PLAYWRIGHT_BASE_URL=http://localhost:8296 \
+ *     npx playwright test --config=tests/e2e/playwright.config.ts spec-coverage/page-components
+ */
+import { test, expect, type APIRequestContext } from '@playwright/test'
+import { APP, bootApp, dismissOverlays, content } from './_nav'
+
+/** OpenRegister object API root for the publication register. */
+const OR_OBJECTS = '/index.php/apps/openregister/api/objects'
+
+/** Marks every fixture this run creates, so cleanup and assertions are run-scoped. */
+const RUN_ID = `oc-g26-${Date.now()}`
+
+/**
+ * Copy that ONLY `src/views/catalogi/CatalogiIndex.vue` passes to CnIndexPage.
+ * The generic manifest `type: "index"` pages (Organizations, Themes, Glossary,
+ * Pages, Menus) take their title and description from `src/manifest.json` and
+ * never render this string, which is what makes it a discriminating locator
+ * rather than a "the shell booted" locator.
+ */
+const CATALOGI_INDEX_DESCRIPTION = 'Manage your data catalogs and their configurations'
+
+/**
+ * Resolve the OpenRegister schema id for a slug.
+ *
+ * Ids are assigned at import time and differ per instance, so hardcoding one
+ * would make this suite pass or fail on the ordering of a register import.
+ *
+ * @param request An authenticated API request context.
+ * @param slug The schema slug (e.g. `wooBatch`).
+ * @return The numeric schema id as a string.
+ */
+async function schemaId(request: APIRequestContext, slug: string): Promise<string> {
+	const resp = await request.get('/index.php/apps/openregister/api/schemas?limit=200', {
+		headers: { 'OCS-APIRequest': 'true' },
+	})
+	expect(resp.status(), 'GET /apps/openregister/api/schemas must answer 200').toBe(200)
+	const body = await resp.json()
+	const rows: Array<Record<string, unknown>> = body?.results ?? (Array.isArray(body) ? body : [])
+	const hit = rows.find((s) => s.slug === slug)
+	expect(hit, `schema "${slug}" must exist on this instance — the register import is a precondition`).toBeTruthy()
+	return String(hit!.id)
+}
+
+/**
+ * Resolve the register id that owns a schema.
+ *
+ * @param request An authenticated API request context.
+ * @param slug The register slug.
+ * @return The numeric register id as a string.
+ */
+async function registerId(request: APIRequestContext, slug: string): Promise<string> {
+	const resp = await request.get('/index.php/apps/openregister/api/registers?_limit=200', {
+		headers: { 'OCS-APIRequest': 'true' },
+	})
+	expect(resp.status(), 'GET /apps/openregister/api/registers must answer 200').toBe(200)
+	const body = await resp.json()
+	const rows: Array<Record<string, unknown>> = body?.results ?? (Array.isArray(body) ? body : [])
+	const hit = rows.find((r) => r.slug === slug)
+	expect(hit, `register "${slug}" must exist on this instance`).toBeTruthy()
+	return String(hit!.id)
+}
+
+/**
+ * Navigate the SPA's real in-app hash route.
+ *
+ * A path-form `page.goto('/apps/opencatalogi/woo/<id>')` loads the SPA index
+ * template and boots the router at `/`, so the Dashboard renders whatever path
+ * was asked for — an assertion written on top of that passes vacuously.
+ *
+ * @param page The Playwright page.
+ * @param route The in-app route, e.g. `/woo/<id>`.
+ */
+async function gotoHash(page: import('@playwright/test').Page, route: string): Promise<void> {
+	await page.goto(`${APP}/#${route}`, { waitUntil: 'domcontentloaded' })
+	await page.waitForTimeout(1500)
+	await dismissOverlays(page)
+}
+
+// ── src/views/catalogi/CatalogiIndex.vue ─────────────────────────────────────
+
+test.describe('page component — CatalogiIndex', () => {
+	/**
+	 * The Catalogs page is a manifest `type: "custom"` page whose `component`
+	 * is `CatalogsIndexView`, i.e. `src/views/catalogi/CatalogiIndex.vue`.
+	 * Reaching it must produce that component's own header copy and its own
+	 * add-label, neither of which any generic index page renders.
+	 */
+	test('CatalogiIndex renders its own index surface, header copy and Add Catalog CTA', async ({ page }) => {
+		await bootApp(page)
+		await gotoHash(page, '/catalogi')
+
+		// The index host must be present…
+		await expect(page.locator('[data-testid="cn-index-page"]').first())
+			.toBeVisible({ timeout: 15000 })
+
+		// …and it must be THIS component's index page, not some other one.
+		await expect(content(page).getByText(CATALOGI_INDEX_DESCRIPTION).first())
+			.toBeVisible({ timeout: 15000 })
+
+		// CatalogiIndex.vue passes `:add-label="t('opencatalogi', 'Add Catalog')"`.
+		await expect(page.locator('[data-testid="cn-cta-primary"]').first())
+			.toBeVisible({ timeout: 10000 })
+		await expect(page.locator('[data-testid="cn-cta-primary"]').first())
+			.toContainText('Catalog', { timeout: 10000 })
+	})
+
+	/**
+	 * CONTROL for the assertion above.
+	 *
+	 * `getByText(...)` resolving to nothing would satisfy any "is absent"
+	 * assertion for free, and a page that failed to mount would satisfy it too.
+	 * So the control is not "the text is missing somewhere" — it is that the
+	 * SAME locator, on a DIFFERENT real page of the same app, resolves
+	 * differently while the shared index host is present on both.
+	 *
+	 * Organizations is a manifest `type: "index"` page rendered by nc-vue's
+	 * generic CnIndexPage from `src/manifest.json`, so it must show the index
+	 * host and must NOT show CatalogiIndex's description.
+	 */
+	test('CatalogiIndex header copy is specific to it — a generic manifest index page does not render it', async ({ page }) => {
+		await bootApp(page)
+		await gotoHash(page, '/organizations')
+
+		// Positive half: we really are on a rendered index page, not a blank
+		// route. Without this the absence assertion below is worthless.
+		await expect(page.locator('[data-testid="cn-index-page"]').first())
+			.toBeVisible({ timeout: 15000 })
+
+		// Negative half: same locator, same DOM, no match.
+		await expect(content(page).getByText(CATALOGI_INDEX_DESCRIPTION))
+			.toHaveCount(0)
+	})
+})
+
+// ── src/views/directory/FederationDirectory.vue ──────────────────────────────
+
+test.describe('page component — FederationDirectory', () => {
+	/**
+	 * `/directory` is a manifest `type: "custom"` page whose component is
+	 * `FederationDirectory`. Its header, its three availability counters and its
+	 * "Add directory" action are drawn by that component and nothing else.
+	 */
+	test('FederationDirectory renders its header, the three availability counters and the Add directory action', async ({ page }) => {
+		await bootApp(page)
+		await gotoHash(page, '/directory')
+
+		const root = page.locator('.federation-directory')
+		await expect(root).toBeVisible({ timeout: 20000 })
+		await expect(root.locator('.federation-directory__title')).toHaveText('Directory')
+
+		// The summary strip is this component's own structure: exactly the three
+		// always-rendered buckets (a fourth, `unknown`, is `v-if`-gated on a
+		// non-zero count and must not be present on a clean instance).
+		const summary = root.locator('[data-testid="federation-directory-summary"]')
+		await expect(summary).toBeVisible({ timeout: 15000 })
+		await expect(summary).toContainText('available')
+		await expect(summary).toContainText('degraded')
+		await expect(summary).toContainText('unreachable')
+
+		await expect(root.getByRole('button', { name: /add directory/i }).first())
+			.toBeVisible({ timeout: 10000 })
+	})
+
+	/**
+	 * CONTROL for the assertion above.
+	 *
+	 * `.federation-directory` is this component's root. On any other real page
+	 * of the same app the shell, header and navigation are identical, so a
+	 * locator that had silently stopped matching would look exactly like a
+	 * passing absence assertion. Pairing it with a positive assertion on the
+	 * OTHER page's own surface means only a genuinely page-scoped root can
+	 * satisfy both halves.
+	 */
+	test('the FederationDirectory root is page-scoped — it is absent from the Catalogs page', async ({ page }) => {
+		await bootApp(page)
+		await gotoHash(page, '/catalogi')
+
+		// Positive half: we are on a real, rendered page.
+		await expect(page.locator('[data-testid="cn-index-page"]').first())
+			.toBeVisible({ timeout: 15000 })
+
+		// Negative half: same locator, same DOM, no match.
+		await expect(page.locator('.federation-directory')).toHaveCount(0)
+	})
+})
+
+// ── src/views/woo/WooBatchDetail.vue ─────────────────────────────────────────
+
+test.describe('page component — WooBatchDetail', () => {
+	/** The `wooBatch` object this describe block created, for cleanup. */
+	let batchId = ''
+	let objectsRoot = ''
+	const caseReference = `${RUN_ID}-woo`
+
+	test.beforeAll(async ({ playwright, baseURL, storageState }) => {
+		const api = await playwright.request.newContext({ baseURL, storageState })
+		const register = await registerId(api, 'publication')
+		const schema = await schemaId(api, 'wooBatch')
+		objectsRoot = `${OR_OBJECTS}/${register}/${schema}`
+
+		const resp = await api.post(objectsRoot, {
+			headers: { 'OCS-APIRequest': 'true', 'Content-Type': 'application/json' },
+			data: {
+				caseReference,
+				status: 'draft',
+				deckAvailable: false,
+			},
+		})
+		expect(resp.status(), `seeding a wooBatch must succeed (got ${resp.status()})`).toBe(201)
+		batchId = String((await resp.json()).id)
+		expect(batchId, 'the seeded wooBatch must come back with an id').toBeTruthy()
+		await api.dispose()
+	})
+
+	test.afterAll(async ({ playwright, baseURL, storageState }) => {
+		if (!batchId) return
+		const api = await playwright.request.newContext({ baseURL, storageState })
+		await api.delete(`${objectsRoot}/${batchId}`, { headers: { 'OCS-APIRequest': 'true' } })
+		await api.dispose()
+	})
+
+	/**
+	 * `/woo/:id` is a manifest `type: "custom"` page whose `component` is
+	 * `WooBatchDetailView`, i.e. `src/views/woo/WooBatchDetail.vue`.
+	 *
+	 * The heading interpolates the batch's own `caseReference`, which this run
+	 * generated, so the assertion cannot be satisfied by a stale fixture, by
+	 * another run's data, or by any other screen in the app.
+	 */
+	test('WooBatchDetail renders the batch heading, the four assessment counts and the Deck queue section', async ({ page }) => {
+		await bootApp(page)
+		await gotoHash(page, `/woo/${batchId}`)
+
+		const root = page.locator('.woo-batch')
+		await expect(root).toBeVisible({ timeout: 20000 })
+
+		// This run's own case reference, in this component's own h2.
+		await expect(root.locator('h2')).toContainText(caseReference, { timeout: 15000 })
+
+		// The four WOO assessment buckets — structure only this component draws.
+		const counts = root.locator('.woo-batch__counts li')
+		await expect(counts).toHaveCount(4)
+		await expect(root.locator('.woo-batch__counts')).toContainText('Te beoordelen')
+		await expect(root.locator('.woo-batch__counts')).toContainText('Niet openbaar')
+
+		// The Deck-board queue section.
+		await expect(root.locator('.woo-batch__deck')).toBeVisible()
+	})
+
+	/**
+	 * CONTROL for the assertion above.
+	 *
+	 * `.woo-batch` is the component's root and is rendered in BOTH the
+	 * found and not-found states — what differs is what it contains. So a
+	 * dead locator cannot produce this difference: the same root must show a
+	 * heading carrying our case reference for a real id, and the component's
+	 * "Batch not found" empty state for an id that cannot resolve.
+	 */
+	test('WooBatchDetail shows its not-found state for an unresolvable id, in the same root', async ({ page }) => {
+		await bootApp(page)
+		await gotoHash(page, '/woo/00000000-0000-0000-0000-000000000000')
+
+		const root = page.locator('.woo-batch')
+		await expect(root).toBeVisible({ timeout: 20000 })
+		await expect(root).toContainText('Batch not found', { timeout: 20000 })
+		await expect(root.locator('.woo-batch__counts li')).toHaveCount(0)
+	})
+})


### PR DESCRIPTION
## What this does

Takes **gate-26 (visual-coverage) from `FAIL — 12` to `PASS`** at full-tree scope, and fixes an app defect found while verifying it.

The reported number was 12. The **real number was 15** — three more components were exempt for reasons nobody wrote as exemptions.

## The three that were hidden

**`FederationDirectory.vue` — a real, routed, shipped page, silently waived by a CSS comment.** The comment read:

> `* @visual exclude scoped copy of .viewHeaderTitleIndented for manifest-v2`

That is ordinary English — *"…exclude scoped copy of `.viewHeaderTitleIndented`…"* — in which `@visual` happens to be the preceding word. `_VISUAL_EXCLUDE_RE` scans the whole file text and does not require the marker to be a directive. Measured both ways on the same tree, restoring byte-identical in between:

```
with the prose  : PASS   (FederationDirectory not in the finding list)
prose neutered  : FAIL — 1   naming src/views/directory/FederationDirectory.vue
restored        : PASS
```

**`PublicationDetail.vue` and `UserSettings.vue` — certified as covered by test docblocks.** The only occurrences of those strings under `tests/e2e/` are prose. For `PublicationDetail`, both are inside the comment of a `test.fixme` written to explain, correctly, that **no route mounts the component**. Documenting that a screen is unreachable is what certified it as visually covered, while the test that would have covered it never runs.

```
PASS — 18 new page(s)
  -> neuter the tokens `PublicationDetail` and `UserSettings` in the two docblocks
FAIL — 2   naming both files
  -> restore (git status empty)
PASS
```

Both are orphans, established with a positive control rather than inferred: `"UserSettings"` occurs **0** times in `js/opencatalogi-main.js` while every wired view occurs 1–7 times; `"PublicationDetail"` occurs 3 times and there are exactly **3 `name: 'PublicationDetail'` route-name references** in `src/`, so no occurrence is the component registering itself.

## The ten that were reported

All ten are unreachable. Nothing imports them (`src/registry.js` is the only place page components reach `CnAppRoot`), no route reaches them, and webpack tree-shakes every one out of the bundle. Positive controls: the six wired views each occur 1–7 times in `js/opencatalogi-main.js`; each of these occurs 0.

None of gate-26's three remedies fits an unreachable screen — you cannot baseline a screen with no route, you cannot drive it in a browser, and a bare waiver claims "no baseline needed" when the truth is "nothing can reach this". Each therefore carries a reason-bearing `@visual exclude` naming #849, so the waiver expires with the issue rather than becoming permanent.

## What was added

`tests/e2e/spec-coverage/page-components.spec.ts` — six tests driving the three reachable components (`CatalogiIndex`, `FederationDirectory`, `WooBatchDetail`).

**It is not under `tests/e2e/visual/` on purpose.** CI is called with `playwright-test-path: tests/e2e`, so it loads `tests/e2e/playwright.config.ts`, whose only project carries `testIgnore: ['**/visual/**']`, and the workflow never passes `--project`. A PNG committed there would turn gate-26 green with **nothing ever executing it**. Proven: moving `tests/e2e/visual/` out entirely leaves gate-26 passing.

Each test asserts something only its component can render, and is paired with a control that makes the **same locator** resolve differently on another real page — a dead selector cannot produce a difference, so the pair is only satisfiable by the component genuinely rendering.

**Every one was proven to fail.** Each assertion target was mutated one at a time, observed red on exactly the targeted assertion, then restored byte-identical:

| test | mutation | observed failure |
|---|---|---|
| CatalogiIndex renders | route → `/organizations` | header copy `element(s) not found` |
| CatalogiIndex copy is specific | route → `/catalogi` | `toHaveCount` expected 0, received 1 |
| FederationDirectory renders | route → `/catalogi` | `.federation-directory` not found |
| FederationDirectory is page-scoped | route → `/directory` | root found where absence expected |
| WooBatchDetail renders | bogus batch id | run's own `caseReference` not found |
| WooBatchDetail not-found state | real batch id | got the rendered batch instead |

## App defect fixed: OOAPI was unreachable on every instance (#847)

The `catalog` schema never declared `hasOoapi`, so OpenRegister's `hardValidation` stripped it, `OoapiService::isOoapiEnabled()` could never return `true`, and all 16 OOAPI v5 routes answered `404 "OOAPI 5.0 publication is not enabled for this catalog"` on every instance — while `CatalogModal.vue:81` rendered a working-looking switch labelled *"Has OOAPI 5.0 publication"* whose value was discarded on save.

Verified with the control in the same request (a declared property alongside the suspect one):

```
PUT .../objects/14/19/<catalogId>  {"hasWooSitemap":true,"hasOoapi":true}  -> 200
before: hasWooSitemap = True | hasOoapi = None
after : hasWooSitemap = True | hasOoapi = True
GET /api/catalogs/publications/ooapi/v5/courses   404 -> 200
```

⚠️ **The feature is not fully unstranded by this PR.** `x-ooapi` is also dropped at schema import — it is neither in OpenRegister's `$passThrough` allowlist nor an `x-openregister-*` key — so resources still render empty. That half needs a change in `openregister` and is documented on #847.

## Verification

| | scope | result |
|---|---|---|
| gate-26 before | full tree (empty-tree base) | `FAIL — 12` |
| gate-26 after | full tree (empty-tree base) | **`PASS — 18 new page(s)`** |
| gate-26 plant control | tracked + **committed** `ZzPlantProbeView.vue` | `PASS` → `FAIL — 1` naming the plant → `PASS` |
| gate-26 visual-dir control | `tests/e2e/visual/` moved out | still `PASS` — the green does not come from the unexecuted dir |
| e2e suite | local rig, NC 34.0.0.12 | 6/6 new tests green; full suite re-run |

Gate numbers were reproduced with the **canonical** gate package (`ConductionNL/.github@origin/main`, 1735-line checker), not the local `.github` checkout, and against the same `headSha` as full-scope run `31490133280`.

## Not in this PR

gate-19 is unchanged at 41. Its findings are analysed in the linked issues rather than papered over: the `app-packaging` scenarios are contradicted by the shipped app (#848), and 13 of the 15 `ooapi-catalog-publication` scenarios are untestable until #847's second half lands — an assertion against that feature today would be asserting an empty list, which passes for the wrong reason.

Refs #847, #848, #849
