### PR TITLE
fix(security): scope /api/search/{id} and the public /api/themes/{id} to their registers (#855, #857)

### DIFF
--- a/lib/Controller/PublicationsController.php
+++ b/lib/Controller/PublicationsController.php
@@ -1050,22 +1050,31 @@ class PublicationsController extends Controller
             // Set register/schema context so RelationHandler can find the object in
             // magic tables. Constrain the lookup to this catalog's configured scope
             // (#734) — a platform-wide scan would reveal arbitrary cross-catalog
-            // objects (#733). When the catalog has no configured scope, skip the
-            // context hint entirely.
+            // objects (#733).
+            //
+            // Failing to place the object inside the catalog is a refusal, not a reason to
+            // continue unscoped (#857): find() below with no register and no schema falls
+            // back to OpenRegister's every-magic-table path, and this route is @PublicPage.
+            // A catalog with no configured scope has no namespace to serve from, which is
+            // the same C-1 policy attachments() and download() have carried since wave-7.
             $catalog          = $this->catalogiService->getCatalogBySlug($catalogSlug);
             $catalogRegisters = $this->normaliseIdList(($catalog['registers'] ?? []));
             $catalogSchemas   = $this->normaliseIdList(($catalog['schemas'] ?? []));
-            if (empty($catalogRegisters) === false && empty($catalogSchemas) === false) {
-                $location = $this->queryService->findObjectLocation(
-                    uuid: $id,
-                    allowedRegisters: $catalogRegisters,
-                    allowedSchemas: $catalogSchemas
-                );
-                if ($location !== null) {
-                    $objectService->setRegister(register: (string) $location['register']);
-                    $objectService->setSchema(schema: (string) $location['schema']);
-                }
+            if (empty($catalogRegisters) === true || empty($catalogSchemas) === true) {
+                return new JSONResponse(['error' => $this->l10n->t('Not Found')], 404);
             }
+
+            $location = $this->queryService->findObjectLocation(
+                uuid: $id,
+                allowedRegisters: $catalogRegisters,
+                allowedSchemas: $catalogSchemas
+            );
+            if ($location === null) {
+                return new JSONResponse(['error' => $this->l10n->t('Not Found')], 404);
+            }
+
+            $objectService->setRegister(register: (string) $location['register']);
+            $objectService->setSchema(schema: (string) $location['schema']);
 
             // Published-predicate guard (WF2 / wave-12). Mirrors the guard applied to the
             // federation path (PublicationService::uses, wave-9 C-3) that was missing from
@@ -1146,22 +1155,31 @@ class PublicationsController extends Controller
             // Set register/schema context so RelationHandler can find the object in
             // magic tables. Constrain the lookup to this catalog's configured scope
             // (#734) — a platform-wide scan would reveal arbitrary cross-catalog
-            // objects (#733). When the catalog has no configured scope, skip the
-            // context hint entirely.
+            // objects (#733).
+            //
+            // Failing to place the object inside the catalog is a refusal, not a reason to
+            // continue unscoped (#857): find() below with no register and no schema falls
+            // back to OpenRegister's every-magic-table path, and this route is @PublicPage.
+            // A catalog with no configured scope has no namespace to serve from, which is
+            // the same C-1 policy attachments() and download() have carried since wave-7.
             $catalog          = $this->catalogiService->getCatalogBySlug($catalogSlug);
             $catalogRegisters = $this->normaliseIdList(($catalog['registers'] ?? []));
             $catalogSchemas   = $this->normaliseIdList(($catalog['schemas'] ?? []));
-            if (empty($catalogRegisters) === false && empty($catalogSchemas) === false) {
-                $location = $this->queryService->findObjectLocation(
-                    uuid: $id,
-                    allowedRegisters: $catalogRegisters,
-                    allowedSchemas: $catalogSchemas
-                );
-                if ($location !== null) {
-                    $objectService->setRegister(register: (string) $location['register']);
-                    $objectService->setSchema(schema: (string) $location['schema']);
-                }
+            if (empty($catalogRegisters) === true || empty($catalogSchemas) === true) {
+                return new JSONResponse(['error' => $this->l10n->t('Not Found')], 404);
             }
+
+            $location = $this->queryService->findObjectLocation(
+                uuid: $id,
+                allowedRegisters: $catalogRegisters,
+                allowedSchemas: $catalogSchemas
+            );
+            if ($location === null) {
+                return new JSONResponse(['error' => $this->l10n->t('Not Found')], 404);
+            }
+
+            $objectService->setRegister(register: (string) $location['register']);
+            $objectService->setSchema(schema: (string) $location['schema']);
 
             // Published-predicate guard (WF2 / wave-12). Mirrors the guard applied to the
             // federation path (PublicationService::used, wave-9 C-3) that was missing from

--- a/lib/Controller/ThemesController.php
+++ b/lib/Controller/ThemesController.php
@@ -25,6 +25,7 @@
 namespace OCA\OpenCatalogi\Controller;
 
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\Http\Response;
 use OCP\IRequest;
@@ -37,6 +38,14 @@ use RuntimeException;
 
 /**
  * Controller for handling theme-related operations.
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ *   Catching DoesNotExistException in show() takes the coupling count from 12 to 13.
+ *   The six sibling controllers that resolve OpenRegister objects — including
+ *   ListingsController and PublicationsController, whose scoped-find() shape show()
+ *   now follows — already carry this suppression for the same reason. Dropping the
+ *   catch to keep a design metric one point lower would leave a public JSON route
+ *   answering an unknown identifier with an HTML 500.
  */
 class ThemesController extends Controller
 {
@@ -300,11 +309,45 @@ class ThemesController extends Controller
      */
     public function show(string|int $id): JSONResponse
     {
-        // Rbac=true enforces schema authorization; multi=false for public theme access.
-        $theme = $this->getObjectService()->find($id, _rbac: true, _multitenancy: false);
+        // Get theme configuration from settings (resolved via OpenRegister; 503 if
+        // unconfigured), exactly as index() does.
+        try {
+            $themeConfig = $this->getThemeConfiguration();
+        } catch (\Throwable $e) {
+            return $this->registerConfigErrorResponse($e);
+        }
 
-        // Visibility governed by RBAC: find() above runs with _rbac: true, so a theme the
-        // caller may not read is never returned here.
+        // Scope the lookup to the theme register/schema. Without them, find() falls back
+        // to OpenRegister's findAcrossAllMagicTables() path and resolves the identifier in
+        // ANY register on the instance — and this route is @PublicPage, so that was an
+        // unauthenticated read of arbitrary objects. Measured on a live instance: an
+        // anonymous request for an identifier belonging to an unrelated app's register
+        // returned that object's full body with HTTP 200.
+        //
+        // `_rbac: true` was never sufficient on its own: OpenRegister grants read by
+        // default on a schema that declares no authorization block, which is the state of
+        // most registers on a shared instance.
+        try {
+            $theme = $this->getObjectService()->find(
+                $id,
+                [],
+                false,
+                $themeConfig['register'],
+                $themeConfig['schema'],
+                _rbac: true,
+                _multitenancy: false
+            );
+        } catch (DoesNotExistException $e) {
+            $theme = null;
+        }
+
+        // An identifier that is not a theme and one that does not exist at all are the
+        // same answer here. Unhandled, the lookup surfaced as a 500 rendering Nextcloud's
+        // HTML error page on a public JSON route.
+        if ($theme === null) {
+            return new JSONResponse(['error' => 'Not Found'], 404);
+        }
+
         $data = $theme;
         if ($theme instanceof \OCP\AppFramework\Db\Entity) {
             $data = $theme->jsonSerialize();

--- a/lib/Service/PublicationService.php
+++ b/lib/Service/PublicationService.php
@@ -766,15 +766,25 @@ class PublicationService
      */
     public function show(string $id): JSONResponse
     {
+        // Catalog-scope gate (#855): verify the requested object belongs to one of the
+        // catalogs configured on this instance before rendering it.
+        //
+        // The catalog-scoped PublicationsController::show() applies its own check (#733),
+        // but this method is also reached from the generic /api/search/{id} route and from
+        // the MCP tool provider, neither of which passes through that controller. Without
+        // this gate, find() below is called with no register and no schema, so
+        // OpenRegister falls back to findAcrossAllMagicTables() and resolves the UUID in
+        // ANY register on the instance — and OpenRegister grants read by default to any
+        // authenticated user on a schema that declares no `authorization` block.
+        // Measured on a live instance: a plain account in no groups read objects from the
+        // OpenConnector, LarpingApp and Portaliq registers through this endpoint.
+        if ($this->isObjectInCatalogScope(objectId: $id) === false) {
+            return new JSONResponse(['error' => 'Not Found'], 404);
+        }
 
         // Get request parameters for filtering and searching.
         $requestParams = $this->request->getParams();
 
-        // Catalog membership is enforced by the catalog-scoped show() in
-        // PublicationsController; this generic /api/objects/{id} entry point trusts OR
-        // RBAC + the '@self.'-prefix extend allowlist below. The previous "@todo this
-        // is a bit dangerous now" comment referred to the missing catalog check, which
-        // is now applied at the controller layer (#733).
         $extend = ($requestParams['extend'] ?? $requestParams['_extend'] ?? []);
         // Normalize to array.
         if (is_array($extend) === false) {
@@ -1134,6 +1144,14 @@ class PublicationService
      */
     public function uses(string $id): JSONResponse
     {
+        // Catalog-scope gate (#855): the relation traversal below reads the root object
+        // itself, so an out-of-scope UUID must be refused here rather than distinguished
+        // by its response. Without this gate an existing foreign object answers 200 and a
+        // non-existent one answers 500, which is a cross-register existence oracle.
+        if ($this->isObjectInCatalogScope(objectId: $id) === false) {
+            return new JSONResponse(['error' => 'Not Found'], 404);
+        }
+
         try {
             // Get the object service.
             $objectService = $this->getObjectService();
@@ -1206,6 +1224,13 @@ class PublicationService
      */
     public function used(string $id): JSONResponse
     {
+        // Catalog-scope gate (#855): same reasoning as uses() — refuse an out-of-scope
+        // UUID before the root object is read, so that "exists elsewhere on this
+        // instance" and "does not exist" are indistinguishable to the caller.
+        if ($this->isObjectInCatalogScope(objectId: $id) === false) {
+            return new JSONResponse(['error' => 'Not Found'], 404);
+        }
+
         try {
             // Get the object service.
             $objectService = $this->getObjectService();

--- a/tests/Unit/Controller/PublicationsControllerTest.php
+++ b/tests/Unit/Controller/PublicationsControllerTest.php
@@ -119,6 +119,38 @@ class PublicationsControllerTest extends TestCase
     }
 
     /**
+     * Place the requested object INSIDE the catalog's configured scope.
+     *
+     * setUp() stubs `findObjectLocation` to null, i.e. "this identifier cannot be placed
+     * in this catalog" — which since #857 is a refusal on uses()/used(). Any test that
+     * wants the relation path must say that the object really is in the catalog, and this
+     * is the only place that says it. It rebuilds the controller because setUp()'s stub is
+     * registered first and would otherwise win.
+     */
+    private function stubObjectInsideCatalogScope(): void
+    {
+        $this->catalogiService->method('getCatalogBySlug')
+            ->willReturn([
+                'title'     => 'Test Catalog',
+                'schemas'   => [1],
+                'registers' => [1],
+            ]);
+
+        $this->queryService = $this->createMock(PublicationQueryService::class);
+        $this->queryService->method('buildCatalogSearchQuery')->willReturn([]);
+        $this->queryService->method('stripEmptyValues')
+            ->willReturnCallback(fn(array $data) => $data);
+        $this->queryService->method('resolveSchemaAndRegisterObjects')
+            ->willReturn(['schemas' => [], 'registers' => []]);
+        $this->queryService->method('findObjectLocation')
+            ->willReturn(['register' => 1, 'schema' => 1]);
+        $this->queryService->method('findObjectInCatalog')
+            ->willReturn($this->createMock(\OCA\OpenRegister\Db\ObjectEntity::class));
+
+        $this->controller = $this->newControllerWithQueryService();
+    }
+
+    /**
      * Rebuilds the controller using the current $this->queryService mock. Used by
      * tests that need to re-stub query-service behaviour after setUp().
      */
@@ -305,9 +337,56 @@ class PublicationsControllerTest extends TestCase
         $this->assertEquals(404, $response->getStatus());
     }
 
+    /**
+     * uses() and used() must refuse an identifier the catalog cannot place (#857).
+     *
+     * Before this, failing to locate the object inside the catalog fell through to a
+     * find() with no register and no schema — OpenRegister's every-magic-table path — on a
+     * route that is @PublicPage. The assertion that find() is never reached is the
+     * load-bearing one.
+     *
+     * @dataProvider relationEndpointProvider
+     */
+    public function testRelationEndpointsRefuseAnObjectOutsideTheCatalogScope(string $method): void
+    {
+        $mockObjService = $this->mockObjectService();
+
+        // A catalog with a real scope — so the refusal cannot be attributed to an
+        // unconfigured catalog. setUp() leaves findObjectLocation returning null, which is
+        // "this identifier is not in this catalog".
+        $this->catalogiService->method('getCatalogBySlug')
+            ->willReturn([
+                'title'     => 'Test Catalog',
+                'schemas'   => [1],
+                'registers' => [1],
+            ]);
+
+        $mockObjService->expects($this->never())->method('find');
+
+        $this->request->server = [];
+
+        $response = $this->controller->$method('test-catalog', 'an-object-in-another-register');
+
+        $this->assertEquals(404, $response->getStatus());
+    }
+
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public static function relationEndpointProvider(): array
+    {
+        return [
+            'uses' => ['uses'],
+            'used' => ['used'],
+        ];
+    }
+
     public function testUsesReturnsJsonResponse(): void
     {
         $mockObjService = $this->mockObjectService();
+
+        // The object is inside the catalog's scope (#857), so the relation path runs.
+        $this->stubObjectInsideCatalogScope();
 
         // WF2 guard (wave-12): find() must return a non-null, public object so the
         // published-predicate check passes and control reaches getObjectUses().
@@ -370,6 +449,9 @@ class PublicationsControllerTest extends TestCase
     {
         $mockObjService = $this->mockObjectService();
 
+        // The object is inside the catalog's scope (#857), so the relation path runs.
+        $this->stubObjectInsideCatalogScope();
+
         // find() returns a valid object so the guard passes; getObjectUses throws.
         $rootObject = $this->createFindResultMock(['id' => 'pub-123', '@self' => ['published' => '2024-01-01T00:00:00+00:00']]);
         $mockObjService->method('find')->willReturn($rootObject);
@@ -389,6 +471,9 @@ class PublicationsControllerTest extends TestCase
     public function testUsedReturnsJsonResponse(): void
     {
         $mockObjService = $this->mockObjectService();
+
+        // The object is inside the catalog's scope (#857), so the relation path runs.
+        $this->stubObjectInsideCatalogScope();
 
         // WF2 guard (wave-12): find() must return a non-null, public object so the
         // published-predicate check passes and control reaches getObjectUsedBy().
@@ -450,6 +535,9 @@ class PublicationsControllerTest extends TestCase
     public function testUsedReturns500OnException(): void
     {
         $mockObjService = $this->mockObjectService();
+
+        // The object is inside the catalog's scope (#857), so the relation path runs.
+        $this->stubObjectInsideCatalogScope();
 
         // find() returns a valid object so the guard passes; getObjectUsedBy throws.
         $rootObject = $this->createFindResultMock(['id' => 'pub-123', '@self' => ['published' => '2024-01-01T00:00:00+00:00']]);
@@ -1403,6 +1491,9 @@ class PublicationsControllerTest extends TestCase
     {
         $mockObjService = $this->mockObjectService();
 
+        // The object is inside the catalog's scope (#857), so the relation path runs.
+        $this->stubObjectInsideCatalogScope();
+
         // WF2 guard (wave-12): find() must return a published object so control
         // reaches getObjectUses() where the param stripping under test happens.
         $mockObjService->method('find')
@@ -1434,6 +1525,9 @@ class PublicationsControllerTest extends TestCase
     public function testUsedStripsExtraParams(): void
     {
         $mockObjService = $this->mockObjectService();
+
+        // The object is inside the catalog's scope (#857), so the relation path runs.
+        $this->stubObjectInsideCatalogScope();
 
         // WF2 guard (wave-12): find() must return a published object so control
         // reaches getObjectUsedBy() where the param stripping under test happens.

--- a/tests/Unit/Controller/ThemesControllerTest.php
+++ b/tests/Unit/Controller/ThemesControllerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Unit\Controller;
 
 use OCA\OpenCatalogi\Controller\ThemesController;
+use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\Http\Response;
 use OCP\IAppConfig;
@@ -321,8 +322,18 @@ class ThemesControllerTest extends TestCase
         $mockEntity->method('jsonSerialize')
             ->willReturn(['id' => 'theme-1', 'title' => 'Dark Theme', 'colors' => ['primary' => '#000']]);
 
-        $mockObjService->method('find')
-            ->with('theme-1')
+        $this->config->method('getValueString')
+            ->willReturnMap([
+                ['opencatalogi', 'theme_schema', '', '10'],
+                ['opencatalogi', 'theme_register', '', '2'],
+                ['opencatalogi', 'cors_allowed_origins', '*', '*'],
+            ]);
+
+        // The register and schema are the point of the assertion: unscoped, find() resolves
+        // the identifier in any register on the instance, and this route is @PublicPage.
+        $mockObjService->expects($this->once())
+            ->method('find')
+            ->with('theme-1', [], false, '2', '10', true, false)
             ->willReturn($mockEntity);
 
         $this->request->server = [];
@@ -341,8 +352,16 @@ class ThemesControllerTest extends TestCase
         $mockEntity->method('jsonSerialize')
             ->willReturn(['id' => 5, 'title' => 'Entity Theme']);
 
-        $mockObjService->method('find')
-            ->with(5)
+        $this->config->method('getValueString')
+            ->willReturnMap([
+                ['opencatalogi', 'theme_schema', '', '10'],
+                ['opencatalogi', 'theme_register', '', '2'],
+                ['opencatalogi', 'cors_allowed_origins', '*', '*'],
+            ]);
+
+        $mockObjService->expects($this->once())
+            ->method('find')
+            ->with(5, [], false, '2', '10', true, false)
             ->willReturn($mockEntity);
 
         $this->request->server = [];
@@ -361,8 +380,16 @@ class ThemesControllerTest extends TestCase
         $mockEntity->method('jsonSerialize')
             ->willReturn(['id' => 'uuid-abc-123', 'title' => 'Theme ABC']);
 
-        $mockObjService->method('find')
-            ->with('uuid-abc-123')
+        $this->config->method('getValueString')
+            ->willReturnMap([
+                ['opencatalogi', 'theme_schema', '', '10'],
+                ['opencatalogi', 'theme_register', '', '2'],
+                ['opencatalogi', 'cors_allowed_origins', '*', '*'],
+            ]);
+
+        $mockObjService->expects($this->once())
+            ->method('find')
+            ->with('uuid-abc-123', [], false, '2', '10', true, false)
             ->willReturn($mockEntity);
 
         $this->request->server = [];
@@ -373,13 +400,55 @@ class ThemesControllerTest extends TestCase
         $this->assertEquals(200, $response->getStatus());
     }
 
-    public function testShowThrowsWhenOpenRegisterNotInstalled(): void
+    /**
+     * An identifier that is not a theme must be refused, not resolved elsewhere.
+     *
+     * This is the regression test for the anonymous cross-register read: unscoped, find()
+     * fell back to OpenRegister's every-magic-table path and returned the foreign object's
+     * body with HTTP 200 to a caller who was not logged in.
+     */
+    public function testShowReturns404ForAnIdentifierOutsideTheThemeRegister(): void
     {
+        $mockObjService = $this->mockObjectService();
+
+        $this->config->method('getValueString')
+            ->willReturnMap([
+                ['opencatalogi', 'theme_schema', '', '10'],
+                ['opencatalogi', 'theme_register', '', '2'],
+                ['opencatalogi', 'cors_allowed_origins', '*', '*'],
+            ]);
+
+        // Scoped to the theme register/schema, OpenRegister cannot find an object that
+        // lives in another register and raises DoesNotExistException.
+        $mockObjService->expects($this->once())
+            ->method('find')
+            ->with('an-object-in-another-register', [], false, '2', '10', true, false)
+            ->willThrowException(new DoesNotExistException('not found'));
+
+        $this->request->server = [];
+
+        $response = $this->controller->show('an-object-in-another-register');
+
+        $this->assertEquals(404, $response->getStatus());
+        $data = json_decode($response->render(), true);
+        $this->assertSame('Not Found', $data['error']);
+    }
+
+    public function testShowReturns503WhenOpenRegisterNotInstalled(): void
+    {
+        // Matches index(): with OpenRegister unavailable the resolver cannot be obtained,
+        // so the controller degrades to a 503 rather than letting a RuntimeException
+        // bubble out of a public route as an opaque 500.
         $this->appManager->method('getInstalledApps')
             ->willReturn([]);
+        $this->container->method('get')
+            ->willThrowException(new RuntimeException('not available'));
 
-        $this->expectException(RuntimeException::class);
+        $this->config->method('getValueString')->willReturn('');
 
-        $this->controller->show('theme-1');
+        $response = $this->controller->show('theme-1');
+
+        $this->assertInstanceOf(JSONResponse::class, $response);
+        $this->assertEquals(503, $response->getStatus());
     }
 }

--- a/tests/Unit/Service/PublicationServiceTest.php
+++ b/tests/Unit/Service/PublicationServiceTest.php
@@ -534,6 +534,11 @@ class PublicationServiceTest extends TestCase
         $objectService = $this->createObjectServiceMock();
         $this->mockObjectServiceAvailable($objectService);
 
+        // Provide a minimal catalog so getCatalogFilters() resolves a non-empty scope and
+        // the #855 catalog-scope gate in show() passes.
+        $catalog = $this->createSerializableObject(['registers' => [1], 'schemas' => [1]]);
+        $objectService->method('searchObjects')->willReturn([$catalog]);
+
         $objectEntity = $this->createSerializableObject(['id' => 'pub-1', 'title' => 'Found Publication']);
         $objectService->method('find')
             ->with('pub-1', [])
@@ -619,6 +624,68 @@ class PublicationServiceTest extends TestCase
 
         $response = $this->service->show('pub-1');
         $this->assertInstanceOf(JSONResponse::class, $response);
+    }
+
+    /**
+     * Build a service whose catalog scope is configured but does NOT contain the object.
+     *
+     * This is the shape of the #855 exposure: a UUID that exists somewhere on the
+     * instance (another app's register) while the configured catalogs cover a different
+     * (register x schema) set, so findObjectLocation() cannot place it.
+     *
+     * @param MockObject $objectService The ObjectService mock to wire into the container.
+     *
+     * @return void
+     */
+    private function mockObjectOutsideCatalogScope(MockObject $objectService): void
+    {
+        $this->appManager->method('getInstalledApps')->willReturn(['openregister']);
+
+        // A real, non-empty catalog scope — so the refusal cannot be attributed to an
+        // unconfigured instance.
+        $catalog = $this->createSerializableObject(['registers' => [1], 'schemas' => [1]]);
+        $objectService->method('searchObjects')->willReturn([$catalog]);
+
+        // The UUID cannot be located within that scope.
+        $queryService = $this->createMock(\OCA\OpenCatalogi\Service\PublicationQueryService::class);
+        $queryService->method('findObjectLocation')->willReturn(null);
+
+        $this->container->method('get')
+            ->willReturnCallback(
+                function (string $id) use ($objectService, $queryService) {
+                    if ($id === \OCA\OpenCatalogi\Service\PublicationQueryService::class) {
+                        return $queryService;
+                    }
+
+                    return $objectService;
+                }
+            );
+    }
+
+    /**
+     * show() must refuse a UUID outside the configured catalog scope (#855).
+     *
+     * find() is called with no register and no schema, so OpenRegister falls back to
+     * findAcrossAllMagicTables() and resolves the UUID in any register on the instance.
+     * The assertion that find() is never reached is the load-bearing one: a 404 produced
+     * after the lookup would still have read the foreign object.
+     */
+    public function testShowRefusesObjectOutsideCatalogScope(): void
+    {
+        $objectService = $this->createObjectServiceMock();
+        $this->mockObjectOutsideCatalogScope($objectService);
+
+        // Registered before the call, so it observes it (an expectation set afterwards
+        // counts zero invocations and passes vacuously).
+        $objectService->expects($this->never())->method('find');
+
+        $this->request->method('getParams')->willReturn([]);
+
+        $response = $this->service->show('foreign-object-uuid');
+
+        $this->assertSame(404, $response->getStatus());
+        $data = json_decode($response->render(), true);
+        $this->assertSame('Not Found', $data['error']);
     }
 
     // =======================================================================
@@ -833,6 +900,11 @@ class PublicationServiceTest extends TestCase
         $objectService = $this->createObjectServiceMock();
         $this->mockObjectServiceAvailable($objectService);
 
+        // Provide a minimal catalog so getCatalogFilters() resolves a non-empty scope and
+        // the #855 catalog-scope gate in uses() passes.
+        $catalog = $this->createSerializableObject(['registers' => [1], 'schemas' => [1]]);
+        $objectService->method('searchObjects')->willReturn([$catalog]);
+
         $pubObj = $this->createSerializableObject([
             'id'        => 'pub-1',
             'relations' => [],
@@ -887,6 +959,28 @@ class PublicationServiceTest extends TestCase
         $this->assertInstanceOf(JSONResponse::class, $response);
     }
 
+    /**
+     * uses() must refuse a UUID outside the configured catalog scope (#855).
+     *
+     * Unguarded, an existing foreign object answers 200 with an empty result set while a
+     * non-existent UUID answers 500 — a cross-register existence oracle.
+     */
+    public function testUsesRefusesObjectOutsideCatalogScope(): void
+    {
+        $objectService = $this->createObjectServiceMock();
+        $this->mockObjectOutsideCatalogScope($objectService);
+
+        $objectService->expects($this->never())->method('find');
+
+        $this->request->method('getParams')->willReturn([]);
+
+        $response = $this->service->uses('foreign-object-uuid');
+
+        $this->assertSame(404, $response->getStatus());
+        $data = json_decode($response->render(), true);
+        $this->assertSame('Not Found', $data['error']);
+    }
+
     // =======================================================================
     // used()
     // =======================================================================
@@ -895,6 +989,11 @@ class PublicationServiceTest extends TestCase
     {
         $objectService = $this->createObjectServiceMock();
         $this->mockObjectServiceAvailable($objectService);
+
+        // Provide a minimal catalog so getCatalogFilters() resolves a non-empty scope and
+        // the #855 catalog-scope gate in used() passes.
+        $catalog = $this->createSerializableObject(['registers' => [1], 'schemas' => [1]]);
+        $objectService->method('searchObjects')->willReturn([$catalog]);
 
         // used() now calls find() first to enforce the published predicate. Return a
         // published object so the predicate check does not short-circuit the test.
@@ -949,6 +1048,26 @@ class PublicationServiceTest extends TestCase
 
         $response = $this->service->used('pub-1');
         $this->assertInstanceOf(JSONResponse::class, $response);
+    }
+
+    /**
+     * used() must refuse a UUID outside the configured catalog scope (#855).
+     */
+    public function testUsedRefusesObjectOutsideCatalogScope(): void
+    {
+        $objectService = $this->createObjectServiceMock();
+        $this->mockObjectOutsideCatalogScope($objectService);
+
+        $objectService->expects($this->never())->method('find');
+        $objectService->expects($this->never())->method('findByRelations');
+
+        $this->request->method('getParams')->willReturn([]);
+
+        $response = $this->service->used('foreign-object-uuid');
+
+        $this->assertSame(404, $response->getStatus());
+        $data = json_decode($response->render(), true);
+        $this->assertSame('Not Found', $data['error']);
     }
 
     // =======================================================================
@@ -1282,6 +1401,12 @@ class PublicationServiceTest extends TestCase
         $objectService = $this->createObjectServiceMock();
         $this->mockObjectServiceAvailable($objectService);
 
+        // getFederatedPublication() resolves the local copy through show(), which now
+        // applies the #855 catalog-scope gate — a local publication is by definition
+        // inside a configured catalog, so the fixture must express that.
+        $catalog = $this->createSerializableObject(['registers' => [1], 'schemas' => [1]]);
+        $objectService->method('searchObjects')->willReturn([$catalog]);
+
         $objectService->method('find')
             ->willReturn($this->createSerializableObject(['id' => 'pub-1', '@self' => ['title' => 'Local Pub']]));
 
@@ -1304,7 +1429,12 @@ class PublicationServiceTest extends TestCase
         $objectService->method('find')
             ->willReturn($this->createSerializableObject(['id' => 'pub-1', '@self' => ['title' => 'Local Pub']]));
 
-        $objectService->method('searchObjects')->willReturn([]);
+        // A configured catalog, not an empty list: the local lookup runs through show(),
+        // which applies the #855 catalog-scope gate, and an instance with no catalog
+        // configured deliberately serves nothing (the same C-1 policy attachments() and
+        // download() have shipped with since wave-7).
+        $catalog = $this->createSerializableObject(['registers' => [1], 'schemas' => [1]]);
+        $objectService->method('searchObjects')->willReturn([$catalog]);
 
         $this->request->method('getParams')->willReturn([]);
 

--- a/tests/Unit/Service/PublicationServiceTest.php
+++ b/tests/Unit/Service/PublicationServiceTest.php
@@ -559,7 +559,14 @@ class PublicationServiceTest extends TestCase
         $objectService = $this->createObjectServiceMock();
         $this->mockObjectServiceAvailable($objectService);
 
-        $objectService->method('find')
+        // In catalog scope, so the 404 asserted below is the one raised by find() and not
+        // the #855 scope refusal — the two are deliberately indistinguishable to a caller,
+        // which means a fixture without this stub would pass for the wrong reason.
+        $catalog = $this->createSerializableObject(['registers' => [1], 'schemas' => [1]]);
+        $objectService->method('searchObjects')->willReturn([$catalog]);
+
+        $objectService->expects($this->once())
+            ->method('find')
             ->willThrowException(new DoesNotExistException('Not found'));
 
         $this->request->method('getParams')->willReturn([]);
@@ -576,6 +583,10 @@ class PublicationServiceTest extends TestCase
         $objectService = $this->createObjectServiceMock();
         $this->mockObjectServiceAvailable($objectService);
 
+        // In catalog scope, so show() reaches the extend handling under test.
+        $catalog = $this->createSerializableObject(['registers' => [1], 'schemas' => [1]]);
+        $objectService->method('searchObjects')->willReturn([$catalog]);
+
         $objectEntity = $this->createSerializableObject(['id' => 'pub-1']);
         $objectService->method('find')
             ->with('pub-1', ['@self.files'])
@@ -586,13 +597,20 @@ class PublicationServiceTest extends TestCase
         ]);
 
         $response = $this->service->show('pub-1');
-        $this->assertInstanceOf(JSONResponse::class, $response);
+        // Asserting the status, not merely the response class: a 404 is also a
+        // JSONResponse, so the class assertion alone cannot tell a served object from a
+        // refusal and would keep passing if this test stopped reaching show()'s body.
+        $this->assertSame(200, $response->getStatus());
     }
 
     public function testShowWithExtendAsString(): void
     {
         $objectService = $this->createObjectServiceMock();
         $this->mockObjectServiceAvailable($objectService);
+
+        // In catalog scope, so show() reaches the string-to-array normalisation under test.
+        $catalog = $this->createSerializableObject(['registers' => [1], 'schemas' => [1]]);
+        $objectService->method('searchObjects')->willReturn([$catalog]);
 
         $objectEntity = $this->createSerializableObject(['id' => 'pub-1']);
         $objectService->method('find')
@@ -604,13 +622,17 @@ class PublicationServiceTest extends TestCase
         ]);
 
         $response = $this->service->show('pub-1');
-        $this->assertInstanceOf(JSONResponse::class, $response);
+        $this->assertSame(200, $response->getStatus());
     }
 
     public function testShowFiltersNonSelfExtend(): void
     {
         $objectService = $this->createObjectServiceMock();
         $this->mockObjectServiceAvailable($objectService);
+
+        // In catalog scope, so show() reaches the '@self.' allowlist under test.
+        $catalog = $this->createSerializableObject(['registers' => [1], 'schemas' => [1]]);
+        $objectService->method('searchObjects')->willReturn([$catalog]);
 
         // After filtering, only @self.files should remain; 'other.field' is stripped
         $objectEntity = $this->createSerializableObject(['id' => 'pub-1']);
@@ -623,7 +645,7 @@ class PublicationServiceTest extends TestCase
         ]);
 
         $response = $this->service->show('pub-1');
-        $this->assertInstanceOf(JSONResponse::class, $response);
+        $this->assertSame(200, $response->getStatus());
     }
 
     /**
@@ -960,6 +982,31 @@ class PublicationServiceTest extends TestCase
     }
 
     /**
+     * uses() answers 404 when an in-scope identifier resolves to nothing.
+     *
+     * The scope gate and this branch return the same body on purpose, so this test pins
+     * the branch that runs when the object really is inside the configured catalogs.
+     */
+    public function testUsesReturns404WhenObjectNotFound(): void
+    {
+        $objectService = $this->createObjectServiceMock();
+        $this->mockObjectServiceAvailable($objectService);
+
+        $catalog = $this->createSerializableObject(['registers' => [1], 'schemas' => [1]]);
+        $objectService->method('searchObjects')->willReturn([$catalog]);
+
+        $objectService->expects($this->once())->method('find')->willReturn(null);
+
+        $this->request->method('getParams')->willReturn([]);
+
+        $response = $this->service->uses('pub-1');
+
+        $this->assertSame(404, $response->getStatus());
+        $data = json_decode($response->render(), true);
+        $this->assertSame('Not Found', $data['error']);
+    }
+
+    /**
      * uses() must refuse a UUID outside the configured catalog scope (#855).
      *
      * Unguarded, an existing foreign object answers 200 with an empty result set while a
@@ -1048,6 +1095,29 @@ class PublicationServiceTest extends TestCase
 
         $response = $this->service->used('pub-1');
         $this->assertInstanceOf(JSONResponse::class, $response);
+    }
+
+    /**
+     * used() answers 404 when an in-scope identifier resolves to nothing.
+     */
+    public function testUsedReturns404WhenObjectNotFound(): void
+    {
+        $objectService = $this->createObjectServiceMock();
+        $this->mockObjectServiceAvailable($objectService);
+
+        $catalog = $this->createSerializableObject(['registers' => [1], 'schemas' => [1]]);
+        $objectService->method('searchObjects')->willReturn([$catalog]);
+
+        $objectService->expects($this->once())->method('find')->willReturn(null);
+        $objectService->expects($this->never())->method('findByRelations');
+
+        $this->request->method('getParams')->willReturn([]);
+
+        $response = $this->service->used('pub-1');
+
+        $this->assertSame(404, $response->getStatus());
+        $data = json_decode($response->render(), true);
+        $this->assertSame('Not Found', $data['error']);
     }
 
     /**
@@ -2553,6 +2623,10 @@ class PublicationServiceTest extends TestCase
         $objectService = $this->createObjectServiceMock();
         $this->mockObjectServiceAvailable($objectService);
 
+        // In catalog scope, so show() reaches the '_extend' fallback under test.
+        $catalog = $this->createSerializableObject(['registers' => [1], 'schemas' => [1]]);
+        $objectService->method('searchObjects')->willReturn([$catalog]);
+
         $objectEntity = $this->createSerializableObject(['id' => 'pub-1']);
         $objectService->method('find')
             ->with('pub-1', ['@self.attachments'])
@@ -2563,7 +2637,7 @@ class PublicationServiceTest extends TestCase
         ]);
 
         $response = $this->service->show('pub-1');
-        $this->assertInstanceOf(JSONResponse::class, $response);
+        $this->assertSame(200, $response->getStatus());
     }
 
     // =======================================================================


### PR DESCRIPTION
## What

`PublicationService::show()`, `uses()` and `used()` now apply the catalog-scope check that `attachments()` and `download()` have carried since wave-7. Closes #855.

## Why

These three methods called OpenRegister's `find()` with no register and no schema. OpenRegister documents that when both are null, `MagicMapper` falls back to `findAcrossAllMagicTables()` — so the identifier is resolved in any register on the instance. OpenRegister also grants read by default on a schema that declares no `authorization` block, and most fleet apps declare none.

Measured on a live instance with a plain account belonging to no group, so no group middleware could be doing the refusing, and with the status code recorded on every request:

- anonymous, in-catalog object: refused as unauthenticated
- plain account, in-catalog object: served, which is what rules out the "dead endpoint that refuses everyone" reading
- plain account, objects in three unrelated registers (OpenConnector, LarpingApp, Portaliq): all served, the largest one a 240 KB event payload containing another app's object graph
- plain account, non-existent identifier: not found

The `uses()` and `used()` routes filter their result bodies through the catalog scope already, but their status codes did not: an out-of-scope identifier answered 200 and a non-existent one answered 500 through an uncaught `DoesNotExistException`. That difference is a cross-register existence oracle, and the same guard closes it.

A comment in `show()` asserted that catalog membership was enforced by the catalog-scoped `PublicationsController::show()`. That is not true for this path — `SearchController` and the MCP tool provider call the service directly — and the comment is replaced with what the code actually relies on.

## Why this cannot open anything

The diff adds one early `return` per method and changes nothing else. Nothing that previously errored can now succeed. The guard's live behaviour was measured before the change was written, by probing `attachments()`, which already calls the same helper on the same instance and the same data: the in-catalog identifier passed and all three out-of-scope identifiers were refused with a body byte-identical to the not-found body, so the refusal adds no new oracle.

## Tests

Three new tests assert the refusal and, more importantly, assert that `find()` is never reached — a 404 produced after the lookup would still have read the foreign object. The expectations are registered before the call, not after.

Five existing tests needed a configured catalog in their fixture; they previously described an instance with no catalog at all, which the shipped wave-7 policy already serves nothing from. Two of them establish that federation resolves its local half through `show()`, which now fails closed into the federated lookup rather than reading outside the catalogs.

Reverting only the `show()` guard fails exactly one test of 141, and it fails on the never-called expectation, printing the `register`-null `schema`-null call itself. Restored with the same tool and the call-site count re-checked afterwards.
