### PR TITLE
fix(install): import the register on a FRESH install, not only on upgrade

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -135,6 +135,20 @@ Doe een [featureverzoek](https://github.com/OpenCatalogi/.github/issues/new/choo
 			-->
 			<step>OCA\OpenCatalogi\Repair\RenameDutchPublicationColumns</step>
 		</post-migration>
+		<!--
+			Nextcloud runs migrateSchemaOnly() on a FIRST install, so NEITHER
+			pre-migration NOR post-migration steps run then — <install> is the only
+			unconditional hook (see \OC\Installer::installAppLastSteps). Without this
+			block InitializeSettings never ran on a fresh instance, so the OpenCatalogi
+			register and schemas were never imported there.
+
+			Only baseline-CREATING steps belong here. RenameDutchPublicationColumns is
+			a one-way data migration: on a fresh install there is nothing to rename, so
+			it stays post-migration-only.
+		-->
+		<install>
+			<step>OCA\OpenCatalogi\Repair\InitializeSettings</step>
+		</install>
 	</repair-steps>
 
 	<!-- The app-menu navigation entry is registered in PHP (lib/AppInfo/Application.php::boot),


### PR DESCRIPTION
The register import has never run on a fresh instance.

`InitializeSettings` — which imports the OpenCatalogi register and schemas into OpenRegister — was declared only under `<post-migration>`.

## Why that never runs on install

`\OC\Installer::installAppLastSteps`:

```php
$previousVersion = $this->config->getAppValue($info["id"], "installed_version", "");
if ($previousVersion !== "") { executeRepairSteps(…, "pre-migration"); }
$ms->migrate("latest", $previousVersion === "");     // schema-only on first install
if ($previousVersion !== "") { executeRepairSteps(…, "post-migration"); }
…
executeRepairSteps($info["id"], $info["repair-steps"]["install"]);   // UNCONDITIONAL
```

On a first install `$previousVersion` is `""`, so **both** pre- and post-migration are skipped; `<install>` is the only unconditional hook. The upgrade path (`AppManager::upgradeApp`) runs pre/post-migration and *not* `install`. An app therefore needs **both** blocks carrying the same baseline steps, with those steps idempotent.

Effect: a fresh OpenCatalogi instance had no register at all until someone happened to upgrade the app.

## Scope

Only baseline-**creating** steps are added. `RenameDutchPublicationColumns` is a one-way data migration — on a fresh install there is nothing to rename — so it stays post-migration-only. Adding migrations to `<install>` would run them against an empty database, which is at best a no-op and at worst an install-breaking error.

`<install>` is placed after `</post-migration>` because the `info.xsd` sequence is `pre-migration, post-migration, live-migration, install, uninstall`. Verified against the schema, including a control confirming the schema rejects the block placed earlier.

Part of a sweep — six apps declare no `<install>` block at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)