### PR TITLE
fix(ci): point shared workflow calls at a ref that exists

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -15,7 +15,10 @@ permissions:
 
 jobs:
   triage:
-    uses: ConductionNL/.github/.github/workflows/issue-triage.yml@feature/openspec-project-sync
+    # @main, not @feature/openspec-project-sync — that branch no longer exists
+    # on ConductionNL/.github, so GitHub could not resolve the callee and the
+    # run failed before any job was created.
+    uses: ConductionNL/.github/.github/workflows/issue-triage.yml@main
     with:
       app-name: opencatalogi
       backlog-existing: ${{ github.event_name == 'workflow_dispatch' && inputs.backlog-existing || false }}

--- a/.github/workflows/openspec-sync.yml
+++ b/.github/workflows/openspec-sync.yml
@@ -11,7 +11,10 @@ permissions:
 
 jobs:
   sync:
-    uses: ConductionNL/.github/.github/workflows/openspec-sync.yml@feature/openspec-project-sync
+    # @main, not @feature/openspec-project-sync — that branch no longer exists
+    # on ConductionNL/.github, so GitHub could not resolve the callee and the
+    # run failed before any job was created.
+    uses: ConductionNL/.github/.github/workflows/openspec-sync.yml@main
     with:
       app-name: opencatalogi
     secrets:


### PR DESCRIPTION
## What

The `Issue Triage` (and, in opencatalogi, `OpenSpec Sync`) caller on **`main`** points at
`ConductionNL/.github@feature/openspec-project-sync`. **That branch does not exist** —
`GET /repos/ConductionNL/.github/git/ref/heads/feature/openspec-project-sync` returns `404`.

## Why this is on `main` and not `development`

`development` **already carries the correct `@main` ref** — it was fixed in the Aug 1–2 sweep.
`main` was not. This repo's **default branch is `main`**, and `issues`-triggered workflows always
run the copy on the **default branch**. So the broken copy is the only one that ever executes,
and the corrected copy on `development` never runs at all.

That is also why this stayed invisible: any status check scoped to `branch=development` reads the
good file and never sees the failing runs.

## Evidence

GitHub cannot resolve a callee at a missing ref, so it fails the run *before creating any job*:

- the run is named by its own file path (`.github/workflows/issue-triage.yml`) instead of by its `name:` (`Issue Triage`)
- `actions/runs/<id>/jobs` returns `total_count: 0`
- `actions/runs/<id>/logs` returns `404`
- `gh run rerun` refuses these runs; only `gh workflow run` re-dispatches them

**openregister has 745 failed `Issue Triage` runs; opencatalogi has 211.** Every one of them failed
this way, and every one of them is on the default branch.

A sweep of every workflow file across all 18 core apps found exactly **5** remaining occurrences of
the dead ref: 2 in nldesign (`development`, fixed in nldesign#278), 1 here in openregister (`main`),
2 in opencatalogi (`main`).

## What this does NOT do

**This will not turn the workflow green, and that is expected.** Once the callee resolves, the job
will run and then fail at the `PROJECT_TOKEN` preflight — the token is set on this repo but the API
rejects it (`HTTP 401`), which is a dead credential and a separate defect that only a rotation can
fix. It is failing the same way in 6 repos' `OpenSpec Sync` and 9 repos' `Issue Triage`.

The gain is `total_count: 0` → `total_count: 1`: a run that reports its real problem instead of
failing invisibly. **Please read the result by job count, not by colour.**

## Note on merging

Opened for review, deliberately **not merged** — this targets `main` and the agent that raised it is
not authorised to merge there.
