### PR TITLE
fix(ci): the shared workflow ref points at a branch that does not exist

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -15,7 +15,10 @@ permissions:
 
 jobs:
   triage:
-    uses: ConductionNL/.github/.github/workflows/issue-triage.yml@feature/openspec-project-sync
+    # @main, not @feature/openspec-project-sync — that branch no longer exists
+    # on ConductionNL/.github, so GitHub could not resolve the callee and the
+    # run failed before any job was created.
+    uses: ConductionNL/.github/.github/workflows/issue-triage.yml@main
     with:
       app-name: opencatalogi
       backlog-existing: ${{ github.event_name == 'workflow_dispatch' && inputs.backlog-existing || false }}

--- a/.github/workflows/openspec-sync.yml
+++ b/.github/workflows/openspec-sync.yml
@@ -11,7 +11,10 @@ permissions:
 
 jobs:
   sync:
-    uses: ConductionNL/.github/.github/workflows/openspec-sync.yml@feature/openspec-project-sync
+    # @main, not @feature/openspec-project-sync — that branch no longer exists
+    # on ConductionNL/.github, so GitHub could not resolve the callee and the
+    # run failed before any job was created.
+    uses: ConductionNL/.github/.github/workflows/openspec-sync.yml@main
     with:
       app-name: opencatalogi
     secrets:


### PR DESCRIPTION
Re-opened from a `hotfix/*` branch. The identical change on `fix/shared-workflow-dead-ref` failed `branch-protection / check-branch` — *"Pull requests to main must come from 'beta' or a 'hotfix/*' branch."* That check is correct and this is a hotfix, so it moved rather than being forced past.

## The defect

The workflows reference `ConductionNL/.github/.github/workflows/openspec-project-sync.yml@feature/openspec-project-sync`. **That branch does not exist — the ref 404s.** A sweep of every workflow file in all 18 repos found 189 refs at `@main` and exactly 5 dead, so this is the complete class.

## Why it survived a sweep that already fixed it

An Aug 1–2 sweep corrected these files on `development`. **This repository's default branch is `main`**, and `issues`-triggered workflows run on the default branch — so the corrected file never executes and the broken one always does.

Fleet-wide that accounts for **955 failed runs**.

## Verification note

The failing `Issue Triage` runs have two independent causes and this PR fixes only one. The other is a **rotated `PROJECT_TOKEN` (HTTP 401), fleet-wide, dead since on or about 2026-08-04** — that needs a credential rotation and cannot be fixed in a workflow file. Expect this workflow to resolve and then fail on the token until that happens; resolving is the observable change here.
