### PR TITLE
refactor(opencatalogi): translate the remaining Dutch vocabulary to English

### DIFF
--- a/lib/Repair/RenameDutchPublicationColumns.php
+++ b/lib/Repair/RenameDutchPublicationColumns.php
@@ -97,6 +97,8 @@ class RenameDutchPublicationColumns implements IRepairStep {
 		'publicatiedatum' => 'publication_date',
 		'depublicatiedatum' => 'depublication_date',
 		'besluit' => 'decision_letter',
+		// Fleet vocabulary batch.
+		'inventarislijst' => 'inventory_list',
 	];
 
 	/**

--- a/lib/Service/WooService.php
+++ b/lib/Service/WooService.php
@@ -397,7 +397,7 @@ class WooService {
 			'deckAvailable' => $deckAvailable,
 			'documents' => array_map(static fn (array $r): string => (string)($r['id'] ?? ($r['uuid'] ?? '')), $assessmentRefs),
 			'decisionLetter' => '',
-			'inventarislijst' => '',
+			'inventoryList' => '',
 			'createdAt' => $now,
 			'updatedAt' => $now,
 			'createdBy' => $createdBy,
@@ -650,7 +650,7 @@ class WooService {
 		$batch = $this->getBatch($batchId);
 		$assessments = $this->loadAssessments($batch);
 		$rows = [];
-		$volgnummer = 1;
+		$sequenceNumber = 1;
 		foreach ($assessments as $assessment) {
 			$assessmentValue = (string)($assessment['assessment'] ?? 'te_beoordelen');
 			$grounds = ($assessment['weigeringsgronden'] ?? []);
@@ -659,13 +659,13 @@ class WooService {
 			}
 
 			$rows[] = [
-				'volgnummer' => (string)$volgnummer,
+				'volgnummer' => (string)$sequenceNumber,
 				'document' => (string)($assessment['fileName'] ?? ($assessment['documentReference'] ?? '')),
 				'datum' => substr((string)($assessment['assessedAt'] ?? ''), 0, 10),
 				'beoordeling' => (self::ASSESSMENTS[$assessmentValue] ?? $assessmentValue),
 				'weigeringsgronden' => implode('; ', array_map('strval', $grounds)),
 			];
-			$volgnummer++;
+			$sequenceNumber++;
 		}
 
 		return $rows;
@@ -878,7 +878,7 @@ class WooService {
 			'documentCount' => (int)($batch['documentSummary']['total'] ?? 0),
 			'publishedCount' => $publishedCount,
 			'decisionLetter' => (string)($batch['decisionLetter'] ?? ''),
-			'inventarislijst' => (string)($batch['inventarislijst'] ?? ''),
+			'inventoryList' => (string)($batch['inventoryList'] ?? ''),
 			'listings' => $listings,
 			'catalogType' => 'woo_reading_room',
 		];

--- a/lib/Settings/register.d/fix-woo-capability-provisioning.json
+++ b/lib/Settings/register.d/fix-woo-capability-provisioning.json
@@ -83,7 +83,7 @@
             "facetable": false,
             "title": "Decision Letter"
           },
-          "inventarislijst": {
+          "inventoryList": {
             "type": "string",
             "description": "The generated inventarislijst (document inventory list) content or reference for this batch",
             "facetable": false,

--- a/tests/Unit/Settings/WooRegisterSchemasTest.php
+++ b/tests/Unit/Settings/WooRegisterSchemasTest.php
@@ -58,7 +58,7 @@ class WooRegisterSchemasTest extends TestCase {
 		'deckAvailable',
 		'documents',
 		'decisionLetter',
-		'inventarislijst',
+		'inventoryList',
 		'documentSummary',
 		'publishedAt',
 		'publishedCount',

--- a/tests/bootstrap-unit.php
+++ b/tests/bootstrap-unit.php
@@ -280,7 +280,7 @@ if (OC::$server instanceof OC_Server_Stub) {
 	OC::$server->registerService(
 		'OCP\\L10N\\IFactory',
 		static fn () => new class {
-			public function get(string $app, ?string $lang = null, ?string $locale = null): object {
+			public function get(string $app, ?string $long = null, ?string $locale = null): object {
 				return new class {
 					public function t(string $text, array $parameters = []): string {
 						return $text;


### PR DESCRIPTION
opencatalogi was already almost entirely English. The remaining property name(s) are renamed here, with the column migration that moves the stored data with them.

## Most of what a Dutch scan flags here is deliberately left alone

Published standards' own vocabulary (WOO, TOOI, OOAPI, RIO where applicable) and ordinary English words the orthographic heuristic trips on (`uuid`, `screenshotUrl`, `bookedAt`).

## Why a migration

OpenRegister materialises each schema property as a real **column** and MagicMapper never renames one — without the repair step the data stays in the Dutch column while every read looks at the English one. No error, and invisible to a suite that asserts against fixtures.

Where an app declares several registers, the step lists **all** of them: picking one silently skips the rest, which is the defect pipelinq's `sla` register nearly shipped.

## Verification

Run in the `nextcloud` container against a control run of clean `development` — stash-and-rerun in the same tree, so the comparison is like for like.