### PR TITLE
opencatalogi-delegate-broadcast-to-or-webhooks: built by hydra for #878

### DIFF
--- a/lib/Service/Broadcast/BroadcastResult.php
+++ b/lib/Service/Broadcast/BroadcastResult.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * Value object describing the outcome of a single broadcast target.
+ *
+ * @category Service
+ * @package  OCA\OpenCatalogi\Service\Broadcast
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2024 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://www.OpenCatalogi.nl
+ *
+ * @spec openspec/changes/opencatalogi-delegate-broadcast-to-or-webhooks/specs/federation/spec.md
+ */
+
+namespace OCA\OpenCatalogi\Service\Broadcast;
+
+/**
+ * BroadcastResult Class.
+ *
+ * Returned by {@see \OCA\OpenCatalogi\Service\BroadcastService::enqueueBroadcast()}
+ * for a single target URL. Introduced as the Phase 1 adapter shape described in
+ * `design.md` ("Decision 3 — Return-shape compatibility via BroadcastResult") for
+ * the opencatalogi-delegate-broadcast-to-or-webhooks change: today `$status` and
+ * `$delivered` describe the outcome of the still-synchronous legacy dispatch
+ * (`STATUS_DELIVERED` / `STATUS_FAILED`); once broadcast delivery is wired to
+ * OpenRegister's `WebhookService` the vocabulary grows to include `enqueued` /
+ * `dead-letter` per that same design.
+ */
+class BroadcastResult {
+
+	/**
+	 * Status value when the broadcast was sent and acknowledged successfully.
+	 *
+	 * @var string
+	 */
+	public const STATUS_DELIVERED = 'delivered';
+
+	/**
+	 * Status value when the broadcast could not be delivered.
+	 *
+	 * @var string
+	 */
+	public const STATUS_FAILED = 'failed';
+
+	/**
+	 * Constructor for BroadcastResult.
+	 *
+	 * @param string $url The target URL this result describes.
+	 * @param string $status One of the STATUS_* constants.
+	 * @param boolean $delivered Whether the target ultimately received the broadcast.
+	 */
+	public function __construct(
+		public readonly string $url,
+		public readonly string $status,
+		public readonly bool $delivered,
+	) {
+	}//end __construct()
+}//end class

--- a/lib/Service/BroadcastService.php
+++ b/lib/Service/BroadcastService.php
@@ -31,6 +31,7 @@ use GuzzleHttp\Client;
 use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\RequestOptions;
 use InvalidArgumentException;
+use OCA\OpenCatalogi\Service\Broadcast\BroadcastResult;
 use OCP\App\IAppManager;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Db\MultipleObjectsReturnedException;
@@ -389,6 +390,46 @@ class BroadcastService {
 	}//end sendBroadcastRequest()
 
 	/**
+	 * Enqueue a broadcast to a single target URL.
+	 *
+	 * Phase 1 adapter towards moving federation broadcast delivery onto
+	 * OpenRegister's `WebhookService` (see `design.md` "Implementation Sketch —
+	 * Phase 1" for opencatalogi-delegate-broadcast-to-or-webhooks). Callers get
+	 * the eventual OR-backed signature now so they do not change again once
+	 * delivery moves off this synchronous path; the body still dispatches via
+	 * {@see sendBroadcastRequest()} because OR's
+	 * `WebhookService::triggerWebhookForEvent()` surface is not present in this
+	 * app's OpenRegister integration surface yet — it is not referenced by
+	 * `tests/Stubs/OpenRegister` or the cross-app allowlist in `psalm.xml`, and
+	 * `design.md`'s "Open Items" flags the exact signature as unconfirmed
+	 * pending OR-API review. Wiring the real delegation is tracked as a
+	 * follow-up once that surface exists to build against.
+	 *
+	 * @param string $url The target URL to broadcast to.
+	 * @param string $directoryUrl The URL of this directory to include in the broadcast.
+	 *
+	 * @return BroadcastResult The outcome of this broadcast attempt.
+	 *
+	 * @throws InvalidArgumentException When the target URL fails the pre-flight SSRF guard.
+	 *
+	 * @spec openspec/changes/opencatalogi-delegate-broadcast-to-or-webhooks/specs/federation/spec.md
+	 */
+	public function enqueueBroadcast(string $url, string $directoryUrl): BroadcastResult {
+		// Pre-flight SSRF guard runs before any dispatch attempt, sync or
+		// OR-backed (design.md "Decision 2 — Pre-flight SSRF guard stays in OC").
+		$this->assertSafeOutboundUrl($url);
+
+		$delivered = $this->sendBroadcastRequest($url, $directoryUrl);
+
+		return new BroadcastResult(
+			url: $url,
+			status: $delivered ? BroadcastResult::STATUS_DELIVERED : BroadcastResult::STATUS_FAILED,
+			delivered: $delivered,
+		);
+
+	}//end enqueueBroadcast()
+
+	/**
 	 * Broadcast this OpenCatalogi directory to one or more instances.
 	 *
 	 * This method handles broadcasting the current directory information to external
@@ -441,18 +482,17 @@ class BroadcastService {
 				continue;
 			}
 
-			// Validate outbound URL before broadcasting — rejects private/internal addresses.
+			// Enqueue the broadcast; the pre-flight SSRF guard runs inside
+			// enqueueBroadcast() and rejects private/internal addresses.
 			try {
-				$this->assertSafeOutboundUrl($targetUrl);
+				$result = $this->enqueueBroadcast($targetUrl, $directoryUrl);
 			} catch (InvalidArgumentException $e) {
 				$this->logger->warning("Skipping unsafe broadcast target: {$targetUrl}");
 				$results[$targetUrl] = false;
 				continue;
 			}
 
-			// Attempt to send broadcast request.
-			$success = $this->sendBroadcastRequest($targetUrl, $directoryUrl);
-			$results[$targetUrl] = $success;
+			$results[$targetUrl] = $result->delivered;
 		}
 
 		// Log summary of broadcast operation.

--- a/tests/Unit/Service/BroadcastServiceTest.php
+++ b/tests/Unit/Service/BroadcastServiceTest.php
@@ -9,6 +9,7 @@ use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use InvalidArgumentException;
+use OCA\OpenCatalogi\Service\Broadcast\BroadcastResult;
 use OCA\OpenCatalogi\Service\BroadcastService;
 use OCP\App\IAppManager;
 use OCP\IAppConfig;
@@ -479,6 +480,75 @@ class BroadcastServiceTest extends \PHPUnit\Framework\TestCase {
 		$this->assertTrue($result);
 
 	}//end testSendBroadcastRequestSuccessOnRetry()
+
+	// ===== enqueueBroadcast tests =====
+
+	/**
+	 * Test enqueueBroadcast returns a delivered BroadcastResult when the
+	 * underlying (still synchronous, Phase 1) dispatch succeeds.
+	 */
+	/**
+	 * @group network
+	 */
+	public function testEnqueueBroadcastSuccess(): void {
+		$this->clientMock->method('post')
+			->willReturn(new Response(200));
+
+		$this->appManagerMock->method('getAppInfo')
+			->willReturn(['version' => '1.0.0']);
+
+		$result = $this->broadcastService->enqueueBroadcast(
+			'https://target.example.com/api/directory',
+			'https://self.example.com/api/directory'
+		);
+
+		$this->assertInstanceOf(BroadcastResult::class, $result);
+		$this->assertSame('https://target.example.com/api/directory', $result->url);
+		$this->assertSame(BroadcastResult::STATUS_DELIVERED, $result->status);
+		$this->assertTrue($result->delivered);
+
+	}//end testEnqueueBroadcastSuccess()
+
+	/**
+	 * Test enqueueBroadcast returns a failed BroadcastResult when the
+	 * underlying dispatch never succeeds.
+	 */
+	/**
+	 * @group network
+	 */
+	public function testEnqueueBroadcastFailure(): void {
+		$this->clientMock->method('post')
+			->willReturn(new Response(500));
+
+		$this->appManagerMock->method('getAppInfo')
+			->willReturn(['version' => '1.0.0']);
+
+		$result = $this->broadcastService->enqueueBroadcast(
+			'https://target.example.com/api/directory',
+			'https://self.example.com/api/directory'
+		);
+
+		$this->assertSame(BroadcastResult::STATUS_FAILED, $result->status);
+		$this->assertFalse($result->delivered);
+
+	}//end testEnqueueBroadcastFailure()
+
+	/**
+	 * Test enqueueBroadcast runs the pre-flight SSRF guard before any dispatch
+	 * attempt: an unsafe target throws and the HTTP client is never invoked.
+	 */
+	public function testEnqueueBroadcastRejectsUnsafeUrlBeforeDispatch(): void {
+		$this->clientMock->expects($this->never())
+			->method('post');
+
+		$this->expectException(InvalidArgumentException::class);
+
+		$this->broadcastService->enqueueBroadcast(
+			'http://169.254.169.254/latest/meta-data',
+			'https://self.example.com/api/directory'
+		);
+
+	}//end testEnqueueBroadcastRejectsUnsafeUrlBeforeDispatch()
 
 	// ===== broadcast tests =====
 


### PR DESCRIPTION
Closes #878.

Built by hydra from `openspec/changes/opencatalogi-delegate-broadcast-to-or-webhooks/`, by an agent running in a checkout of this repository — it read the spec and the surrounding code and edited the working tree. The commit was made by the pipeline, not by the agent: the agent never held a forge credential.

## The gates

`scripts/run-hydra-gates.sh --scope-to-diff --base origin/development` exited **0** — the exit code IS the failure count, and it is scoped to this branch's own diff rather than to the repository's backlog.

```
[hydra-gates] Delegating to conduction/hydra-gates at /usr/local/lib/hydra-gates/hydra-gates
[hydra-gates] findings logs: /tmp/hydra-gates.DHtjsLEn
[hydra-gates] gate package: UNKNOWN — this run cannot say which version of the gates produced its verdicts.
[hydra-gates] Comparing it against another run (e.g. a strict-subset baseline check) compares two possibly-different programs.
[hydra-gates] Set HYDRA_GATES_PKG_SHA to make the comparison sound.
[hydra-gates] App dir: /tmp/hydra-stage-4M8i4G/repo (absolute)
[hydra-gates] SCOPE-MODE: diff
[hydra-gates] File scope: the diff only (--scope-to-diff / HYDRA_GATE_SCOPE=diff). Inherited debt in untouched files is NOT judged.
[hydra-gates] SCOPE-FILE-COUNT: 3
[hydra-gates] Scope: diff vs origin/development — 3 changed file(s)
[gate-1] spdx-headers: PASS
[gate-2] forbidden-patterns: PASS
[gate-3] stub-scan: PASS
[gate-4] composer-audit: NOT APPLICABLE — neither composer.json nor composer.lock is in this diff — under ADR-020 diff scoping the dependency tree is unchanged from the base branch, so this PR introduces no dependency change to audit.
[hydra-gates] gate-5 route-auth: 6 routed entr(ies) NOT JUDGED (controller class unresolvable here) — see /tmp/hydra-gates.DHtjsLEn/hydra-gate-route-auth-unresolved.log. This is not a pass for them; reachability is gate-14's.
[gate-5] route-auth: NOT APPLICABLE — 0 routed method(s) were judged — appinfo/routes.php is not in this diff and no controller serving a route is either, so under ADR-020 no endpoint's auth posture changed in this PR. 6 entr(ies) were additionally unresolvable here.
[gate-6] orphan-auth: PASS
[gate-7] no-admin-idor: NOT APPLICABLE — scope was empty — 0 lib/Controller PHP file(s) in this diff, so NOTHING was inspected; unguarded #[NoAdminRequired] endpoints (IDOR, OWASP A01:2021) are UNVERIFIED by this run.
[gate-8] unsafe-auth-resolver: PASS
[gate-9] semantic-auth: NOT APPLICABLE — scope was empty — 0 lib/Controller PHP file(s) in this diff, so NOTHING was inspected; auth-attribute-vs-body semantic mismatches are UNVERIFIED by this run.
[gate-10] initial-state: NOT APPLICABLE — 0 tracked, non-minified .vue/.js/.ts file(s) under src/ or js/ in this diff — nothing was inspected, so DOM reads of server-injected data are UNVERIFIED by this run.
[gate-11] admin-router: NOT APPLICABLE — this app's router(s) — src/main.js — are not in this diff, so under ADR-020 the routing table is unchanged from the base branch.
[gate-12] nc-input-labels: NOT APPLICABLE — 93 .vue component(s) exist here and the diff against 'origin/development' touched none of them, so no <NcSelect> was inspected. Diff-scoped out under ADR-020 — not a gap, and not a pass.
[gate-13] modal-isolation: NOT APPLICABLE — 47 .vue component(s) exist here and the diff against 'origin/development' touched none of them, so no component was inspected. Diff-scoped out under ADR-020 — not a gap, and not a pass.
[gate-14] route-reachability: NOT APPLICABLE — no routed controller method (an entry in appinfo/routes.php whose target class is in scope) is in scope for this run: the run was NARROWED with --scope-to-diff and the diff against 'origin/development' touches none (the ADR-020 rule, now opt-in — see hydra-gates/ADR-020-SUPERSEDED.md). NOTHING was inspected and nothing could be, so this is NOT a pass. Re-run at the default full scope to judge the whole tree.
[gate-15] dashboard-antipattern: PASS
[gate-16] spec-coverage: PASS
[gate-17] redundant-controller: PASS
[gate-18] notification-dialect: NOT APPLICABLE — no register JSON under lib/Settings (*register*.json or register.d/*.json) is in scope for this run: the run was NARROWED with --scope-to-diff and the diff against 'origin/development' touches none (the ADR-020 rule, now opt-in — see hydra-gates/ADR-020-SUPERSEDED.md). NOTHING was inspected and nothing could be, so this is NOT a pass. Re-run at the default full scope to judge the whole tree.
[gate-19] e2e-coverage: NOT APPLICABLE — the diff against 'origin/development' touched NO spec file, so no scenario was inspected. Diff-scoped out under ADR-020, exactly as gates 4/6/7 are for the same diff — not a gap: the specs in this repo are unchanged from the base branch, so this PR introduces no scenario whose @e2e traceability could be missing. This gate runs on the next PR that touches a spec. See /tmp/hydra-gates.DHtjsLEn/hydra-gate-e2e-coverage.log.
[gate-20] or-objectservice-api: PASS
[gate-21] conflict-markers: PASS
[gate-22] manifest-validation: NOT APPLICABLE — no src/manifest.json is in scope for this run: the run was NARROWED with --scope-to-diff and the diff against 'origin/development' touches none (the ADR-020 rule, now opt-in — see hydra-gates/ADR-020-SUPERSEDED.md). NOTHING was inspected and nothing could be, so this is NOT a pass. Re-run at the default full scope to judge the whole tree.
[hydra-gates] gate-23 or-abstraction-anti-patterns: 0 rule(s) matched (see /tmp/hydra-gates.DHtjsLEn/hydra-gate-or-abstraction-anti-patterns.log); WARN mode.
[gate-23] or-abstraction-anti-patterns: PASS
[gate-24] integration-parity: NOT APPLICABLE — no scripts/check-integration-parity.sh, and this repo registers no integration leaves at all — no `new LeafDescriptor(` in lib/ and neither `registerIntegration(` nor `integrations.register(` in src/. There is no server↔JS pair for parity to correlate.
[gate-25] contract-coverage: NOT APPLICABLE — the diff against 'origin/development' touched NO lib/Controller file, so no endpoint was inspected. Diff-scoped out under ADR-020, exactly as gates 6/7 are for the same diff — not a gap: this PR exposes no new endpoint whose wire contract could be untested. This gate runs on the next PR that touches a controller. See /tmp/hydra-gates.DHtjsLEn/hydra-gate-contract-coverage.log.
[gate-26] visual-coverage: NOT APPLICABLE — the diff against 'origin/development' ADDED no page component (nothing under src/views|src/pages, no new manifest page component), so no screen was inspected. Diff-scoped out under ADR-020 — not a gap: this PR adds no screen whose appearance could be unbaselined. See /tmp/hydra-gates.DHtjsLEn/hydra-gate-visual-coverage.log.
[gate-27] no-phantom-cross-app-rpc: PASS
[gate-28] license-triangle: PASS
[gate-29] gitignore-then-commit: NOT APPLICABLE — the diff against 'origin/development' adds no non-comment line to .gitignore, so there is no new ignore rule whose path could already be tracked. Diff-scoped out under ADR-020.
[gate-30] public-monitoring: NOT APPLICABLE — 3 monitoring endpoint(s) found; none of their controllers is touched by this diff (ADR-020) — see /tmp/hydra-gates.DHtjsLEn/hydra-gate-public-monitoring-notes.log.
[gate-31] img-alt: NOT APPLICABLE — no markup file (src|templates|appinfo/templates **/*.vue|php|html) is in scope for this run — the repository has none, or the diff touches none under ADR-020. No <img> was inspected and none could be.
[gate-32] semantic-controls: NOT APPLICABLE — no markup file (src|templates|appinfo/templates **/*.vue|php|html) is in scope for this run — the repository has none, or the diff touches none under ADR-020. No click target was inspected and none could be.
[gate-33] axe-core: NOT APPLICABLE — no tests/axe/report.json, and the caller did not set enable-axe — this repo has not opted into runtime accessibility enforcement. Runtime a11y (contrast / landmark / ARIA-validity / live-region) is therefore NOT enforced here, by a choice recorded in the caller's workflow rather than in this run. To enforce it, set `enable-axe: true` on ConductionNL/.github's quality.yml; this gate then becomes blocking and its absence becomes a failure.
[gate-34] window-confirm: NOT APPLICABLE — no frontend source file (src|templates|appinfo/templates **/*.vue|js|ts|php|html) is in scope for this run: the run was NARROWED with --scope-to-diff and the diff against 'origin/development' touches none (the ADR-020 rule, now opt-in — see hydra-gates/ADR-020-SUPERSEDED.md). NOTHING was inspected and nothing could be, so this is NOT a pass. Re-run at the default full scope to judge the whole tree.
[gate-35] img-alt-empty-only: NOT APPLICABLE — no markup file (src|templates|appinfo/templates **/*.vue|php|html) is in scope for this run: the run was NARROWED with --scope-to-diff and the diff against 'origin/development' touches none (the ADR-020 rule, now opt-in — see hydra-gates/ADR-020-SUPERSEDED.md). NOTHING was inspected and nothing could be, so this is NOT a pass. Re-run at the default full scope to judge the whole tree.
[gate-36] tabindex-positive: NOT APPLICABLE — no frontend source file (src|templates|appinfo/templates **/*.vue|js|ts|php|html) is in scope for this run: the run was NARROWED with --scope-to-diff and the diff against 'origin/development' touches none (the ADR-020 rule, now opt-in — see hydra-gates/ADR-020-SUPERSEDED.md). NOTHING was inspected and nothing could be, so this is NOT a pass. Re-run at the default full scope to judge the whole tree.
[gate-37] aria-hidden-focusable: NOT APPLICABLE — no markup file (src|templates|appinfo/templates **/*.vue|php|html) is in scope for this run: the run was NARROWED with --scope-to-diff and the diff against 'origin/development' touches none (the ADR-020 rule, now opt-in — see hydra-gates/ADR-020-SUPERSEDED.md). NOTHING was inspected and nothing could be, so this is NOT a pass. Re-run at the default full scope to judge the whole tree.
[gate-38] skip-link: NOT APPLICABLE — no app page root (src/App.vue, src/**/*Root.vue) or document-owning PHP template (templates|appinfo/templates **/*.php) is in scope for this run: the run was NARROWED with --scope-to-diff and the diff against 'origin/development' touches none (the ADR-020 rule, now opt-in — see hydra-gates/ADR-020-SUPERSEDED.md). NOTHING was inspected and nothing could be, so this is NOT a pass. Re-run at the default full scope to judge the whole tree.
[gate-39] button-name: NOT APPLICABLE — no markup file (src|templates|appinfo/templates **/*.vue|php|html) is in scope for this run: the run was NARROWED with --scope-to-diff and the diff against 'origin/development' touches none (the ADR-020 rule, now opt-in — see hydra-gates/ADR-020-SUPERSEDED.md). NOTHING was inspected and nothing could be, so this is NOT a pass. Re-run at the default full scope to judge the whole tree.
[gate-40] form-label-association: NOT APPLICABLE — no markup file (src|templates|appinfo/templates **/*.vue|php|html) is in scope for this run: the run was NARROWED with --scope-to-diff and the diff against 'origin/development' touches none (the ADR-020 rule, now opt-in — see hydra-gates/ADR-020-SUPERSEDED.md). NOTHING was inspected and nothing could be, so this is NOT a pass. Re-run at the default full scope to judge the whole tree.
[gate-41] html-lang: NOT APPLICABLE — no PHP template (templates|appinfo/templates **/*.php) is in scope for this run: the run was NARROWED with --scope-to-diff and the diff against 'origin/development' touches none (the ADR-020 rule, now opt-in — see hydra-gates/ADR-020-SUPERSEDED.md). NOTHING was inspected and nothing could be, so this is NOT a pass. Re-run at the default full scope to judge the whole tree.
[gate-42] link-text-quality: NOT APPLICABLE — no markup file (src|templates|appinfo/templates **/*.vue|php|html) is in scope for this run: the run was NARROWED with --scope-to-diff and the diff against 'origin/development' touches none (the ADR-020 rule, now opt-in — see hydra-gates/ADR-020-SUPERSEDED.md). NOTHING was inspected and nothing could be, so this is NOT a pass. Re-run at the default full scope to judge the whole tree.
[gate-43] table-headers: NOT APPLICABLE — no markup file (src|templates|appinfo/templates **/*.vue|php|html) is in scope for this run: the run was NARROWED with --scope-to-diff and the diff against 'origin/development' touches none (the ADR-020 rule, now opt-in — see hydra-gates/ADR-020-SUPERSEDED.md). NOTHING was inspected and nothing could be, so this is NOT a pass. Re-run at the default full scope to judge the whole tree.
[gate-44] autocomplete-attr: NOT APPLICABLE — no markup file (src|templates|appinfo/templates **/*.vue|php|html) is in scope for this run: the run was NARROWED with --scope-to-diff and the diff against 'origin/development' touches none (the ADR-020 rule, now opt-in — see hydra-gates/ADR-020-SUPERSEDED.md). NOTHING was inspected and nothing could be, so this is NOT a pass. Re-run at the default full scope to judge the whole tree.
[gate-45] prefers-reduced-motion: NOT APPLICABLE — scope was empty — 0 markup or stylesheet file(s) (css/, src/, templates/, appinfo/templates/) in this diff, so NO <style> block and NO stylesheet was inspected; motion without a prefers-reduced-motion fallback is UNVERIFIED by this run.
[gate-46] spec-anchor-existence: PASS
[gate-47] security-change-has-tests: PASS
[gate-48] csrf-cochange: NOT APPLICABLE — the diff against 'origin/development' touches NO lib/Controller/*.php, so there was no controller for a #[NoCSRFRequired] to be dropped FROM — NOT ONE controller line was read by this run. A removal is a property of a change set, and this change set contains no candidate for one. This is NOT a clean bill of health for the app's CSRF posture; it runs on the next change that touches a controller.
[gate-49] controller-exception-translation: NOT APPLICABLE — scope was empty — 0 lib/Controller PHP file(s) in this repo or this diff, so NO controller method was inspected; untranslated service exceptions (HTTP 500 on a defended path) are UNVERIFIED by this run.
[gate-50] security-config-fail-mode: PASS
[gate-51] schema-property-titles: NOT APPLICABLE — scope was empty — 0 lib/Settings/*register*.json (or register.d/*.json) file(s) in this repo or this diff, so NO schema property was inspected; missing human-friendly titles are UNVERIFIED by this run.
[hydra-gates] gate-52 custom-widget-ratchet: the RATCHET half was NOT computed — the helper printed no base/head/delta counts, which it does only when it has a base ref to compare against. The JUSTIFICATION half (every custom kind:"widget" entry needs a `_note`) did run over 187 file(s). A PASS below covers that half only.
[gate-52] custom-widget-ratchet: NOT APPLICABLE — no src/**/*.{js,ts,vue} file (a component registry declaring kind:"widget" entries) is in scope for this run: the run was NARROWED with --scope-to-diff and the diff against 'origin/development' touches none (the ADR-020 rule, now opt-in — see hydra-gates/ADR-020-SUPERSEDED.md). NOTHING was inspected and nothing could be, so this is NOT a pass. Re-run at the default full scope to judge the whole tree.
[gate-53] effective-manifest-crossref: NOT APPLICABLE — the diff against 'origin/development' touched no manifest input (src/manifest.json, src/manifest.d/**, src/menu-layout.json, lib/Settings/*register*.json), so NO effective manifest was assembled or cross-referenced. Diff-scoped out under ADR-020 — not a gap: the manifests in this repo are unchanged from the base branch. This gate runs on the next PR that touches a manifest input.
[gate-54] relation-dialect: NOT APPLICABLE — scope was empty — 0 lib/Settings/*register*.json (or register.d/*.json) file(s) in this repo or this diff, so NO relation property was inspected; non-canonical relation dialects (ADR-062 rules 6/7/10) are UNVERIFIED by this run.
[gate-55] detail-page-discipline: NOT APPLICABLE — scope was empty — 0 src/manifest.json or src/manifest.d/*.json file(s) in this repo or this diff, so NO type:"detail" page was inspected; ADR-062 grid discipline (render-path shadowing, widgets↔layout integrity, widget icons, row/viewAll routes) is UNVERIFIED by this run.
[gate-56] register-handler-resolution: NOT APPLICABLE — 4 register JSON(s) exist here and the diff against 'origin/development' touched none of them, so NONE were inspected. Diff-scoped out under ADR-020 — this gate runs on the next PR that touches a register.
[gate-57] orphaned-write-capability: PASS
[gate-58] e2e-networkidle: NOT APPLICABLE — 29 tests/e2e file(s) exist here and the diff against 'origin/development' touched none of them, so NONE were inspected. Diff-scoped out under ADR-020 (the fleet carries a 278-site legacy backlog this gate deliberately does not block on) — it runs on the next PR that touches an e2e file.
[gate-59] unclosable-gate: PASS
[gate-60] icon-vocabulary: NOT APPLICABLE — src/manifest.json exists here and the diff against 'origin/development' touched no manifest, so NO icon was inspected. Diff-scoped out under ADR-020 — this gate runs on the next PR that touches a manifest.
[gate-61] listener-work-placement: NOT APPLICABLE — the diff against 'origin/development' put every post-event registration out of scope, so NONE were inspected. This gate is deliberately delta-scoped even at full file scope — the fleet's registration backlog is a work-list, not a reason to block an unrelated change. It runs on the next change that touches a listener registration. ADVISORY, and it decides nothing here: a whole-tree sweep of this same tree reaches 5 registration(s) carrying 0 finding(s), NONE of which this run judged — see /tmp/hydra-gates.DHtjsLEn/hydra-gate-listener-work-placement.advisory.log. See /tmp/hydra-gates.DHtjsLEn/hydra-gate-listener-work-placement.log.
[gate-62] store-plane: NOT APPLICABLE — the diff against 'origin/development' touched no manifest and no menu-layout, so NO manifest was inspected. Diff-scoped out under ADR-020 — not a gap: the manifests in this repo are unchanged from the base branch, so this PR introduces no store-plane naming or discovery decision (ADR-080) to judge. This gate runs on the next PR that touches a manifest. See /tmp/hydra-gates.DHtjsLEn/hydra-gate-store-plane.log.
[gate-63] settings-surface: NOT APPLICABLE — the diff against 'origin/development' touched no manifest and no menu-layout, so NO manifest was inspected. Diff-scoped out under ADR-020 — not a gap. This gate adjudicates ADR-079 placement as declared in src/manifest.json, src/manifest.d/ and src/menu-layout.json, and nothing else. The manifests in this repo are unchanged from the base branch, so this PR introduces no manifest placement decision to judge. It runs on the next PR that touches one of those. See /tmp/hydra-gates.DHtjsLEn/hydra-gate-settings-surface.log.
[gate-64] apphost-autoload-prelude: PASS
[gate-65] coding-standard-adoption: PASS

[hydra-gates] COVERAGE: 20 of 65 declared gates reported a result (45 not applicable to this repo/diff; 20 of 20 applicable gates ran).
[hydra-gates] NOT APPLICABLE — subject matter absent from this repo or this diff.
[hydra-gates] These do NOT count against coverage. Each stated its own reason above:
[hydra-gates]   gate-4 composer-audit
[hydra-gates]   gate-5 route-auth
[hydra-gates]   gate-7 no-admin-idor
[hydra-gates]   gate-9 semantic-auth
[hydra-gates]   gate-10 initial-state
[hydra-gates]   gate-11 admin-router
[hydra-gates]   gate-12 nc-input-labels
[hydra-gates]   gate-13 modal-isolation
[hydra-gates]   gate-14 route-reachability
[hydra-gates]   gate-18 notification-dialect
[hydra-gates]   gate-19 e2e-coverage
[hydra-gates]   gate-22 manifest-validation
[hydra-gates]   gate-24 integration-parity
[hydra-gates]   gate-25 contract-coverage
[hydra-gates]   gate-26 visual-coverage
[hydra-gates]   gate-29 gitignore-then-commit
[hydra-gates]   gate-30 public-monitoring
[hydra-gates]   gate-31 img-alt
[hydra-gates]   gate-32 semantic-controls
[hydra-gates]   gate-33 axe-core
[hydra-gates]   gate-34 window-confirm
[hydra-gates]   gate-35 img-alt-empty-only
[hydra-gates]   gate-36 tabindex-positive
[hydra-gates]   gate-37 aria-hidden-focusable
[hydra-gates]   gate-38 skip-link
[hydra-gates]   gate-39 button-name
[hydra-gates]   gate-40 form-label-association
[hydra-gates]   gate-41 html-lang
[hydra-gates]   gate-42 link-text-quality
[hydra-gates]   gate-43 table-headers
[hydra-gates]   gate-44 autocomplete-attr
[hydra-gates]   gate-45 prefers-reduced-motion
[hydra-gates]   gate-48 csrf-cochange
[hydra-gates]   gate-49 controller-exception-translation
[hydra-gates]   gate-51 schema-property-titles
[hydra-gates]   gate-52 custom-widget-ratchet
[hydra-gates]   gate-53 effective-manifest-crossref
[hydra-gates]   gate-54 relation-dialect
[hydra-gates]   gate-55 detail-page-discipline
[hydra-gates]   gate-56 register-handler-resolution
[hydra-gates]   gate-58 e2e-networkidle
[hydra-gates]   gate-60 icon-vocabulary
[hydra-gates]   gate-61 listener-work-placement
[hydra-gates]   gate-62 store-plane
[hydra-gates]   gate-63 settings-surface
[hydra-gates] ALL 20 APPLICABLE GATES GREEN — and all 20 of them ran.
[hydra-gates] The other 45 are not applicable to this repo/diff and are named above.
[hydra-gates] This is NOT 'all 65 gates green' — it is 'nothing applicable was left unchecked'.

```

---

⚠️ **Read the diff, not the label.** A non-zero gate count is information about this change, not a verdict on whether it should be merged, and a zero one is not a review. Nothing here has been read by a person yet.