### PR TITLE
fix(security): give every public endpoint a volume ceiling (ADR-082)

### DIFF
--- a/lib/Controller/ApiDocumentationController.php
+++ b/lib/Controller/ApiDocumentationController.php
@@ -30,6 +30,7 @@ namespace OCA\OpenCatalogi\Controller;
 use OCP\App\IAppManager;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\AnonRateLimit;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IAppConfig;
 use OCP\IL10N;
@@ -134,6 +135,7 @@ class ApiDocumentationController extends Controller {
 	 *
 	 * @spec openspec/changes/public-api-openapi-document/specs/api-documentation/spec.md#requirement-the-document-is-served-publicly-with-cors-api-doc-003
 	 */
+	#[AnonRateLimit(limit: 120, period: 60)]
 	public function index(): JSONResponse {
 		try {
 			$raw = file_get_contents(__DIR__ . '/../../openapi.json');

--- a/lib/Controller/CatalogiController.php
+++ b/lib/Controller/CatalogiController.php
@@ -28,6 +28,7 @@ namespace OCA\OpenCatalogi\Controller;
 use OCA\OpenCatalogi\Service\CatalogiService;
 use OCP\App\IAppManager;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\Attribute\AnonRateLimit;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\Http\Response;
 use OCP\IAppConfig;
@@ -174,6 +175,11 @@ class CatalogiController extends Controller {
 	 *
 	 * @spec openspec/specs/cross-origin-api-access/spec.md#requirement-answer-cors-preflight-requests-on-public-api-controllers-cor-001
 	 */
+	// Generous, as for every preflightedCors() in this app: the browser sends
+	// this OPTIONS request BEFORE each cross-origin call it makes. A ceiling
+	// tight enough to bite here would break ordinary cross-origin use rather
+	// than an attack.
+	#[AnonRateLimit(limit: 240, period: 60)]
 	public function preflightedCors(): Response {
 		$response = new Response();
 		$response->addHeader('Access-Control-Allow-Origin', $this->resolveAllowedOrigin());
@@ -197,6 +203,7 @@ class CatalogiController extends Controller {
 	 *
 	 * @spec openspec/specs/catalogs/spec.md
 	 */
+	#[AnonRateLimit(limit: 120, period: 60)]
 	public function index(): JSONResponse {
 		// Get catalog configuration from settings (resolved via OpenRegister; 503 if unconfigured).
 		try {
@@ -259,6 +266,7 @@ class CatalogiController extends Controller {
 	 *
 	 * @spec openspec/specs/catalogs/spec.md
 	 */
+	#[AnonRateLimit(limit: 120, period: 60)]
 	public function show(string|int $id): JSONResponse {
 		// Get all objects using the catalog's registers and schemas as filters.
 		$response = $this->catalogiService->index($id);

--- a/lib/Controller/DcatController.php
+++ b/lib/Controller/DcatController.php
@@ -31,6 +31,7 @@ use OCA\OpenCatalogi\Service\DcatSerializer;
 use OCA\OpenCatalogi\Service\DcatService;
 use OCA\OpenCatalogi\Settings\OpenCatalogiAdmin;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\Attribute\AnonRateLimit;
 use OCP\AppFramework\Http\Attribute\AuthorizedAdminSetting;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\Http\Response;
@@ -136,6 +137,7 @@ class DcatController extends Controller {
 	 *
 	 * @spec openspec/specs/dcat-ap-harvest/spec.md#requirement-per-catalog-dcat-ap-nl-document-endpoint-dcat-001
 	 */
+	#[AnonRateLimit(limit: 240, period: 60)]
 	public function preflightedCors(): Response {
 		$response = new Response();
 		foreach ($this->corsHeaders() as $name => $value) {
@@ -157,6 +159,7 @@ class DcatController extends Controller {
 	 *
 	 * @spec openspec/specs/dcat-ap-harvest/spec.md#requirement-instance-level-dcat-catalog-document-dcat-002
 	 */
+	#[AnonRateLimit(limit: 120, period: 60)]
 	public function instance(): Response {
 		try {
 			$format = $this->serializer->negotiate(
@@ -195,6 +198,7 @@ class DcatController extends Controller {
 	 * @spec openspec/specs/dcat-ap-harvest/spec.md#requirement-content-negotiation-across-rdf-serializations-dcat-007
 	 * @spec openspec/specs/dcat-ap-harvest/spec.md#requirement-harvester-grade-pagination-and-caching-dcat-008
 	 */
+	#[AnonRateLimit(limit: 120, period: 60)]
 	public function catalog(string $catalogSlug): Response {
 		try {
 			$format = $this->serializer->negotiate(

--- a/lib/Controller/DirectoryController.php
+++ b/lib/Controller/DirectoryController.php
@@ -30,6 +30,7 @@ use OCA\OpenCatalogi\Service\DirectoryService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Db\MultipleObjectsReturnedException;
+use OCP\AppFramework\Http\Attribute\AnonRateLimit;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\Http\Response;
 use OCP\IAppConfig;
@@ -145,6 +146,7 @@ class DirectoryController extends Controller {
 	 *
 	 * @spec openspec/specs/cross-origin-api-access/spec.md#requirement-answer-cors-preflight-requests-on-public-api-controllers-cor-001
 	 */
+	#[AnonRateLimit(limit: 240, period: 60)]
 	public function preflightedCors(): Response {
 		$response = new Response();
 		$response->addHeader('Access-Control-Allow-Origin', $this->resolveAllowedOrigin());
@@ -168,6 +170,7 @@ class DirectoryController extends Controller {
 	 *
 	 * @spec openspec/specs/dashboard/spec.md
 	 */
+	#[AnonRateLimit(limit: 120, period: 60)]
 	public function index(): JSONResponse {
 		try {
 			// Retrieve all request parameters.
@@ -225,6 +228,7 @@ class DirectoryController extends Controller {
 	 *
 	 * @spec openspec/specs/dashboard/spec.md
 	 */
+	#[AnonRateLimit(limit: 30, period: 60)]
 	public function update(): JSONResponse {
 		// Get the directory URL from the request parameters.
 		$directoryUrl = $this->request->getParam('directory');

--- a/lib/Controller/FederationController.php
+++ b/lib/Controller/FederationController.php
@@ -32,6 +32,7 @@ namespace OCA\OpenCatalogi\Controller;
 
 use OCA\OpenCatalogi\Service\PublicationService;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\Attribute\AnonRateLimit;
 use OCP\AppFramework\Http\DataDownloadResponse;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IL10N;
@@ -76,6 +77,7 @@ class FederationController extends Controller {
 	 *
 	 * @spec openspec/specs/federation/spec.md
 	 */
+	#[AnonRateLimit(limit: 120, period: 60)]
 	public function publications(): JSONResponse {
 		// Get all current query parameters.
 		$queryParams = $this->request->getParams();
@@ -129,6 +131,7 @@ class FederationController extends Controller {
 	 *
 	 * @spec openspec/specs/federation/spec.md
 	 */
+	#[AnonRateLimit(limit: 120, period: 60)]
 	public function publication(string $id): JSONResponse {
 		try {
 			// Use the service method to get the publication with federation support.
@@ -169,6 +172,7 @@ class FederationController extends Controller {
 	 *
 	 * @spec openspec/specs/federation/spec.md
 	 */
+	#[AnonRateLimit(limit: 120, period: 60)]
 	public function publicationUses(string $id): JSONResponse {
 		try {
 			// Use the service method to get the publication uses with federation support.
@@ -209,6 +213,7 @@ class FederationController extends Controller {
 	 *
 	 * @spec openspec/specs/federation/spec.md
 	 */
+	#[AnonRateLimit(limit: 120, period: 60)]
 	public function publicationUsed(string $id): JSONResponse {
 		try {
 			// Use the service method to get the publication used with federation support.
@@ -246,6 +251,7 @@ class FederationController extends Controller {
 	 *
 	 * @spec openspec/specs/federation/spec.md
 	 */
+	#[AnonRateLimit(limit: 120, period: 60)]
 	public function publicationAttachments(string $id): JSONResponse {
 		return $this->publicationService->attachments(id: $id);
 	}//end publicationAttachments()
@@ -264,6 +270,9 @@ class FederationController extends Controller {
 	 *
 	 * @spec openspec/specs/federation/spec.md
 	 */
+	// Lower than the sibling reads: a download moves file bytes, so the cost of
+	// one call is materially higher than a metadata lookup.
+	#[AnonRateLimit(limit: 60, period: 60)]
 	public function publicationDownload(string $id): DataDownloadResponse|JSONResponse {
 		return $this->publicationService->download(id: $id);
 	}//end publicationDownload()

--- a/lib/Controller/GlossaryController.php
+++ b/lib/Controller/GlossaryController.php
@@ -27,6 +27,7 @@ namespace OCA\OpenCatalogi\Controller;
 
 use OCP\App\IAppManager;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\Attribute\AnonRateLimit;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\Http\Response;
 use OCP\IAppConfig;
@@ -180,6 +181,7 @@ class GlossaryController extends Controller {
 	 *
 	 * @spec openspec/specs/cross-origin-api-access/spec.md#requirement-answer-cors-preflight-requests-on-public-api-controllers-cor-001
 	 */
+	#[AnonRateLimit(limit: 240, period: 60)]
 	public function preflightedCors(): Response {
 		// Create and configure the response.
 		$response = new Response();
@@ -206,6 +208,7 @@ class GlossaryController extends Controller {
 	 *
 	 * @spec openspec/specs/content-management/spec.md
 	 */
+	#[AnonRateLimit(limit: 120, period: 60)]
 	public function index(): JSONResponse {
 		// Get glossary configuration from settings (resolved via OpenRegister; 503 if unconfigured).
 		try {
@@ -295,6 +298,7 @@ class GlossaryController extends Controller {
 	 *
 	 * @spec openspec/specs/content-management/spec.md
 	 */
+	#[AnonRateLimit(limit: 120, period: 60)]
 	public function show(string|int $id): JSONResponse {
 		// Use searchObjectsPaginated to find single glossary term.
 		$searchQuery = [

--- a/lib/Controller/ListingsController.php
+++ b/lib/Controller/ListingsController.php
@@ -38,6 +38,7 @@ use OCP\AppFramework\Controller;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Db\MultipleObjectsReturnedException;
 use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\AnonRateLimit;
 use OCP\AppFramework\Http\Attribute\AuthorizedAdminSetting;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\Http\Response;
@@ -163,6 +164,7 @@ class ListingsController extends Controller {
 	 *
 	 * @spec openspec/specs/cross-origin-api-access/spec.md
 	 */
+	#[AnonRateLimit(limit: 240, period: 60)]
 	public function preflightedCors(): Response {
 		$response = new Response();
 		$response->addHeader('Access-Control-Allow-Origin', $this->resolveAllowedOrigin());
@@ -281,6 +283,7 @@ class ListingsController extends Controller {
 	 *
 	 * @spec openspec/specs/dashboard/spec.md
 	 */
+	#[AnonRateLimit(limit: 120, period: 60)]
 	public function show(string|int $id): JSONResponse {
 		// Get listing register/schema from configuration; 503 if unconfigured.
 		// An `''` here would reach OR's setRegister('') and surface as an uncaught

--- a/lib/Controller/MenusController.php
+++ b/lib/Controller/MenusController.php
@@ -27,6 +27,7 @@ namespace OCA\OpenCatalogi\Controller;
 
 use OCP\App\IAppManager;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\Attribute\AnonRateLimit;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\Http\Response;
 use OCP\IAppConfig;
@@ -172,6 +173,7 @@ class MenusController extends Controller {
 	 *
 	 * @spec openspec/specs/cross-origin-api-access/spec.md#requirement-answer-cors-preflight-requests-on-public-api-controllers-cor-001
 	 */
+	#[AnonRateLimit(limit: 240, period: 60)]
 	public function preflightedCors(): Response {
 		// Create and configure the response.
 		$response = new Response();
@@ -196,6 +198,7 @@ class MenusController extends Controller {
 	 *
 	 * @spec openspec/specs/content-management/spec.md
 	 */
+	#[AnonRateLimit(limit: 120, period: 60)]
 	public function index(): JSONResponse {
 		// Get menu configuration from settings (resolved via OpenRegister; 503 if unconfigured).
 		try {
@@ -258,6 +261,7 @@ class MenusController extends Controller {
 	 *
 	 * @spec openspec/specs/content-management/spec.md
 	 */
+	#[AnonRateLimit(limit: 120, period: 60)]
 	public function show(string|int $id): JSONResponse {
 		// Use searchObjectsPaginated to find single menu.
 		$searchQuery = [

--- a/lib/Controller/OoapiController.php
+++ b/lib/Controller/OoapiController.php
@@ -38,6 +38,7 @@ use OCA\OpenCatalogi\Service\OoapiService;
 use OCA\OpenCatalogi\Settings\OpenCatalogiAdmin;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\AnonRateLimit;
 use OCP\AppFramework\Http\Attribute\AuthorizedAdminSetting;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\Http\Response;
@@ -172,6 +173,7 @@ class OoapiController extends Controller {
 	 *
 	 * @spec openspec/specs/ooapi-catalog-publication/spec.md#requirement-per-catalog-ooapi-5-0-resource-endpoints-ooapi-001
 	 */
+	#[AnonRateLimit(limit: 240, period: 60)]
 	public function preflightedCors(): Response {
 		$response = new Response();
 		foreach ($this->corsHeaders() as $name => $value) {

--- a/lib/Controller/PagesController.php
+++ b/lib/Controller/PagesController.php
@@ -27,6 +27,7 @@ namespace OCA\OpenCatalogi\Controller;
 
 use OCP\App\IAppManager;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\Attribute\AnonRateLimit;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\Http\Response;
 use OCP\IAppConfig;
@@ -181,6 +182,7 @@ class PagesController extends Controller {
 	 *
 	 * @spec openspec/specs/cross-origin-api-access/spec.md#requirement-answer-cors-preflight-requests-on-public-api-controllers-cor-001
 	 */
+	#[AnonRateLimit(limit: 240, period: 60)]
 	public function preflightedCors(): Response {
 		// Create and configure the response.
 		$response = new Response();
@@ -204,6 +206,7 @@ class PagesController extends Controller {
 	 *
 	 * @spec openspec/specs/content-management/spec.md
 	 */
+	#[AnonRateLimit(limit: 120, period: 60)]
 	public function index(): JSONResponse {
 		// Get page configuration from settings (resolved via OpenRegister; 503 if unconfigured).
 		try {
@@ -259,6 +262,7 @@ class PagesController extends Controller {
 	 *
 	 * @spec openspec/specs/content-management/spec.md
 	 */
+	#[AnonRateLimit(limit: 120, period: 60)]
 	public function show(string $slug): JSONResponse {
 		// Get page configuration from settings (resolved via OpenRegister; 503 if unconfigured).
 		try {

--- a/lib/Controller/PublicationsController.php
+++ b/lib/Controller/PublicationsController.php
@@ -39,6 +39,7 @@ use OCA\OpenCatalogi\Service\UsageCounterService;
 use OCP\App\IAppManager;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Http\Attribute\AnonRateLimit;
 use OCP\AppFramework\Http\DataDownloadResponse;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\Http\Response;
@@ -395,6 +396,7 @@ class PublicationsController extends Controller {
 	 *
 	 * @spec openspec/specs/cross-origin-api-access/spec.md#requirement-answer-cors-preflight-requests-on-public-api-controllers-cor-001
 	 */
+	#[AnonRateLimit(limit: 240, period: 60)]
 	public function preflightedCors(): Response {
 		// Determine the origin via the same allowlist-aware resolver used elsewhere
 		// so we never reflect an arbitrary caller-supplied Origin (#735).
@@ -427,6 +429,7 @@ class PublicationsController extends Controller {
 	 *
 	 * @spec openspec/specs/publications/spec.md
 	 */
+	#[AnonRateLimit(limit: 120, period: 60)]
 	public function index(string $catalogSlug): JSONResponse {
 		try {
 			// Get the catalog from cache or database.
@@ -558,6 +561,7 @@ class PublicationsController extends Controller {
 	 *
 	 * @spec openspec/specs/publications/spec.md
 	 */
+	#[AnonRateLimit(limit: 120, period: 60)]
 	public function show(string $catalogSlug, string $id): JSONResponse {
 		try {
 			// Get the catalog from cache or database.
@@ -841,6 +845,7 @@ class PublicationsController extends Controller {
 	 *
 	 * @spec openspec/specs/publications/spec.md
 	 */
+	#[AnonRateLimit(limit: 120, period: 60)]
 	public function attachments(string $catalogSlug, string $id): JSONResponse {
 
 		try {
@@ -925,6 +930,9 @@ class PublicationsController extends Controller {
 	 *
 	 * @spec openspec/specs/publications/spec.md
 	 */
+	// Lower than the sibling reads: a download moves file bytes, so the cost of
+	// one call is materially higher than a metadata lookup.
+	#[AnonRateLimit(limit: 60, period: 60)]
 	public function download(string $catalogSlug, string $id): DataDownloadResponse|JSONResponse {
 		try {
 			// Get the catalog from cache or database.
@@ -1021,6 +1029,7 @@ class PublicationsController extends Controller {
 	 *
 	 * @spec openspec/specs/publications/spec.md
 	 */
+	#[AnonRateLimit(limit: 120, period: 60)]
 	public function uses(string $catalogSlug, string $id): JSONResponse {
 		try {
 			$objectService = $this->getObjectService();
@@ -1125,6 +1134,7 @@ class PublicationsController extends Controller {
 	 *
 	 * @spec openspec/specs/publications/spec.md
 	 */
+	#[AnonRateLimit(limit: 120, period: 60)]
 	public function used(string $catalogSlug, string $id): JSONResponse {
 		try {
 			$objectService = $this->getObjectService();

--- a/lib/Controller/RobotsController.php
+++ b/lib/Controller/RobotsController.php
@@ -29,6 +29,7 @@ use OCA\OpenCatalogi\Service\SettingsService;
 use OCA\OpenCatalogi\Service\SitemapService;
 use OCP\App\IAppManager;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\Attribute\AnonRateLimit;
 use OCP\IL10N;
 use OCP\IRequest;
 use OCP\IURLGenerator;
@@ -86,6 +87,9 @@ class RobotsController extends Controller {
 	 *
 	 * @spec openspec/specs/woo-compliance/spec.md
 	 */
+	// Generous: robots.txt is fetched by every crawler that visits, and a
+	// ceiling that trips here blocks indexing rather than abuse.
+	#[AnonRateLimit(limit: 240, period: 60)]
 	public function index(): TextResponse {
 		$settings = $this->settingsService->getSettings();
 

--- a/lib/Controller/SchemaOrgController.php
+++ b/lib/Controller/SchemaOrgController.php
@@ -31,6 +31,7 @@ namespace OCA\OpenCatalogi\Controller;
 use OCA\OpenCatalogi\Service\CatalogiService;
 use OCA\OpenCatalogi\Service\SchemaOrgService;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\Attribute\AnonRateLimit;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\Http\Response;
 use OCP\IAppConfig;
@@ -132,6 +133,7 @@ class SchemaOrgController extends Controller {
 	 *
 	 * @spec openspec/specs/structured-data-discoverability/spec.md
 	 */
+	#[AnonRateLimit(limit: 240, period: 60)]
 	public function preflightedCors(): Response {
 		$response = new Response();
 		foreach ($this->corsHeaders() as $name => $value) {
@@ -159,6 +161,7 @@ class SchemaOrgController extends Controller {
 	 *
 	 * @spec openspec/specs/structured-data-discoverability/spec.md
 	 */
+	#[AnonRateLimit(limit: 120, period: 60)]
 	public function catalog(string $catalogSlug): JSONResponse {
 		try {
 			$catalog = $this->catalogiService->getCatalogBySlug($catalogSlug);

--- a/lib/Controller/SearchController.php
+++ b/lib/Controller/SearchController.php
@@ -29,6 +29,7 @@ use OCA\OpenCatalogi\Service\PublicationService;
 use OCP\App\IAppManager;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\AnonRateLimit;
 use OCP\AppFramework\Http\DataDownloadResponse;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IL10N;
@@ -132,6 +133,9 @@ class SearchController extends Controller {
 	 * @spec openspec/changes/add-public-fulltext-search/tasks.md#task-3
 	 * @spec openspec/changes/add-document-content-search/tasks.md#task-3
 	 */
+	// Lower than a plain read: search is the most expensive query this app
+	// serves anonymously.
+	#[AnonRateLimit(limit: 60, period: 60)]
 	public function index(): JSONResponse {
 		try {
 			$objectService = $this->getObjectService();

--- a/lib/Controller/SitemapController.php
+++ b/lib/Controller/SitemapController.php
@@ -29,6 +29,7 @@ use OCA\OpenCatalogi\Http\XMLResponse;
 use OCA\OpenCatalogi\Service\SitemapService;
 use OCA\OpenCatalogi\Settings\OpenCatalogiAdmin;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\Attribute\AnonRateLimit;
 use OCP\AppFramework\Http\Attribute\AuthorizedAdminSetting;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
@@ -68,6 +69,7 @@ class SitemapController extends Controller {
 	 *
 	 * @spec openspec/specs/woo-compliance/spec.md
 	 */
+	#[AnonRateLimit(limit: 120, period: 60)]
 	public function index(string $catalogSlug, string $categoryCode): XMLResponse {
 		return $this->sitemapService->buildSitemapIndex(
 			catalogSlug: $catalogSlug,
@@ -89,6 +91,7 @@ class SitemapController extends Controller {
 	 *
 	 * @spec openspec/specs/woo-compliance/spec.md
 	 */
+	#[AnonRateLimit(limit: 120, period: 60)]
 	public function sitemap(string $catalogSlug, string $categoryCode): XMLResponse {
 		$page = (int)($this->request->getParams()['page'] ?? 1);
 		return $this->sitemapService->buildSitemap(

--- a/lib/Controller/ThemesController.php
+++ b/lib/Controller/ThemesController.php
@@ -28,6 +28,7 @@ namespace OCA\OpenCatalogi\Controller;
 use OCP\App\IAppManager;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Http\Attribute\AnonRateLimit;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\Http\Response;
 use OCP\IAppConfig;
@@ -176,6 +177,7 @@ class ThemesController extends Controller {
 	 *
 	 * @spec openspec/specs/cross-origin-api-access/spec.md#requirement-answer-cors-preflight-requests-on-public-api-controllers-cor-001
 	 */
+	#[AnonRateLimit(limit: 240, period: 60)]
 	public function preflightedCors(): Response {
 		// Create and configure the response.
 		$response = new Response();
@@ -203,6 +205,7 @@ class ThemesController extends Controller {
 	 *
 	 * @spec openspec/specs/content-management/spec.md
 	 */
+	#[AnonRateLimit(limit: 120, period: 60)]
 	public function index(): JSONResponse {
 		// Get theme configuration from settings (resolved via OpenRegister; 503 if unconfigured).
 		try {
@@ -297,6 +300,7 @@ class ThemesController extends Controller {
 	 *
 	 * @spec openspec/specs/content-management/spec.md
 	 */
+	#[AnonRateLimit(limit: 120, period: 60)]
 	public function show(string|int $id): JSONResponse {
 		// Get theme configuration from settings (resolved via OpenRegister; 503 if
 		// unconfigured), exactly as index() does.


### PR DESCRIPTION
## What

Adds `#[AnonRateLimit]` to **44 publicly reachable methods** across 16 controllers (ADR-082). gate-82 goes 44 → 0.

## Why these were missed

Every one declares itself public with the legacy **`@PublicPage` annotation**, not the `#[PublicPage]` attribute — this app had **zero** attribute-form public endpoints, so the fleet sweep that line-anchored the attribute form reported it as having nothing to throttle. The annotation is a live declaration, and this app's own endpoint proves it:

```
GET /apps/opencatalogi/api/catalogi   (no auth)  ->  200
{"results":[],"total":0,...}
```

## Limits, chosen per endpoint

| endpoint class | limit | reason |
|---|---|---|
| `preflightedCors` (11×), `robots.txt` | 240/60 | the browser sends OPTIONS before *each* cross-origin call; crawlers fetch robots.txt on every visit. A ceiling tight enough to bite here breaks ordinary use, not an attack |
| `search` | 60/60 | the most expensive query served anonymously |
| `download`, `publicationDownload` | 60/60 | moves file bytes — materially costlier than a metadata lookup |
| `update` (directory) | 30/60 | write |
| everything else (reads) | 120/60 | |

## Three inert markers found, not fixed here

`lib/Service/PublicationService.php` carries real `@PublicPage` annotations on `index`, `uses` and `used` — copy-pasted from a controller. The class declares `class PublicationService {`, extends nothing, and appears **nowhere in `appinfo/routes.php`**, so Nextcloud never reads those markers and no rate limit could apply.

They are **not** a vulnerability, and I've left them alone rather than widen this PR — but they should be deleted, because they read as an exposure that does not exist. gate-82 reports them as `NOTE ... inert` rather than counting them.

## Why `AnonRateLimit` and not `BruteForceProtection`

These endpoints check no credential, and `#[BruteForceProtection]` without a paired `registerAttempt()` is the **inert half** of a two-half mechanism. `AnonRateLimit` also leaves authenticated traffic untouched, so no integration is affected.

## Verification

- `php -l` clean on all 16 files.
- Diff is **72 added lines, 0 removed** — purely additive.
- gate-82 (.github#460): **44 public methods, 44 throttled, 0 unthrottled, 3 inert**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
