### PR TITLE
chore: remove three inert routing annotations from PublicationService

### DIFF
--- a/lib/Service/PublicationService.php
+++ b/lib/Service/PublicationService.php
@@ -714,10 +714,6 @@ class PublicationService {
 	 *
 	 * @return JSONResponse A JSON response containing the list of objects
 	 *
-	 * @NoAdminRequired
-	 * @NoCSRFRequired
-	 * @PublicPage
-	 *
 	 * @spec openspec/specs/publications/spec.md
 	 */
 	public function index(null|string|int $catalogId = null, ?array $customParams = null): JSONResponse {
@@ -1113,10 +1109,6 @@ class PublicationService {
 	 *
 	 * @throws ContainerExceptionInterface|NotFoundExceptionInterface
 	 *
-	 * @NoAdminRequired
-	 * @NoCSRFRequired
-	 * @PublicPage
-	 *
 	 * @spec openspec/specs/publications/spec.md
 	 */
 	public function uses(string $id): JSONResponse {
@@ -1191,10 +1183,6 @@ class PublicationService {
 	 * @return JSONResponse A JSON response containing the referenced objects
 	 *
 	 * @throws ContainerExceptionInterface|NotFoundExceptionInterface
-	 *
-	 * @NoAdminRequired
-	 * @NoCSRFRequired
-	 * @PublicPage
 	 *
 	 * @spec openspec/specs/publications/spec.md
 	 */


### PR DESCRIPTION
## What

Removes three copy-pasted routing annotation blocks from `PublicationService` — `@NoAdminRequired`, `@NoCSRFRequired`, `@PublicPage` on `index()`, `uses()` and `used()`.

## Why

They are **inert**. `PublicationService` declares `class PublicationService {`, extends nothing, and appears **nowhere in `appinfo/routes.php`**. Nextcloud reads these markers off the routed *controller* method, so nothing here is reachable and no rate limit or CSRF policy could ever apply to them.

They are not a vulnerability. They are worse than harmless in one specific way: **they read as an exposure that does not exist.** Anyone auditing this app's public surface has to open the file, check the class declaration, and grep the routes to find out they mean nothing — which is exactly the work this PR removes.

Surfaced by gate-82 (`.github#460`), which reports markers on unrouted classes as `NOTE ... inert` rather than counting them as findings.

## Scope note

All three annotations in each block are removed, not just `@PublicPage`. `@NoAdminRequired` and `@NoCSRFRequired` are inert here for exactly the same reason, and leaving them would keep the file reading like routing configuration.

## Verification

- `php -l` clean.
- Diff is **0 added, 12 removed** — deletions only.
- The one *legitimate* `@PublicPage` reference in this file is prose at line 192 (`"was reachable from anonymous @PublicPage endpoints — a DoS…"`) and is **untouched**; it explains a past defect and is not a declaration.
- gate-82 on this tree: **44 public methods, 44 throttled, 0 unthrottled, 0 inert** (was `3 inert`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
