### PR TITLE
perf(settings): resolve register schemas in one batched query

### DIFF
--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -486,15 +486,48 @@ class SettingsService {
 				return $registers;
 			}
 
-			$enrichedRegisters = [];
-
+			// Normalise every register to its array form once, so the schema-ID
+			// sweep below and the enrichment pass agree on the same shape.
+			$registerArrays = [];
 			foreach ($registers as $register) {
-				// Convert register to array if it's an object.
 				$registerArray = (array)$register;
 				if (is_object($register) === true && method_exists($register, 'jsonSerialize') === true) {
 					$registerArray = $register->jsonSerialize();
 				}
 
+				$registerArrays[] = $registerArray;
+			}
+
+			// Collect the distinct numeric schema IDs referenced by ALL registers, then
+			// resolve them in ONE batched query. Resolving per-ID inside the register
+			// loop issued a `find()` per schema — on this instance that is 2,814 queries
+			// for 348 registers on every settings request, and dominated the ~11s the
+			// endpoint took to respond.
+			$idsToResolve = [];
+			foreach ($registerArrays as $registerArray) {
+				$schemaIds = $registerArray['schemas'] ?? [];
+				if (is_array($schemaIds) === false) {
+					continue;
+				}
+
+				foreach ($schemaIds as $schemaId) {
+					if (is_numeric($schemaId) === true) {
+						$idsToResolve[(int)$schemaId] = true;
+					}
+				}
+			}
+
+			// The batched lookup chunks its IN() list and returns a map keyed by
+			// schema ID. It reads the table directly, matching the _rbac: false /
+			// _multitenancy: false posture the per-ID find() call used here before.
+			$schemaMap = [];
+			if (empty($idsToResolve) === false) {
+				$schemaMap = $schemaMapper->findMultipleOptimized(ids: array_keys($idsToResolve));
+			}
+
+			$enrichedRegisters = [];
+
+			foreach ($registerArrays as $registerArray) {
 				// Get schema IDs from the register.
 				$schemaIds = $registerArray['schemas'] ?? [];
 
@@ -504,7 +537,7 @@ class SettingsService {
 					continue;
 				}
 
-				// Fetch full schema objects for each schema ID.
+				// Replace each schema ID with the full schema object from the batch.
 				$fullSchemas = [];
 				foreach ($schemaIds as $schemaId) {
 					// Skip if not a number (already an object).
@@ -513,21 +546,19 @@ class SettingsService {
 						continue;
 					}
 
-					try {
-						$schema = $schemaMapper->find((int)$schemaId, _rbac: false, _multitenancy: false);
-						if ($schema !== null) {
-							// Convert schema entity to array.
-							$schemaArray = (array)$schema;
-							if (is_object($schema) === true && method_exists($schema, 'jsonSerialize') === true) {
-								$schemaArray = $schema->jsonSerialize();
-							}
-
-							$fullSchemas[] = $schemaArray;
-						}
-					} catch (\Exception $e) {
-						// Schema not found, skip it.
+					// A schema ID with no row is silently dropped, as before.
+					$schema = $schemaMap[(int)$schemaId] ?? null;
+					if ($schema === null) {
 						continue;
 					}
+
+					// Convert schema entity to array.
+					$schemaArray = (array)$schema;
+					if (is_object($schema) === true && method_exists($schema, 'jsonSerialize') === true) {
+						$schemaArray = $schema->jsonSerialize();
+					}
+
+					$fullSchemas[] = $schemaArray;
 				}//end foreach
 
 				// Replace schema IDs with full schema objects.

--- a/tests/Unit/Service/SettingsServiceTest.php
+++ b/tests/Unit/Service/SettingsServiceTest.php
@@ -132,6 +132,28 @@ class SettingsServiceTest extends \PHPUnit\Framework\TestCase {
 						return $schemaMock;
 					}
 				);
+
+			// enrichRegistersWithSchemas() resolves every referenced schema in one
+			// batched call rather than a find() per ID. Mirror the real mapper's
+			// contract: a map keyed by schema ID, with unknown IDs simply absent.
+			$mock->method('findMultipleOptimized')
+				->willReturnCallback(
+					function (array $ids) use ($schemaMap) {
+						$found = [];
+						foreach ($ids as $id) {
+							if (isset($schemaMap[(int)$id]) === false) {
+								continue;
+							}
+
+							$schemaMock = $this->createMock(Schema::class);
+							$schemaMock->method('jsonSerialize')
+								->willReturn($schemaMap[(int)$id]);
+							$found[(int)$id] = $schemaMock;
+						}
+
+						return $found;
+					}
+				);
 		}
 
 		return $mock;


### PR DESCRIPTION
## Problem

`SettingsService::enrichRegistersWithSchemas()` called `SchemaMapper::find()` once per schema ID, inside the register loop. On this dev instance — 348 registers, 2,814 schema references — that is **2,814 individual queries on every `/api/settings` request**, and the dashboard hits that endpoint on load.

## Change

Collect the distinct numeric schema IDs across all registers first, then resolve them with a single `findMultipleOptimized()` call. That method chunks its `IN()` list (avoiding the 1,000-expression cap) and returns a map keyed by schema ID. It reads the table directly, matching the `_rbac: false` / `_multitenancy: false` posture the per-ID `find()` used here before.

## Behaviour is unchanged

Schema ordering, pass-through of non-numeric entries, and the silent drop of IDs with no row all behave exactly as before.

Verified against live data rather than by inspection: **345 of 348 registers serialise byte-identically**. The 3 that differ were re-uploaded during the measurement window — `owner`/`application` moved `imported` → `uploaded-config`, versions bumped `0.0.2` → `1.0.x`, and `updated` timestamps moved from 08:30 to 18:06.

## Measurements

| | Before | After |
|---|---|---|
| curl, uncompressed | 11.17s | **1.32s** |
| curl, gzipped | — | **1.43s** |
| browser, isolated | 11.23s | **1.09s** (TTFB 975ms) |

## Tests

The unit tests stubbed `find()`, which this no longer calls — they failed loudly, which is the control that they exercise this path. `createSchemaMapperMock()` now also stubs `findMultipleOptimized()` with the real contract.

Full gate run in the container on PHP 8.4 (the host CLI is 8.2, so `composer check:strict` fatals in `platform_check.php` without analysing anything):

- lint: 194 files clean
- phpcs: **10 errors — exactly the HEAD baseline** for this file
- phpstan: `[OK] No errors` (verified live with a deliberate error, since a zero-file run prints the same)
- psalm: exit 0
- phpunit: **1320 tests, 0 failures**

## Follow-ups (not in this PR)

The payload is still 11.5 MB. A field projection to `id`/`title`/`slug` would cut it 99%, but `schemaHelpers.js` reads `schema.properties` and fails closed, so that needs per-consumer work rather than a blanket projection.