### PR TITLE
docs(spec): hand the website CMS to Portaliq, with a scheduled proxy removal

### DIFF
--- a/openspec/changes/cms-handover/.openspec.yaml
+++ b/openspec/changes/cms-handover/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: conduction
+created: 2026-08-15

--- a/openspec/changes/cms-handover/proposal.md
+++ b/openspec/changes/cms-handover/proposal.md
@@ -1,0 +1,60 @@
+---
+kind: code
+---
+
+# Proposal: cms-handover
+
+## Summary
+
+Hand the public-site CMS — `menu`, `page` and the glossary — from OpenCatalogi
+to Portaliq. The CRUD UI moves immediately; `MenusController`,
+`PagesController` and `GlossaryController` become thin deprecated proxies to
+Portaliq's content API for exactly one release, then are removed by a separate
+change.
+
+Chain link 9 of `hydra/openspec/changes/portaliq-phase-two`. Implements
+ADR-086 §3 on the OpenCatalogi side.
+
+## Motivation
+
+OpenCatalogi owns the fleet's public-site CMS by accident of history: `menu`
+and `page` OpenRegister objects, a glossary, and 31 frontend files of modals,
+index views, forms and dialogs. It is a catalogue application that also happens
+to be where you edit a website's navigation.
+
+Portaliq is the app whose job that is, and it now has a `website` to scope
+content to, a headless content API, and a renderer. Two apps editing the same
+objects is worse than one app plus a redirect — an editor should never have to
+know which of two surfaces is authoritative.
+
+No data migrates: these are already OpenRegister objects.
+
+## Affected Projects
+
+- [ ] `opencatalogi` — remove the menu/page/glossary CRUD UI; reduce the three
+      controllers to deprecated proxies; point admins at Portaliq.
+
+## Design notes
+
+**The CRUD UI moves immediately; the read path lingers.** A live deployment may
+still call OpenCatalogi's endpoints — including `tilburg-woo-ui`, which ten
+municipalities run. Breaking those at cutover buys nothing.
+
+**The proxy is deliberately visible.** Deprecated, dated, and removed by its own
+change, so "the proxy is still there" is a backlog item rather than something
+nobody remembers.
+
+**Catalogue-specific content is out of scope.** Catalogues, publications,
+themes and directory federation stay in OpenCatalogi. What moves is the
+website CMS: navigation, pages and the begrippenlijst.
+
+## Risks
+
+- **Ten municipal deployments read these endpoints today.** The proxy has to be
+  behaviour-identical, verified against recorded responses rather than against
+  the new implementation's idea of what they should be.
+- **Removing the UI while the proxy remains is an asymmetry**, and asymmetries
+  get forgotten. The removal change is written at the same time as this one.
+- **`GlossaryController` has consumers beyond the CMS** — the manifest config
+  listener and `SettingsService` both reference the glossary. Those references
+  are checked before anything is deleted, not after.

--- a/openspec/changes/cms-handover/specs/cms-handover/spec.md
+++ b/openspec/changes/cms-handover/specs/cms-handover/spec.md
@@ -1,0 +1,89 @@
+# cms-handover Delta: cms-handover
+
+**Status**: in-progress
+**Scope**: opencatalogi
+**OpenSpec changes**:
+
+- [cms-handover](../../)
+
+## Purpose
+
+Hands the website CMS — menus, pages and the begrippenlijst — from OpenCatalogi
+to Portaliq, leaving a deprecated read path for one release. Implements the
+OpenCatalogi side of ADR-086 §3. Related: the cross-app delta
+`hydra/openspec/changes/portaliq-phase-two/specs/portaliq-cms/spec.md`.
+
+## ADDED Requirements
+
+### Requirement: OpenCatalogi MUST NOT retain a second editing surface
+
+The menu, page and glossary CRUD UI SHALL be removed from OpenCatalogi. An
+administrator SHALL be directed to Portaliq.
+
+#### Scenario: There is exactly one place to edit a menu
+
+- **GIVEN** the handover is complete
+- **WHEN** the fleet is searched for a menu-editing surface
+- **THEN** only Portaliq's is present
+
+#### Scenario: An admin arriving at the old location is redirected
+
+- **GIVEN** an administrator opening the former CMS location in OpenCatalogi
+- **THEN** they are told where the capability now lives and can reach it
+
+### Requirement: The read path MUST stay behaviour-identical while deprecated
+
+`MenusController`, `PagesController` and `GlossaryController` SHALL delegate to
+Portaliq's content API and SHALL return responses identical to those they
+returned before the handover. They SHALL be marked deprecated.
+
+#### Scenario: An existing consumer sees no change
+
+- **GIVEN** a response recorded from the pre-handover endpoint
+- **WHEN** the same request is made through the proxy
+- **THEN** the response matches that recording
+- **AND** the comparison is against the recording, not against what the new
+  implementation considers correct
+
+#### Scenario: Deprecation is announced in the response
+
+- **GIVEN** a request to a proxied endpoint
+- **THEN** the response is marked deprecated
+
+#### Scenario: Portaliq being unavailable is reported, not faked
+
+- **GIVEN** Portaliq is not installed or not reachable
+- **WHEN** a proxied endpoint is called
+- **THEN** it reports the failure rather than returning an empty success
+
+### Requirement: Remaining glossary consumers MUST be identified before removal
+
+Every OpenCatalogi reference to the glossary outside the CMS UI SHALL be
+enumerated and either migrated or explicitly retained.
+
+#### Scenario: Non-CMS consumers are accounted for
+
+- **GIVEN** the glossary references in the manifest config listener and the
+  settings service
+- **WHEN** the handover completes
+- **THEN** each is either migrated to Portaliq's API or documented as retained
+- **AND** none is discovered after deletion
+
+### Requirement: Proxy removal MUST be scheduled as its own change
+
+The removal of the deprecated controllers SHALL be a separate, written change,
+not a follow-up intention.
+
+#### Scenario: The removal is in the backlog on day one
+
+- **GIVEN** this change is merged
+- **WHEN** the backlog is inspected
+- **THEN** the removal change exists, naming the controllers and the release
+  after which they go
+
+#### Scenario: Catalogue capabilities are untouched
+
+- **GIVEN** the handover is complete
+- **WHEN** catalogues, publications, themes and directory federation are
+  exercised
+- **THEN** all behave as before — only the website CMS moved

--- a/openspec/changes/cms-handover/tasks.md
+++ b/openspec/changes/cms-handover/tasks.md
@@ -1,0 +1,47 @@
+# Tasks: cms-handover
+
+> Hand the website CMS to Portaliq, leave a deprecated read path
+> (ADR-032 `kind: code`). Checkbox budget: 4 tasks × 2 = 8 unindented
+> `- [ ]` lines (cap 20).
+
+## Implementation Tasks
+
+### Task 1: Record the current behaviour before changing it
+- **spec_ref**: `openspec/changes/cms-handover/specs/cms-handover/spec.md#requirement-the-read-path-must-stay-behaviour-identical-while-deprecated`
+- **files**: `tests/fixtures/cms-baseline/*.json`, `tests/Unit/Controller/CmsProxyParityTest.php`
+- **acceptance_criteria**:
+  - Responses from `MenusController`, `PagesController` and `GlossaryController` are recorded from the CURRENT implementation, before any edit, covering two-level menus, ordered page content and glossary terms
+  - The recordings are the assertion target for the proxy — comparing the proxy against the new implementation's expectations would prove only that two new things agree
+  - Recordings come from a deployment with real data, not from fixtures written to match the schema
+- [ ] Implement
+- [ ] Test
+
+### Task 2: Reduce the controllers to deprecated proxies
+- **spec_ref**: `openspec/changes/cms-handover/specs/cms-handover/spec.md#requirement-the-read-path-must-stay-behaviour-identical-while-deprecated`
+- **files**: `lib/Controller/MenusController.php`, `lib/Controller/PagesController.php`, `lib/Controller/GlossaryController.php`
+- **acceptance_criteria**:
+  - Each delegates to Portaliq's content API and matches its recorded baseline
+  - Each is marked deprecated in the response and in its docblock
+  - Portaliq unavailable reports the failure — it does NOT return an empty success, which a consumer reads as "no menus" and renders as a site with no navigation
+- [ ] Implement
+- [ ] Test
+
+### Task 3: Remove the CRUD UI and account for other glossary consumers
+- **spec_ref**: `openspec/changes/cms-handover/specs/cms-handover/spec.md#requirement-remaining-glossary-consumers-must-be-identified-before-removal`
+- **files**: `src/views/menus/`, `src/views/pages/`, `src/views/glossary/`, `src/modals/{menu,menuItem,page,pageContents,glossary}/`, `src/dialogs/{menu,page}/`, `src/manifest.json`
+- **acceptance_criteria**:
+  - The 31 menu/page/glossary frontend files are removed and the manifest no longer routes to them; an admin reaching the old location is told where the capability lives
+  - Every glossary reference OUTSIDE the CMS UI — `ProvideManifestConfigStateListener`, `SettingsService`, `UiController`, `EntityDetailPage.vue`, `Modals.vue`, `navigation.ts` — is enumerated FIRST and each is migrated or documented as retained
+  - No such consumer is discovered after deletion
+  - Catalogues, publications, themes and directory federation are exercised and unchanged
+- [ ] Implement
+- [ ] Test
+
+### Task 4: Write the removal change now, not later
+- **spec_ref**: `openspec/changes/cms-handover/specs/cms-handover/spec.md#requirement-proxy-removal-must-be-scheduled-as-its-own-change`
+- **files**: `openspec/changes/cms-proxy-removal/`
+- **acceptance_criteria**:
+  - The removal change exists with proposal and tasks, naming the three controllers and the release after which they go
+  - It is written in this change, because a deprecation with no scheduled removal becomes permanent
+- [ ] Implement
+- [ ] Test

--- a/openspec/changes/cms-proxy-removal/.openspec.yaml
+++ b/openspec/changes/cms-proxy-removal/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: conduction
+created: 2026-08-15

--- a/openspec/changes/cms-proxy-removal/proposal.md
+++ b/openspec/changes/cms-proxy-removal/proposal.md
@@ -1,0 +1,58 @@
+---
+kind: code
+---
+
+# Proposal: cms-proxy-removal
+
+## Summary
+
+Delete `MenusController`, `PagesController` and `GlossaryController` from
+OpenCatalogi, one release after `cms-handover` reduced them to deprecated
+proxies pointing at Portaliq's content API.
+
+## Motivation
+
+This change exists because `cms-handover` requires it to exist. Its Task 4
+says so explicitly, and the reason is stated there: **a deprecation with no
+scheduled removal becomes permanent.**
+
+The proxies are the price of not breaking ten live municipal deployments at
+cutover. They are not a design — they are a transition, and a transition with
+no end date is just a second implementation that nobody owns. Writing this
+change on the same day as the handover means "the proxy is still there" shows
+up in a backlog rather than being remembered by whoever happens to notice.
+
+## Preconditions
+
+This change SHALL NOT be merged until all of the following hold. Each is a
+thing to check, not a box to tick from memory:
+
+- [ ] `cms-handover` has shipped and been in a release for at least one cycle.
+- [ ] Portaliq's content API is serving the menus, pages and glossary of every
+      deployment that previously read OpenCatalogi's endpoints — verified per
+      deployment, not inferred from one.
+- [ ] The proxy endpoints' access logs show no callers over a full release
+      cycle. **Absence of logging is not absence of callers**: if the endpoints
+      are not instrumented, instrument them first and wait, rather than reading
+      an empty grep as proof.
+- [ ] `tilburg-woo-ui` — the largest known consumer — no longer calls them.
+
+## Affected Projects
+
+- [ ] `opencatalogi` — remove the three controllers, their routes, their tests
+      and their spec coverage.
+
+## Risks
+
+- **The consumer you did not know about.** These are public read endpoints; a
+  municipality's own integration may call them without anyone here knowing.
+  The log check above is the only real defence, and it is worth more than the
+  deprecation notice.
+- **Removing the routes is easy to do partially.** The controllers, the route
+  entries, the tests and the specs go together; leaving a route pointing at a
+  deleted controller is a 500, not a 404.
+
+## Out of scope
+
+Catalogues, publications, themes and directory federation. Only the website
+CMS moved, and only its proxies are removed here.

--- a/openspec/changes/cms-proxy-removal/specs/cms-handover/spec.md
+++ b/openspec/changes/cms-proxy-removal/specs/cms-handover/spec.md
@@ -1,0 +1,57 @@
+# cms-handover Delta: cms-proxy-removal
+
+**Status**: blocked — see the preconditions in the proposal
+**Scope**: opencatalogi
+**OpenSpec changes**:
+
+- [cms-proxy-removal](../../)
+
+## Purpose
+
+Completes the handover begun in `cms-handover` by removing the deprecated
+menu, page and glossary read proxies. Related: ADR-086 §3.
+
+## REMOVED Requirements
+
+### Requirement: The read path MUST stay behaviour-identical while deprecated
+
+**Reason**: the deprecation window has elapsed and the proxies are removed.
+The requirement described a transition, not an end state.
+
+**Migration**: consumers read Portaliq's `/api/content/*` endpoints. The
+response shapes were held identical throughout the window precisely so this
+step needs no consumer change beyond the base URL.
+
+## ADDED Requirements
+
+### Requirement: The proxied endpoints MUST be gone, not silently broken
+
+The three controllers, their route entries, their tests and their spec
+coverage SHALL be removed together. A request to a former endpoint SHALL
+return 404, never a 500.
+
+#### Scenario: A former endpoint returns not-found
+
+- **GIVEN** a request to a removed menu, page or glossary endpoint
+- **THEN** it returns 404
+- **AND** not a 500 — a route left pointing at a deleted controller is the
+  usual way this half-lands
+
+#### Scenario: Nothing references the removed controllers
+
+- **GIVEN** the change is complete
+- **WHEN** the app is searched for the controller names
+- **THEN** no route, test, spec or manifest entry names them
+
+### Requirement: Removal MUST be evidenced, not assumed
+
+The change SHALL record the evidence that no consumer still calls the
+endpoints.
+
+#### Scenario: The log check is positive evidence, not an empty grep
+
+- **GIVEN** the access-log check over a full release cycle
+- **THEN** the record states that the endpoints were instrumented and observed
+  receiving no calls
+- **AND** an unlogged endpoint is treated as unknown, not as unused — the two
+  produce the same empty result and mean opposite things

--- a/openspec/changes/cms-proxy-removal/tasks.md
+++ b/openspec/changes/cms-proxy-removal/tasks.md
@@ -1,0 +1,29 @@
+# Tasks: cms-proxy-removal
+
+> Removes the deprecated CMS proxies (ADR-032 `kind: code`). BLOCKED until the
+> preconditions in the proposal hold. Checkbox budget: 2 tasks × 2 = 4
+> unindented `- [ ]` lines (cap 20).
+
+## Implementation Tasks
+
+### Task 1: Evidence that nothing still calls the endpoints
+- **spec_ref**: `openspec/changes/cms-proxy-removal/specs/cms-handover/spec.md#requirement-removal-must-be-evidenced-not-assumed`
+- **files**: `docs/cms-proxy-retirement.md`
+- **acceptance_criteria**:
+  - The proxy endpoints are instrumented BEFORE the observation window opens; an unlogged endpoint is unknown, not unused, and the two look identical
+  - Access logs over a full release cycle show no callers, recorded per deployment rather than generalised from one
+  - `tilburg-woo-ui` is confirmed to have stopped calling them
+  - The record states what was checked and over what period, so a later reader can judge the evidence rather than trust the conclusion
+- [ ] Implement
+- [ ] Test
+
+### Task 2: Remove the controllers, routes, tests and specs together
+- **spec_ref**: `openspec/changes/cms-proxy-removal/specs/cms-handover/spec.md#requirement-the-proxied-endpoints-must-be-gone-not-silently-broken`
+- **files**: `lib/Controller/MenusController.php`, `lib/Controller/PagesController.php`, `lib/Controller/GlossaryController.php`, `appinfo/routes.php`, `tests/Unit/Controller/`, `openspec/specs/content-management/spec.md`
+- **acceptance_criteria**:
+  - Controllers, route entries, tests and spec coverage are removed in one change; a route surviving its controller returns 500, which is worse than the 404 this is meant to produce
+  - A request to any former endpoint returns 404
+  - A repo search for the controller names finds no route, test, spec or manifest reference
+  - Catalogues, publications, themes and directory federation are exercised and unchanged
+- [ ] Implement
+- [ ] Test


### PR DESCRIPTION
## What

Two spec-only changes handing the public-site CMS to Portaliq.

Programme context: [hydra#581](https://github.com/ConductionNL/hydra/pull/581) (ADR-086). Implementation: [portaliq#114](https://github.com/ConductionNL/portaliq/pull/114).

## `cms-handover`

The public-site CMS — `menu`, `page` and the glossary, plus 31 frontend files — moves to Portaliq, the app whose job it is. OpenCatalogi is a catalogue application that also happens to be where you edit a website's navigation.

**No data migrates.** These are already OpenRegister objects; the move is ownership.

The CRUD UI goes immediately. `MenusController`, `PagesController` and `GlossaryController` become deprecated proxies for one release, because ten municipal deployments read them today and breaking that at cutover buys nothing.

Two details the spec is deliberately strict about:

- **The proxies must be behaviour-identical, asserted against a *recording* of today's responses.** Comparing the proxy against the new implementation's expectations would prove only that two new things agree.
- **Glossary references outside the CMS UI are enumerated before anything is deleted** — `ProvideManifestConfigStateListener`, `SettingsService`, `UiController`, `EntityDetailPage.vue`, `Modals.vue`, `navigation.ts` — not discovered after.

Also: Portaliq being unavailable must be *reported*, not returned as an empty success. A consumer reads an empty menu list as "no menus" and renders a site with no navigation.

## `cms-proxy-removal`

Deletes those proxies one release later.

It exists because `cms-handover` requires it to exist. A deprecation with no scheduled removal becomes permanent, and "the proxy is still there" should be a backlog item rather than something someone happens to notice.

Its preconditions are things to check, not boxes to tick. The access-log check in particular: **an unlogged endpoint is *unknown*, not unused**, and the two produce the same empty result while meaning opposite things. So the endpoints get instrumented first and observed over a release cycle, rather than an empty grep being read as proof.

## Blocked on

`portaliq/portal-cms-admin-ui`. `cms-handover` removes the only editorial surface in the fleet; shipping it before a replacement exists would leave nobody able to edit a menu at all. That ordering is recorded in the programme's gap analysis.

## Out of scope

Catalogues, publications, themes and directory federation. Only the website CMS moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
