### PR TITLE
chore(deps): track @conduction/nextcloud-vue ^2.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@codemirror/lang-json": "^6.0.2",
         "@codemirror/lang-xml": "^6.1.0",
-        "@conduction/nextcloud-vue": "2.2.0-vue3.16",
+        "@conduction/nextcloud-vue": "^2.3.0",
         "@fortawesome/fontawesome-svg-core": "^6.6.0",
         "@fortawesome/free-brands-svg-icons": "6.6.0",
         "@fortawesome/free-regular-svg-icons": "6.6.0",
@@ -2128,9 +2128,9 @@
       }
     },
     "node_modules/@conduction/nextcloud-vue": {
-      "version": "2.2.0-vue3.16",
-      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.2.0-vue3.16.tgz",
-      "integrity": "sha512-eqKSYzS8hrvqzedbgwAch5M/rn2uPEBDBccZZPIRVZ/XrQMYd0yzseTCLyalsBDrWtdb9HoTOp5OBW+p2WFdwQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.3.0.tgz",
+      "integrity": "sha512-jwQJ5gqcUfWbKMCXUNO8BteRD4yakLVEAIx6Qd+2+BLZaiENLUFDYVnHxARef9AyZmvBAOxQCVHC3Fk8jgDBOA==",
       "license": "EUPL-1.2",
       "dependencies": {
         "@ckpack/vue-color": "^1.6.0",
@@ -2186,7 +2186,7 @@
         "axe-core": "^4.10.0",
         "dexie": "^4.0.8",
         "dompurify": "^3.0.0",
-        "eslint": "^8.56.0 || ^9.0.0",
+        "eslint": "^8.56.0 || ^9.0.0 || ^10.0.0",
         "eslint-plugin-vue": "^9.21.0 || ^10.0.0",
         "gridstack": "^12.0.0",
         "marked": "^12.0.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@codemirror/lang-json": "^6.0.2",
     "@codemirror/lang-xml": "^6.1.0",
-    "@conduction/nextcloud-vue": "2.2.0-vue3.16",
+    "@conduction/nextcloud-vue": "^2.3.0",
     "@fortawesome/fontawesome-svg-core": "^6.6.0",
     "@fortawesome/free-brands-svg-icons": "6.6.0",
     "@fortawesome/free-regular-svg-icons": "6.6.0",
@@ -138,10 +138,7 @@
     "postcss": ">=8.4.47",
     "fast-xml-parser": ">=5.7.0",
     "markdown-it": ">=12.3.2",
-    "uuid": ">=14.0.0",
-    "@conduction/nextcloud-vue": {
-      "eslint": "$eslint"
-    }
+    "uuid": ">=14.0.0"
   },
   "prettier": "@nextcloud/prettier-config"
 }


### PR DESCRIPTION
## What

Moves `@conduction/nextcloud-vue` from the exact pin `2.2.0-vue3.16` to the range `^2.3.0`, and drops the `overrides."@conduction/nextcloud-vue".eslint` entry.

## Why

The Vue 3 line used to ship as a prerelease series (`2.2.0-vue3.x`) alongside a Vue 2 `latest`. That split is gone: the Vue 3 line has been folded into the mainline 2.x series and now ships as **2.3.0 on `latest`**. All 40 `vue3.x` prereleases — including the `2.2.0-vue3.16` this app pinned — are deprecated, so `npm install` warns until the pin moves.

A caret range instead of an exact pin means future 2.x releases of the shared library reach the app without a per-repo edit.

The `overrides` entry existed for exactly one reason: the old prerelease declared `eslint: "^8.56.0 || ^9.0.0"` and so could not see this app's eslint 10, which broke peer resolution. 2.3.0 declares `"^8.56.0 || ^9.0.0 || ^10.0.0"` itself — visible in the lockfile diff — so the workaround is now dead weight.

## Risk

Low, and measured rather than assumed:

- **No API change.** 252 components before, 252 after; no export removed. The only public-surface addition is the BSN validator block.
- **Peer ranges identical** apart from the eslint widening described above.
- **No dependency-tree change.** The lockfile churn is version, `resolved`, `integrity` and the eslint peer string. Zero packages added or removed.

Internally the library did move — 2,542 changed lines across 36 files, touching `CnDataTable`, `CnDetailPage`, `CnAppNav` and `CnDashboardGrid` — which is why this was verified per app rather than swept.

## Verification

Run locally against the real 2.3.0 tarball:

| check | result |
|---|---|
| resolved version | 2.3.0 (confirmed in `node_modules` and the lockfile) |
| `npm run build` | exit 0 |
| `npm run lint` | exit 0 |
| `npm test` | exit 0 |

Unit tests: `Tests: 66 passed, 66 total`
Lint: `✖ 569 problems (0 errors, 569 warnings)` — warnings are the pre-existing suppression baseline, not new.
