### PR TITLE
fix(tests): follow ObjectEntity's getters becoming real methods

### DIFF
--- a/tests/Stubs/OpenRegister/Db/ObjectEntity.php
+++ b/tests/Stubs/OpenRegister/Db/ObjectEntity.php
@@ -102,14 +102,50 @@ class ObjectEntity extends \OCP\AppFramework\Db\Entity implements \JsonSerializa
 	}//end jsonSerialize()
 
 	/*
-	 * NOTE: getId() / getUuid() / getRegister() / getSchema() are deliberately NOT
-	 * declared here. The real OCA\OpenRegister\Db\ObjectEntity declares none of them
-	 * either — they are served by OCP\AppFramework\Db\Entity::__call (routed through
-	 * this stub's own __call above). Declaring them made the stub's method surface
-	 * diverge from the real class's, which silently changed how PHPUnit builds a
-	 * double: onlyMethods() succeeded here and threw CannotUseOnlyMethodsException in
-	 * CI, and addMethods() would do the reverse. Keep the magic surface magic.
+	 * NOTE: this stub's method surface must MIRROR the real
+	 * OCA\OpenRegister\Db\ObjectEntity exactly, because PHPUnit chooses between
+	 * addMethods() and onlyMethods() on whether the method exists. A divergence
+	 * is silent locally and fails only in CI, where the real class is installed:
+	 * onlyMethods() throws CannotUseOnlyMethodsException against a magic method,
+	 * and addMethods() throws CannotUseAddMethodsException against a real one.
+	 *
+	 * getUuid() / getRegister() / getSchema() became REAL methods on the real
+	 * class when OpenRegister published its ObjectService/ObjectEntity
+	 * interfaces, so they are declared below. getId() is still served by
+	 * OCP\AppFramework\Db\Entity::__call (routed through this stub's own __call
+	 * above) and so stays undeclared. When the real class moves again, move this
+	 * stub with it.
 	 */
+
+	/**
+	 * Stub for getUuid — a REAL method on the real class.
+	 *
+	 * @return string|null
+	 */
+	public function getUuid(): ?string {
+		$value = ($this->_props['uuid'] ?? null);
+		return ($value === null) ? null : (string) $value;
+	}//end getUuid()
+
+	/**
+	 * Stub for getRegister — a REAL method on the real class.
+	 *
+	 * @return string|null
+	 */
+	public function getRegister(): ?string {
+		$value = ($this->_props['register'] ?? null);
+		return ($value === null) ? null : (string) $value;
+	}//end getRegister()
+
+	/**
+	 * Stub for getSchema — a REAL method on the real class.
+	 *
+	 * @return string|null
+	 */
+	public function getSchema(): ?string {
+		$value = ($this->_props['schema'] ?? null);
+		return ($value === null) ? null : (string) $value;
+	}//end getSchema()
 
 	/**
 	 * Stub for getObject — a REAL method on the real class.

--- a/tests/Unit/Controller/PublicationsControllerTest.php
+++ b/tests/Unit/Controller/PublicationsControllerTest.php
@@ -754,22 +754,24 @@ class PublicationsControllerTest extends TestCase {
 	 * Helper to create an ObjectEntity mock that supports magic __call getters.
 	 */
 	private function createObjectEntityMock(int $id = 42, int $schema = 1, int $register = 1): \OCA\OpenRegister\Db\ObjectEntity {
-		// getId()/getSchema()/getRegister() are NOT declared on ObjectEntity — nor on
-		// its parent OCP\AppFramework\Db\Entity, which serves them through __call().
-		// onlyMethods() requires a really-declared method and throws
-		// CannotUseOnlyMethodsException for all three, so the magic surface has to be
-		// declared with addMethods(). addMethods() generates parameterless methods,
-		// which is correct here (and only here) because all three are zero-argument
-		// getters and no call site — in lib/ or in this file — ever passes them an
-		// argument.
+		// getSchema()/getRegister() became really-declared methods when OpenRegister
+		// published its ObjectService/ObjectEntity interfaces, so they need
+		// onlyMethods(). getId() is still served by OCP\AppFramework\Db\Entity::__call()
+		// and still needs addMethods(), which generates a parameterless method — correct
+		// here because no call site, in lib/ or in this file, passes it an argument.
+		//
+		// The two real getters are typed `?string`, so their return values are cast.
+		// The ids stay int parameters because every caller passes ints, but a double
+		// that returned them untyped would be looser than the class it stands for: the
+		// magic surface used to accept anything, and the tests leaned on that.
 		$mockObj = $this->getMockBuilder(\OCA\OpenRegister\Db\ObjectEntity::class)
 			->disableOriginalConstructor()
 			->onlyMethods(['getSchema', 'getRegister'])
 			->addMethods(['getId'])
 			->getMock();
 		$mockObj->method('getId')->willReturn($id);
-		$mockObj->method('getSchema')->willReturn($schema);
-		$mockObj->method('getRegister')->willReturn($register);
+		$mockObj->method('getSchema')->willReturn((string) $schema);
+		$mockObj->method('getRegister')->willReturn((string) $register);
 		return $mockObj;
 	}
 

--- a/tests/Unit/Controller/PublicationsControllerTest.php
+++ b/tests/Unit/Controller/PublicationsControllerTest.php
@@ -764,7 +764,8 @@ class PublicationsControllerTest extends TestCase {
 		// argument.
 		$mockObj = $this->getMockBuilder(\OCA\OpenRegister\Db\ObjectEntity::class)
 			->disableOriginalConstructor()
-			->addMethods(['getId', 'getSchema', 'getRegister'])
+			->onlyMethods(['getSchema', 'getRegister'])
+			->addMethods(['getId'])
 			->getMock();
 		$mockObj->method('getId')->willReturn($id);
 		$mockObj->method('getSchema')->willReturn($schema);

--- a/tests/Unit/Listener/CatalogCacheEventListenerTest.php
+++ b/tests/Unit/Listener/CatalogCacheEventListenerTest.php
@@ -36,18 +36,16 @@ class CatalogCacheEventListenerTest extends TestCase {
 		string $uuid = 'test-uuid',
 		?string $slug = 'test-slug',
 	): ObjectEntity&MockObject {
-		// ObjectEntity really declares jsonSerialize(). getUuid()/getRegister()/
-		// getSchema() are NOT declared anywhere on it — nor on its parent
-		// OCP\AppFramework\Db\Entity, which serves them through __call(). onlyMethods()
-		// requires a really-declared method and throws CannotUseOnlyMethodsException for
-		// the magic three, so the magic surface has to be declared with addMethods().
-		// addMethods() generates parameterless methods, which is correct here (and only
-		// here) because all three are zero-argument getters and no call site — in lib/
-		// or in this file — ever passes them an argument.
+		// ObjectEntity really declares jsonSerialize(), and — since OpenRegister
+		// published its ObjectService/ObjectEntity interfaces — getUuid(),
+		// getRegister() and getSchema() as well. They used to be magic, served by
+		// OCP\AppFramework\Db\Entity::__call(), and were doubled with addMethods();
+		// addMethods() now throws CannotUseAddMethodsException because the methods
+		// exist. Which builder is correct is decided by the real class, so this must
+		// move whenever it does.
 		$entity = $this->getMockBuilder(ObjectEntity::class)
 			->disableOriginalConstructor()
-			->onlyMethods(['jsonSerialize'])
-			->addMethods(['getUuid', 'getRegister', 'getSchema'])
+			->onlyMethods(['jsonSerialize', 'getUuid', 'getRegister', 'getSchema'])
 			->getMock();
 
 		$entity->method('getSchema')->willReturn($schema);

--- a/tests/Unit/Listener/CatalogSchemaEventListenerTest.php
+++ b/tests/Unit/Listener/CatalogSchemaEventListenerTest.php
@@ -287,8 +287,7 @@ class CatalogSchemaEventListenerTest extends TestCase {
 		// them an argument.
 		$entity = $this->getMockBuilder(ObjectEntity::class)
 			->disableOriginalConstructor()
-			->onlyMethods(['getObject'])
-			->addMethods(['getRegister', 'getSchema'])
+			->onlyMethods(['getObject', 'getRegister', 'getSchema'])
 			->getMock();
 		$entity->method('getSchema')->willReturn($schema);
 		$entity->method('getRegister')->willReturn($register);

--- a/tests/Unit/Listener/ObjectCreatedEventListenerTest.php
+++ b/tests/Unit/Listener/ObjectCreatedEventListenerTest.php
@@ -53,18 +53,16 @@ class ObjectCreatedEventListenerTest extends TestCase {
 			$jsonData['depublicationDate'] = $depublished->format('c');
 		}
 
-		// ObjectEntity really declares jsonSerialize(). getUuid()/getRegister()/
-		// getSchema() are NOT declared anywhere on it — nor on its parent
-		// OCP\AppFramework\Db\Entity, which serves them through __call(). onlyMethods()
-		// requires a really-declared method and throws CannotUseOnlyMethodsException for
-		// the magic three, so the magic surface has to be declared with addMethods().
-		// addMethods() generates parameterless methods, which is correct here (and only
-		// here) because all three are zero-argument getters and no call site — in lib/
-		// or in this file — ever passes them an argument.
+		// ObjectEntity really declares jsonSerialize(), and — since OpenRegister
+		// published its ObjectService/ObjectEntity interfaces — getUuid(),
+		// getRegister() and getSchema() as well. They used to be magic, served by
+		// OCP\AppFramework\Db\Entity::__call(), and were doubled with addMethods();
+		// addMethods() now throws CannotUseAddMethodsException because the methods
+		// exist. Which builder is correct is decided by the real class, so this must
+		// move whenever it does.
 		$entity = $this->getMockBuilder(ObjectEntity::class)
 			->disableOriginalConstructor()
-			->onlyMethods(['jsonSerialize'])
-			->addMethods(['getUuid', 'getRegister', 'getSchema'])
+			->onlyMethods(['jsonSerialize', 'getUuid', 'getRegister', 'getSchema'])
 			->getMock();
 
 		$entity->method('jsonSerialize')->willReturn($jsonData);

--- a/tests/Unit/Listener/ObjectUpdatedEventListenerTest.php
+++ b/tests/Unit/Listener/ObjectUpdatedEventListenerTest.php
@@ -48,18 +48,16 @@ class ObjectUpdatedEventListenerTest extends TestCase {
 			$jsonData['depublicationDate'] = $depublished->format('c');
 		}
 
-		// ObjectEntity really declares jsonSerialize(). getUuid()/getRegister()/
-		// getSchema() are NOT declared anywhere on it — nor on its parent
-		// OCP\AppFramework\Db\Entity, which serves them through __call(). onlyMethods()
-		// requires a really-declared method and throws CannotUseOnlyMethodsException for
-		// the magic three, so the magic surface has to be declared with addMethods().
-		// addMethods() generates parameterless methods, which is correct here (and only
-		// here) because all three are zero-argument getters and no call site — in lib/
-		// or in this file — ever passes them an argument.
+		// ObjectEntity really declares jsonSerialize(), and — since OpenRegister
+		// published its ObjectService/ObjectEntity interfaces — getUuid(),
+		// getRegister() and getSchema() as well. They used to be magic, served by
+		// OCP\AppFramework\Db\Entity::__call(), and were doubled with addMethods();
+		// addMethods() now throws CannotUseAddMethodsException because the methods
+		// exist. Which builder is correct is decided by the real class, so this must
+		// move whenever it does.
 		$entity = $this->getMockBuilder(ObjectEntity::class)
 			->disableOriginalConstructor()
-			->onlyMethods(['jsonSerialize'])
-			->addMethods(['getUuid', 'getRegister', 'getSchema'])
+			->onlyMethods(['jsonSerialize', 'getUuid', 'getRegister', 'getSchema'])
 			->getMock();
 
 		$entity->method('jsonSerialize')->willReturn($jsonData);


### PR DESCRIPTION
## What

Moves `getUuid()`, `getRegister()` and `getSchema()` from `addMethods()` to `onlyMethods()` in the five test doubles that build a mock of `OCA\OpenRegister\Db\ObjectEntity`, and re-syncs `tests/Stubs/OpenRegister/Db/ObjectEntity.php` so the stub declares them too.

## Why

OpenRegister published its `ObjectService`/`ObjectEntity` interfaces today. That turned those three getters from magic — routed through `OCP\AppFramework\Db\Entity::__call()` — into really-declared methods.

PHPUnit chooses its mock builder on exactly that distinction: `addMethods()` refuses a method that exists, `onlyMethods()` refuses one that doesn't. So every double built with `addMethods()` for those three now throws `CannotUseAddMethodsException`.

**This repository did not need a commit to break.** CI installs OpenRegister from its own branch, so the change arrives on its own. `development` is currently red on all 6 PHPUnit cells — verified by re-running its own last green workflow unchanged, which now fails identically.

## Scope

Only the three that actually became real are moved. `getId()`, `getSlug()` and `setObject()` are still magic on the real class and stay on `addMethods()` — `PublicationsControllerTest` therefore needs both builders on one mock, which is correct rather than an oversight.

## The stub

`tests/Stubs/OpenRegister/Db/ObjectEntity.php` stands in when OpenRegister is not installed, and its method surface has to mirror the real class. If it doesn't, the two environments disagree about which builder is legal and the result is green locally and red in CI — which is precisely the failure mode its own comment warned about, in the opposite direction. It now declares the three getters, and the comment says which way it must be kept in step when the real class moves again.

The stub returns `?string` like the real class, casting non-null values, because the magic `__call()` path it replaces returned whatever was stored without coercion.

## Verification

The real class is only present in CI, so CI is the authoritative check here — locally these tests exercise the stub, not the class that broke. Locally confirmed: all six files parse, no `addMethods()` call referencing a now-real method remains, and the remaining `addMethods()` uses target genuinely magic methods only.
