### PR TITLE
fix(lint): clear 5 of 8 tranche-A suppressions

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -245,11 +245,6 @@
       "count": 1
     }
   },
-  "src/entities/index.js": {
-    "import/export": {
-      "count": 1
-    }
-  },
   "src/entities/listing/listing.mock.ts": {
     "import-extensions/extensions": {
       "count": 1
@@ -336,9 +331,6 @@
     }
   },
   "src/main.js": {
-    "no-undef": {
-      "count": 1
-    },
     "no-unused-vars": {
       "count": 1
     }
@@ -643,9 +635,6 @@
     "no-console": {
       "count": 1
     },
-    "preserve-caught-error": {
-      "count": 1
-    },
     "vue/prefer-define-options": {
       "count": 1
     },
@@ -866,9 +855,6 @@
     "import/extensions": {
       "count": 1
     },
-    "import/no-unresolved": {
-      "count": 1
-    },
     "n/no-missing-import": {
       "count": 1
     }
@@ -882,9 +868,6 @@
     }
   },
   "src/views/dashboard/Dashboard.vue": {
-    "import/named": {
-      "count": 1
-    },
     "jsdoc/require-param-type": {
       "count": 3
     },

--- a/src/entities/index.js
+++ b/src/entities/index.js
@@ -1,4 +1,5 @@
-/* eslint-disable import/export */
+// No `eslint-disable import/export`: the flat config does not register that
+// rule, so the comment was ITSELF the error.
 export * from './attachment/index.js'
 export * from './catalogi/index.js'
 export * from './configuration/index.js'

--- a/src/main.js
+++ b/src/main.js
@@ -173,6 +173,12 @@ function tryLoadTranslations() {
 // component-options object without altering the lib's internals.
 const RoutePageRenderer = { ...CnPageRenderer }
 
+// `require.context` is a WEBPACK build-time API, not CommonJS `require`: the
+// bundler rewrites this call at compile time and no `require` exists at
+// runtime. eslint's browser globals therefore report `no-undef` correctly —
+// the code is right and the linter is right. Scoped to this one identifier so
+// a genuinely undefined name elsewhere in the file still fails.
+/* global require */
 const fragmentCtx = require.context('./manifest.d/', false, /\.json$/)
 const fragments = fragmentCtx
 	.keys()

--- a/src/modals/object/ObjectModal.vue
+++ b/src/modals/object/ObjectModal.vue
@@ -702,7 +702,9 @@ export default {
 					try {
 						dataToSave = JSON.parse(this.jsonData)
 					} catch (e) {
-						throw new Error('Invalid JSON format: ' + e.message, { cause: e })
+						throw new Error('Invalid JSON format: ' + e.message, {
+							cause: e,
+						})
 					}
 				} else {
 					dataToSave = this.formData

--- a/src/modals/object/ObjectModal.vue
+++ b/src/modals/object/ObjectModal.vue
@@ -702,7 +702,7 @@ export default {
 					try {
 						dataToSave = JSON.parse(this.jsonData)
 					} catch (e) {
-						throw new Error('Invalid JSON format: ' + e.message)
+						throw new Error('Invalid JSON format: ' + e.message, { cause: e })
 					}
 				} else {
 					dataToSave = this.formData

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -1,6 +1,8 @@
 /* eslint-disable n/no-missing-import */
-/* eslint-disable import/no-unresolved */
 /* eslint-disable import/extensions */
+// `import/no-unresolved` is NOT disabled here: the flat config does not
+// register it, so the disable comment was itself an error ("Definition for
+// rule 'import/no-unresolved' was not found").
 // fk these rules above here
 
 // The store script handles app wide variables (or state), for the use of these variables and there governing concepts read the design.md

--- a/src/views/dashboard/Dashboard.vue
+++ b/src/views/dashboard/Dashboard.vue
@@ -412,7 +412,10 @@
 </template>
 
 <script>
-// eslint-disable-next-line import/named -- CnChartWidget available in local source; will be in next npm release
+// The `import/named` disable that used to sit here is gone: the flat config
+// does not register that rule, so the comment was itself an error. Its note is
+// worth keeping though — CnChartWidget exists in the local nc-vue source and
+// ships in a later npm release.
 import {
 	buildHeaders,
 	CnChartWidget,


### PR DESCRIPTION
## What

Clears **5 of this repo's 8** tranche-A eslint suppressions — the set where a suppression can hide a real defect.

## Cleared

**Three were comments for rules that do not exist.** `import/export` (`entities/index.js`), `import/no-unresolved` (`store/store.js`) and `import/named` (`Dashboard.vue`) are not registered by the flat config, so each disable comment was *itself* the error: *"Definition for rule ... was not found."* Dashboard.vue's note about `CnChartWidget` being local-only is kept as prose — it is still true, it just was not doing anything as a disable.

**One discarded a stack trace.** `ObjectModal.vue` did `throw new Error('Invalid JSON format: ' + e.message)` inside a `catch` — the message survives, the parse error's stack does not. Now passes `{ cause: e }`.

**One was a real build-time API under a file-wide suppression.** `require.context()` in `main.js` is a webpack API rewritten at compile time, so eslint is right that no runtime `require` exists and the code is right too. Scoped to `/* global require */` rather than switching `no-undef` off for the whole entrypoint.

## Kept deliberately — 3

The remaining `no-unused-expressions` are the short-circuit idiom (`this.fetchGroups && this.fetchGroups()`), measured across the full statement: deliberate, not bare expressions. Rewriting correct control flow by hand is risk without a defect to fix.

## Verification

| check | result |
|---|---|
| `npx eslint src` | **0 errors** (569 pre-existing warnings, unchanged) |
| `npm run build` | exit 0 |
| `npm test` | **66 passed**, 15 suites |
| suppressions | 642 → **637** |
