### PR TITLE
fix(publications): fail closed when the catalog register/schema is unconfigured (gate-50: 4 → 0)

### DIFF
--- a/lib/Service/PublicationService.php
+++ b/lib/Service/PublicationService.php
@@ -254,10 +254,91 @@ class PublicationService {
 	}//end getFileService()
 
 	/**
+	 * Resolve the configured catalog register/schema pair, failing CLOSED.
+	 *
+	 * Both callers below derive the instance's entire publication visibility
+	 * scope from these two keys, so an unconfigured instance must refuse rather
+	 * than search. The read and the check that makes it safe sit adjacent on
+	 * purpose: separating them is what let both a reviewer and hydra gate-50
+	 * read the site as unguarded.
+	 *
+	 * WHY THE EMPTY DEFAULT IS NOT SELF-CORRECTING. `''` is not the same as
+	 * "absent". `MagicMapper` reads the pair with `??`, which only falls through
+	 * on null, so `''` is captured as a *present* filter, passes the
+	 * `!== null` guard, and is then cast — `find((int) '')` is `find(0)`, which
+	 * resolves nothing. Today that happens to bail out to an empty result, so
+	 * this is not a live data leak. But the refusal is BORROWED from another
+	 * app's mapper rather than stated here, and an empty string is strictly
+	 * worse than null on the paginated path, where the global-search fallbacks
+	 * are gated on `register === null && schema === null` and so are silently
+	 * suppressed by `''`. This method states the refusal locally instead.
+	 *
+	 * Empty arrays are the correct refusal rather than an exception, because
+	 * that is already the contract callers handle: setObjectServiceContext()
+	 * checks `empty($allowedRegisters) || empty($allowedSchemas)` and returns
+	 * without querying, explicitly to refuse a platform-wide scan.
+	 *
+	 * @return array{register: string, schema: string}|null The configured pair,
+	 *         or null when either key is unset — the caller must then refuse.
+	 *
+	 * @spec exclude Configuration plumbing — resolves and validates the two
+	 *       app-config keys that scope every publication query.
+	 */
+	private function resolveCatalogScope(): ?array {
+		$schema = $this->config->getValueString($this->appName, 'catalog_schema', '');
+		$register = $this->config->getValueString($this->appName, 'catalog_register', '');
+		if ($schema === '' || $register === '') {
+			return null;
+		}
+
+		return [
+			'register' => $register,
+			'schema' => $schema,
+		];
+	}//end resolveCatalogScope()
+
+	/**
+	 * Collect the unique values of one array-valued property across catalogs.
+	 *
+	 * Extracted from getCatalogFilters() so the fail-closed guard added there
+	 * does not push that method over PHPMD's NPath threshold (measured: 320
+	 * against a limit of 200). Mirrors CatalogiService::collectUnique(), which
+	 * was extracted for the same reason when the same guard landed there.
+	 *
+	 * A baseline entry would have been the wrong repair: it is scoped to
+	 * (rule, file) and would licence every future violation of that rule in
+	 * this file, including ones nobody has looked at.
+	 *
+	 * @param array<int, mixed> $catalogs The catalog objects returned by the search.
+	 * @param string $property The array-valued property to collect ('registers' | 'schemas').
+	 *
+	 * @return array<int, mixed> The de-duplicated union of that property's values.
+	 *
+	 * @spec exclude Pure collection helper extracted from getCatalogFilters();
+	 *       carries no behaviour of its own.
+	 */
+	private function collectUnique(array $catalogs, string $property): array {
+		$collected = [];
+
+		foreach ($catalogs as $catalog) {
+			$catalog = $catalog->jsonSerialize();
+			if (isset($catalog[$property]) === true && is_array($catalog[$property]) === true) {
+				$collected = array_merge($collected, $catalog[$property]);
+			}
+		}
+
+		return array_unique($collected);
+	}//end collectUnique()
+
+	/**
 	 * Get register and schema combinations from catalogs.
 	 *
 	 * This method retrieves all catalogs (or a specific one if ID is provided),
 	 * extracts their registers and schemas, and stores them as general variables.
+	 *
+	 * When the catalog register/schema pair is unconfigured this returns empty
+	 * arrays without querying — see resolveCatalogScope() for why that refusal
+	 * is stated here rather than left to the mapper.
 	 *
 	 * @param string|integer|null $catalogId Optional ID of a specific catalog to filter by
 	 *
@@ -283,15 +364,22 @@ class PublicationService {
 			return $cached['result'];
 		}
 
-		// Establish the default schema and register.
-		$schema = $this->config->getValueString($this->appName, 'catalog_schema', '');
-		$register = $this->config->getValueString($this->appName, 'catalog_register', '');
+		// FAIL CLOSED on an unconfigured catalog scope. See resolveCatalogScope().
+		$scope = $this->resolveCatalogScope();
+		if ($scope === null) {
+			$this->availableRegisters = [];
+			$this->availableSchemas = [];
+			return [
+				'registers' => [],
+				'schemas' => [],
+			];
+		}
 
 		// Setup the config array for searchObjects.
 		$query = [
 			'@self' => [
-				'register' => $register,
-				'schema' => $schema,
+				'register' => $scope['register'],
+				'schema' => $scope['schema'],
 			],
 		];
 
@@ -308,27 +396,9 @@ class PublicationService {
 			$catalogs = [$this->getObjectService()->find($catalogId)];
 		}
 
-		// Initialize arrays to store unique registers and schemas.
-		$uniqueRegisters = [];
-		$uniqueSchemas = [];
-
-		// Iterate over each catalog to extract registers and schemas.
-		foreach ($catalogs as $catalog) {
-			$catalog = $catalog->jsonSerialize();
-			// Check if 'registers' is an array and merge unique values.
-			if (isset($catalog['registers']) === true && is_array($catalog['registers']) === true) {
-				$uniqueRegisters = array_merge($uniqueRegisters, $catalog['registers']);
-			}
-
-			// Check if 'schemas' is an array and merge unique values.
-			if (isset($catalog['schemas']) === true && is_array($catalog['schemas']) === true) {
-				$uniqueSchemas = array_merge($uniqueSchemas, $catalog['schemas']);
-			}
-		}
-
 		// Remove duplicate values and assign to class properties.
-		$this->availableRegisters = array_unique($uniqueRegisters);
-		$this->availableSchemas = array_unique($uniqueSchemas);
+		$this->availableRegisters = $this->collectUnique(catalogs: $catalogs, property: 'registers');
+		$this->availableSchemas = $this->collectUnique(catalogs: $catalogs, property: 'schemas');
 
 		$result = [
 			'registers' => array_values($this->availableRegisters),
@@ -1968,9 +2038,24 @@ class PublicationService {
 		$page = (int)($queryParams['_page'] ?? $queryParams['page'] ?? 1);
 		$offset = (int)($queryParams['offset'] ?? (($page - 1) * $limit));
 
-		// Get minimal required config from cache or defaults.
-		$schema = $this->config->getValueString($this->appName, 'catalog_schema', '');
-		$register = $this->config->getValueString($this->appName, 'catalog_register', '');
+		// FAIL CLOSED on an unconfigured catalog scope, exactly as
+		// getCatalogFilters() does — see resolveCatalogScope(). This is the fast
+		// path that deliberately bypasses getCatalogFilters(), so it has to carry
+		// the same refusal; without it the bypass is also a bypass of the guard.
+		$scope = $this->resolveCatalogScope();
+		if ($scope === null) {
+			return [
+				'results' => [],
+				'total' => 0,
+				'limit' => $limit,
+				'offset' => $offset,
+				'page' => $page,
+				'pages' => 1,
+			];
+		}
+
+		$schema = $scope['schema'];
+		$register = $scope['register'];
 
 		$timings['setup'] = ((microtime(true) - $setupStart) * 1000);
 

--- a/tests/Unit/Service/PublicationServiceTest.php
+++ b/tests/Unit/Service/PublicationServiceTest.php
@@ -59,6 +59,37 @@ class PublicationServiceTest extends TestCase {
 		);
 	}
 
+	/**
+	 * Stub a CONFIGURED catalog scope — the normal state of a live instance.
+	 *
+	 * PublicationService now refuses to query when `catalog_register` or
+	 * `catalog_schema` is empty (hydra gate-50, fail closed). A fixture that
+	 * left both at '' while also stubbing searchObjects() to return a catalog
+	 * described a state OpenRegister cannot produce: an empty register/schema
+	 * is captured by `??` as a *present* filter, `find((int) '')` resolves
+	 * nothing, and MagicMapper returns an empty result — so the catalog those
+	 * fixtures handed back could never have been found. Configuring the scope
+	 * makes them model a reachable state instead.
+	 *
+	 * MUST be the FIRST getValueString stub registered on $this->config:
+	 * PHPUnit evaluates matchers in registration order and the first match
+	 * wins, so a later stub on the same method never fires.
+	 *
+	 * @return void
+	 */
+	private function mockConfiguredCatalogScope(): void {
+		$this->config->method('getValueString')
+			->willReturnCallback(
+				static function (string $app, string $key, string $default = ''): string {
+					return match ($key) {
+						'catalog_register' => 'catalog-register-1',
+						'catalog_schema' => 'catalog-schema-1',
+						default => '',
+					};
+				}
+			);
+	}
+
 	// -----------------------------------------------------------------------
 	// Helper: create a mock ObjectService
 	// -----------------------------------------------------------------------
@@ -262,6 +293,58 @@ class PublicationServiceTest extends TestCase {
 		$this->assertContains('sch-x', $result['schemas']);
 		$this->assertContains('sch-y', $result['schemas']);
 		$this->assertContains('sch-z', $result['schemas']);
+	}
+
+	/**
+	 * The catalog register/schema pair scopes every publication query, so an
+	 * unconfigured instance must REFUSE rather than search.
+	 *
+	 * These three tests are the load-bearing proof for hydra gate-50: they set
+	 * the restrictive value and watch the restrictive branch be taken. The
+	 * assertion that carries the weight is `never()` on searchObjects() —
+	 * the permissive path reaches the object service, the refusing path
+	 * cannot. Asserting only the empty return would pass either way, because a
+	 * search that resolves nothing also returns empty.
+	 *
+	 * @dataProvider provideUnconfiguredCatalogScopes
+	 *
+	 * @param string $schema The configured catalog_schema value.
+	 * @param string $register The configured catalog_register value.
+	 *
+	 * @return void
+	 */
+	public function testGetCatalogFiltersRefusesWhenScopeUnconfigured(string $schema, string $register): void {
+		$objectService = $this->createObjectServiceMock();
+		$this->mockObjectServiceAvailable($objectService);
+
+		$this->config->method('getValueString')
+			->willReturnMap([
+				['opencatalogi', 'catalog_schema', '', $schema],
+				['opencatalogi', 'catalog_register', '', $register],
+			]);
+
+		// The refusal is the point: no query may be issued at all.
+		$objectService->expects($this->never())->method('searchObjects');
+		$objectService->expects($this->never())->method('searchObjectsPaginated');
+
+		$result = $this->service->getCatalogFilters();
+
+		$this->assertSame(['registers' => [], 'schemas' => []], $result);
+		$this->assertSame([], $this->service->getAvailableRegisters());
+		$this->assertSame([], $this->service->getAvailableSchemas());
+	}
+
+	/**
+	 * Every way the catalog scope can be incomplete.
+	 *
+	 * @return array<string, array{0: string, 1: string}>
+	 */
+	public static function provideUnconfiguredCatalogScopes(): array {
+		return [
+			'neither configured' => ['', ''],
+			'register missing' => ['schema-1', ''],
+			'schema missing' => ['', 'register-1'],
+		];
 	}
 
 	public function testGetCatalogFiltersBySpecificCatalogId(): void {
@@ -505,6 +588,7 @@ class PublicationServiceTest extends TestCase {
 	// =======================================================================
 
 	public function testShowReturnsObjectWhenFound(): void {
+		$this->mockConfiguredCatalogScope();
 		$objectService = $this->createObjectServiceMock();
 		$this->mockObjectServiceAvailable($objectService);
 
@@ -529,6 +613,7 @@ class PublicationServiceTest extends TestCase {
 	}
 
 	public function testShowReturns404WhenNotFound(): void {
+		$this->mockConfiguredCatalogScope();
 		$objectService = $this->createObjectServiceMock();
 		$this->mockObjectServiceAvailable($objectService);
 
@@ -552,6 +637,7 @@ class PublicationServiceTest extends TestCase {
 	}
 
 	public function testShowWithExtendParameter(): void {
+		$this->mockConfiguredCatalogScope();
 		$objectService = $this->createObjectServiceMock();
 		$this->mockObjectServiceAvailable($objectService);
 
@@ -576,6 +662,7 @@ class PublicationServiceTest extends TestCase {
 	}
 
 	public function testShowWithExtendAsString(): void {
+		$this->mockConfiguredCatalogScope();
 		$objectService = $this->createObjectServiceMock();
 		$this->mockObjectServiceAvailable($objectService);
 
@@ -597,6 +684,7 @@ class PublicationServiceTest extends TestCase {
 	}
 
 	public function testShowFiltersNonSelfExtend(): void {
+		$this->mockConfiguredCatalogScope();
 		$objectService = $this->createObjectServiceMock();
 		$this->mockObjectServiceAvailable($objectService);
 
@@ -683,6 +771,7 @@ class PublicationServiceTest extends TestCase {
 	// =======================================================================
 
 	public function testAttachmentsReturnsFormattedFiles(): void {
+		$this->mockConfiguredCatalogScope();
 		// Need to set up both ObjectService and FileService via container
 		$objectService = $this->createObjectServiceMock();
 		$fileService = $this->createFileServiceMock();
@@ -768,6 +857,7 @@ class PublicationServiceTest extends TestCase {
 	}
 
 	public function testAttachmentsReturns500OnGenericException(): void {
+		$this->mockConfiguredCatalogScope();
 		$objectService = $this->createObjectServiceMock();
 		$fileService = $this->createFileServiceMock();
 
@@ -841,6 +931,7 @@ class PublicationServiceTest extends TestCase {
 	}
 
 	public function testDownloadReturns500OnGenericException(): void {
+		$this->mockConfiguredCatalogScope();
 		$objectService = $this->createObjectServiceMock();
 		$fileService = $this->createFileServiceMock();
 
@@ -881,6 +972,7 @@ class PublicationServiceTest extends TestCase {
 	// =======================================================================
 
 	public function testUsesReturnsEmptyWhenNoRelations(): void {
+		$this->mockConfiguredCatalogScope();
 		$objectService = $this->createObjectServiceMock();
 		$this->mockObjectServiceAvailable($objectService);
 
@@ -949,6 +1041,7 @@ class PublicationServiceTest extends TestCase {
 	 * the branch that runs when the object really is inside the configured catalogs.
 	 */
 	public function testUsesReturns404WhenObjectNotFound(): void {
+		$this->mockConfiguredCatalogScope();
 		$objectService = $this->createObjectServiceMock();
 		$this->mockObjectServiceAvailable($objectService);
 
@@ -992,6 +1085,7 @@ class PublicationServiceTest extends TestCase {
 	// =======================================================================
 
 	public function testUsedReturnsEmptyWhenNoRelations(): void {
+		$this->mockConfiguredCatalogScope();
 		$objectService = $this->createObjectServiceMock();
 		$this->mockObjectServiceAvailable($objectService);
 
@@ -1058,6 +1152,7 @@ class PublicationServiceTest extends TestCase {
 	 * used() answers 404 when an in-scope identifier resolves to nothing.
 	 */
 	public function testUsedReturns404WhenObjectNotFound(): void {
+		$this->mockConfiguredCatalogScope();
 		$objectService = $this->createObjectServiceMock();
 		$this->mockObjectServiceAvailable($objectService);
 
@@ -1199,7 +1294,7 @@ class PublicationServiceTest extends TestCase {
 		$objectService = $this->createObjectServiceMock();
 		$this->mockObjectServiceAvailable($objectService);
 
-		$this->config->method('getValueString')->willReturn('');
+		$this->mockConfiguredCatalogScope();
 
 		$catalog = $this->createSerializableObject([
 			'registers' => ['reg-1'],
@@ -1230,7 +1325,7 @@ class PublicationServiceTest extends TestCase {
 		$objectService = $this->createObjectServiceMock();
 		$this->mockObjectServiceAvailable($objectService);
 
-		$this->config->method('getValueString')->willReturn('');
+		$this->mockConfiguredCatalogScope();
 
 		$catalog = $this->createSerializableObject([
 			'registers' => ['reg-1'],
@@ -1413,6 +1508,7 @@ class PublicationServiceTest extends TestCase {
 	// =======================================================================
 
 	public function testGetFederatedPublicationFoundLocally(): void {
+		$this->mockConfiguredCatalogScope();
 		$objectService = $this->createObjectServiceMock();
 		$this->mockObjectServiceAvailable($objectService);
 
@@ -1438,7 +1534,7 @@ class PublicationServiceTest extends TestCase {
 		$objectService = $this->createObjectServiceMock();
 		$this->mockObjectServiceAvailable($objectService);
 
-		$this->config->method('getValueString')->willReturn('');
+		$this->mockConfiguredCatalogScope();
 
 		$objectService->method('find')
 			->willReturn($this->createSerializableObject(['id' => 'pub-1', '@self' => ['title' => 'Local Pub']]));
@@ -2249,7 +2345,7 @@ class PublicationServiceTest extends TestCase {
 		$objectService = $this->createObjectServiceMock();
 		$this->mockObjectServiceAvailable($objectService);
 
-		$this->config->method('getValueString')->willReturn('');
+		$this->mockConfiguredCatalogScope();
 
 		$catalog = $this->createSerializableObject([
 			'registers' => ['reg-1', 'reg-2'],
@@ -2509,6 +2605,7 @@ class PublicationServiceTest extends TestCase {
 	// =======================================================================
 
 	public function testShowWithUnderscoreExtendParameter(): void {
+		$this->mockConfiguredCatalogScope();
 		$objectService = $this->createObjectServiceMock();
 		$this->mockObjectServiceAvailable($objectService);
 
@@ -2618,7 +2715,7 @@ class PublicationServiceTest extends TestCase {
 		$objectService = $this->createObjectServiceMock();
 		$this->mockObjectServiceAvailable($objectService);
 
-		$this->config->method('getValueString')->willReturn('');
+		$this->mockConfiguredCatalogScope();
 
 		$pubObj = $this->createSerializableObject([
 			'id' => 'pub-1',
@@ -2650,7 +2747,7 @@ class PublicationServiceTest extends TestCase {
 		$objectService = $this->createObjectServiceMock();
 		$this->mockObjectServiceAvailable($objectService);
 
-		$this->config->method('getValueString')->willReturn('');
+		$this->mockConfiguredCatalogScope();
 
 		// used() now calls find() first to enforce the published predicate. Return a
 		// published object so the predicate check does not short-circuit the test.
@@ -2682,7 +2779,7 @@ class PublicationServiceTest extends TestCase {
 		$objectService = $this->createObjectServiceMock();
 		$this->mockObjectServiceAvailable($objectService);
 
-		$this->config->method('getValueString')->willReturn('');
+		$this->mockConfiguredCatalogScope();
 
 		$catalog = $this->createSerializableObject([
 			'registers' => ['single-reg'],
@@ -3621,6 +3718,7 @@ class PublicationServiceTest extends TestCase {
 	// =======================================================================
 
 	public function testDownloadReturnsZipOnSuccess(): void {
+		$this->mockConfiguredCatalogScope();
 		$objectService = $this->createObjectServiceMock();
 		$fileService = $this->createFileServiceMock();
 
@@ -3688,6 +3786,7 @@ class PublicationServiceTest extends TestCase {
 	}
 
 	public function testDownloadPropagatesMetadataPdfError(): void {
+		$this->mockConfiguredCatalogScope();
 		$objectService = $this->createObjectServiceMock();
 		$fileService = $this->createFileServiceMock();
 
@@ -3740,6 +3839,7 @@ class PublicationServiceTest extends TestCase {
 	// =======================================================================
 
 	public function testAttachmentsReturns404OnNotFoundException(): void {
+		$this->mockConfiguredCatalogScope();
 		$objectService = $this->createObjectServiceMock();
 		$fileService = $this->createFileServiceMock();
 


### PR DESCRIPTION
Closes hydra **gate-50** (`security-config-fail-mode`) in this repo: **4 → 0**.

## Before / after — the gate's own checker, both sides on the same base

gate-50's checker is an inline Python heredoc inside `run-hydra-gates.sh` (lines 7598–7832), not a `check_*.py`. I extracted it verbatim and drove it with the same file enumeration the gate uses (`_enum_tracked '(Controller|Service)[^/]*\.php$' lib`, full-repo mode).

| | findings | **files measured** | exit |
|---|---|---|---|
| base `origin/development` @ `c1d00d7b` | **4** | **46** | 1 |
| this branch | **0** | **46** | 0 |

Same 46 files on both sides, so the green is not a zero-file run. ⚠️ Both sides were re-measured **after** rebasing onto `c1d00d7b` — my first measurement was against `3a1f7b0e`, which `development` had moved 43 commits past, and three of those commits touched the very files in this PR.

The four findings, all in `lib/Service/PublicationService.php`:

```
:287 catalog_schema     :288 catalog_register    (getCatalogFilters)
:1972 catalog_schema    :1973 catalog_register   (getLocalPublicationsUltraFast)
```

## What was actually wrong — and what was NOT

These two keys scope **every publication query on the instance**. Both sites read them with an empty default and put whatever came back straight into a `searchObjects()` filter.

**This is not a live data leak, and I checked rather than assumed.** Traced end-to-end through openregister: an empty-string `@self.register` is captured by `??` as a *present* filter (`''` is not `null`), passes the `!== null` guard, and `find((int) '')` is `find(0)`, which resolves nothing — so `MagicMapper` bails out to a hardcoded empty result (`MagicMapper.php:9721-9726` for `searchObjects`, `:10055-10064` for `searchObjectsPaginated`), **before any RBAC or tenancy SQL is built**. So the instance already failed closed.

**But it failed closed by borrowing another app's mapper behaviour rather than by saying so here** — the fragile shape this fleet has been bitten by before: anyone changing that bail-out silently un-guards every caller above it. Two further reasons the borrowed guarantee is not good enough:

- 🔑 **`''` is strictly worse than `null` on the paginated path.** The global `_search`, `_relations_contains` and `_ids` fallbacks are all gated on `registerId === null && schemaId === null`, so an empty string **suppresses** searches a `null` would have run. An unset config silently disables fallbacks nobody knows are there.
- The app cannot distinguish "not configured" from "configured, no catalogues", and pays a pointless round-trip to find out.

## The fix is this repo's own established pattern, not an invention

`resolveCatalogScope()` reads both keys and returns `null` when either is empty; both call sites then refuse. That is exactly what two sibling methods in this same repo already do for these same two keys:

- `CatalogiService::getCatalogFilters()` — the direct twin, guarded earlier with the same shape;
- `DcatService::getDcatEnabledCatalogs()` (`lib/Service/DcatService.php:576-580`) — `if ($register === '' || $schema === '') { return []; }`.

Empty arrays are the right refusal rather than an exception, because that is already the contract callers handle: `setObjectServiceContext()` checks `empty($allowedRegisters) || empty($allowedSchemas)` and returns without querying, explicitly to refuse a platform-wide scan.

`getLocalPublicationsUltraFast()` gets the same guard because it is the fast path that deliberately **bypasses** `getCatalogFilters()` — without it, the bypass is also a bypass of the guard.

## The proof: I watched the restrictive branch be taken

Three new cases (`testGetCatalogFiltersRefusesWhenScopeUnconfigured`, data-provided over *neither / register missing / schema missing*). The load-bearing assertion is **`never()` on `searchObjects()`** — asserting only the empty return would pass either way, because a search that resolves nothing also returns empty.

**Positive control — the tests were run against the unguarded code first and all three FAILED**, for the right reason:

```
OCA\OpenRegister\Service\ObjectService::searchObjects([...]): array|int was not expected to be called.
/lib/Service/PublicationService.php:302
```

That is the old code issuing the unscoped query. With the guard: `OK (3 tests, 12 assertions)`.

## Blast radius — 24 fixtures, and why correcting them is not weakening them

The guard initially failed **23 existing tests**. Every one stubbed `getValueString => ''` *and* stubbed `searchObjects` to hand back a catalog — a combination **OpenRegister cannot produce**, since an empty register/schema resolves nothing. Those fixtures described an unreachable state.

They now call a `mockConfiguredCatalogScope()` helper that stubs a configured scope (the normal state of a live instance) and `''` for every other key, so no other behaviour moves. ⚠️ Recorded in the helper's docblock because it is a real trap: **PHPUnit evaluates stub matchers in registration order and the first match wins**, so this helper must be registered before any other `getValueString` stub — I verified that empirically rather than assuming it.

## Verification — every leg, base vs branch, same commands

| check | base `c1d00d7b` | this branch |
|---|---|---|
| gate-50 | **4** findings / 46 files, exit 1 | **0** / 46 files, exit 0 |
| PHPUnit `Unit Tests` | 1345 tests, **0 failures**, 2 skipped | 1348 tests, **0 failures**, 2 skipped |
| phpcs `PublicationService.php` | 15 errors, 2 warnings | **15 errors, 2 warnings** (no new) |
| phpmd (both rulesets, baselined) | RC=0 | **RC=0** |
| phpstan | — | **RC=0, "No errors"** |
| psalm | — | **RC=0, "No errors found!"** |

The +3 tests are exactly the new data-provider cases. The 15 phpcs errors are pre-existing named-parameter findings in this 4 000-line file; I added 2 and removed them again by writing `collectUnique(catalogs: …, property: …)`.

⚠️ **`collectUnique()` is not gratuitous.** The guard alone pushed `getCatalogFilters()` to an **NPath of 320 against a threshold of 200** and turned phpmd red — the same trap that reddened procest#855. Extracting the collection loop restores RC=0, and it mirrors `CatalogiService::collectUnique()`, which was extracted for exactly this reason when the same guard landed there. A phpmd baseline entry would have been the wrong repair: it is scoped to (rule, file) and would licence every future violation of that rule in this file.

⚠️ **Unit tests here cannot run in a bare checkout** — `nextcloud/ocp` declares no autoload section, so `OCP\IAppConfig` does not exist and every test *errors* rather than fails. They were run inside a Nextcloud tree with openregister mounted.

## Deliberately NOT done

- **No logger on the refusal.** `PublicationService` injects none, and adding `LoggerInterface` is a new class reference on an already-large class — the PHPMD `CouplingBetweenObjects` threshold is 13 and a `mixed` hint alone once cost +1 and reddened CI. openregister already logs this condition. Flagging it as a real gap: an operator currently sees "no publications" with no local signal.
- **The 15 pre-existing phpcs errors** in this file are untouched. They come from the locally vendored coding-standard; opencatalogi's `PHP Quality` job is not in the fleet's failing set, so I did not want to "fix" 15 call sites against a standard I could not confirm CI runs.
- **`authorization: null`.** This repo ships **26 `"authorization"` keys, 10 of them `null`**, and openregister treats a null block as open to any authenticated user. That is a real and separate issue — note `PublicationService.php:825` already documents this exact mechanism and `isObjectInCatalogScope()` was added to defend against it. **None of the 4 gate-50 findings are that shape**: all four are `IAppConfig::getValueString` reads, and `PublicationService.php` contains no `authorization` block. I did not touch one.

## Base parity

Baseline: opencatalogi's gate state on `development` is currently **UNKNOWN** — its newest completed run returns `jobs=0` (unreadable, not green) and the run before it has `Hydra Gates` and `E2E` both **`cancelled`**, which is no evidence either way. Gate parity here is therefore established **locally, with the gate's own checker, run against `c1d00d7b` and against this branch**, as tabulated above — not inferred from CI.
