### PR TITLE
chore(deps): raise hydra-gates to v1.8.0 so gates 65-84 exist locally

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -3927,16 +3927,16 @@
         },
         {
             "name": "conduction/hydra-gates",
-            "version": "v1.7.3",
+            "version": "v1.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ConductionNL/.github.git",
-                "reference": "9b9896abf87167e97b821d8ee86c5422f0b32e80"
+                "reference": "9fc64ab93f7a20b69f6b5912745ef9fc456c1cee"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ConductionNL/.github/zipball/9b9896abf87167e97b821d8ee86c5422f0b32e80",
-                "reference": "9b9896abf87167e97b821d8ee86c5422f0b32e80",
+                "url": "https://api.github.com/repos/ConductionNL/.github/zipball/9fc64ab93f7a20b69f6b5912745ef9fc456c1cee",
+                "reference": "9fc64ab93f7a20b69f6b5912745ef9fc456c1cee",
                 "shasum": ""
             },
             "require": {
@@ -3951,6 +3951,11 @@
                     "runner": "hydra-gates/scripts/run-hydra-gates.sh",
                     "helpers": "hydra-gates/scripts/lib",
                     "schemas": "hydra-gates/scripts/schemas"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "OCA\\OpenRegister\\Contract\\": "hydra-gates/contracts/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -3975,9 +3980,9 @@
             "support": {
                 "docs": "https://github.com/ConductionNL/.github/blob/main/hydra-gates/README.md",
                 "issues": "https://github.com/ConductionNL/.github/issues",
-                "source": "https://github.com/ConductionNL/.github/tree/v1.7.3"
+                "source": "https://github.com/ConductionNL/.github/tree/v1.8.0"
             },
-            "time": "2026-08-12T22:32:31+00:00"
+            "time": "2026-08-15T06:24:48+00:00"
         },
         {
             "name": "consolidation/annotated-command",
@@ -9950,9 +9955,9 @@
         "php": "^8.3",
         "ext-zip": "*"
     },
-    "platform-dev": {},
+    "platform-dev": [],
     "platform-overrides": {
         "php": "8.3"
     },
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
`conduction/hydra-gates` was locked at **v1.7.3** here. That release's
`run-hydra-gates.sh` stops at **gate-64**, so gates 65–84 — including
**gate-66 `openregister-dependency-shape`**, which this fleet is currently
failing on — could not be run locally at all. CI floats on `.github@main` and
runs them regardless, so the vendored copy was measuring something narrower
than the thing that decides the build.

v1.8.0 also adds an autoload mapping the older release does not have:

```
"OCA\\OpenRegister\\Contract\\": "hydra-gates/contracts/"
```

and ships `ObjectServiceInterface` and `ObjectEntityInterface` in the package.
Those interfaces are **absent at v1.7.3**, which is a large part of why apps
have been hand-rolling contract stubs for ADR-084 instead of type-hinting the
published thing.

Constraint is already `^1.0`, so this is a lock-only change — verified that no
package other than `conduction/hydra-gates` moved. Nothing else in the tree is
touched.

Eight apps in the fleet were already on v1.8.0 (openregister, docudesk,
procest, softwarecatalog, pipelinq, shillinq, decidesk, openbuild); this brings
the rest into line.
