### PR TITLE
style: clear Frontend Check (format), and the two eslint import-spacing errors

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -47,11 +47,9 @@ import customComponents from './registry.js'
 import 'gridstack/dist/gridstack.min.css'
 // Library CSS — must be explicit import (webpack tree-shakes side-effect imports from aliased packages)
 import '@conduction/nextcloud-vue/css/index.css'
-
 // Bump vue-select's dropdown z-index above NcDialog's modal — see the file's
 // own comment for the upstream stacking-order bug this compensates for.
 import './css/vue-select-dialog-z-fix.css'
-
 import '@kangc/v-md-editor/lib/style/base-editor.css'
 import '@kangc/v-md-editor/lib/theme/style/github.css'
 library.add(fas, fab, far)

--- a/src/views/catalogi/CatalogiIndex.vue
+++ b/src/views/catalogi/CatalogiIndex.vue
@@ -2,7 +2,9 @@
 	<CnIndexPage
 		ref="indexPage"
 		:title="t('opencatalogi', 'Catalogs')"
-		:description="t('opencatalogi', 'Manage your data catalogs and their configurations')"
+		:description="
+			t('opencatalogi', 'Manage your data catalogs and their configurations')
+		"
 		:show-title="true"
 		:schema="schema"
 		:objects="currentObjects"
@@ -41,14 +43,23 @@
 		@view="viewCatalog">
 		<template #below-header>
 			<NcNoteCard v-if="loaded && !isAdmin" type="info">
-				{{ t('opencatalogi', 'This page is read-only. Only administrators can create, edit, or delete entries here.') }}
+				{{
+					t(
+						'opencatalogi',
+						'This page is read-only. Only administrators can create, edit, or delete entries here.',
+					)
+				}}
 			</NcNoteCard>
 		</template>
 
 		<!-- Custom column: visibility badge -->
 		<template #column-listed="{ row }">
 			<CnStatusBadge
-				:label="row.listed ? t('opencatalogi', 'Public') : t('opencatalogi', 'Private')"
+				:label="
+					row.listed
+						? t('opencatalogi', 'Public')
+						: t('opencatalogi', 'Private')
+				"
 				:color-map="visibilityColorMap" />
 		</template>
 
@@ -92,12 +103,33 @@ export default {
 	},
 	setup() {
 		const sidebarState = inject('sidebarState', null)
-		const { schema, sortKey, sortOrder, visibleColumns, onSort, onPageChange, onPageSizeChange, refresh } = useListView('catalog', {
+		const {
+			schema,
+			sortKey,
+			sortOrder,
+			visibleColumns,
+			onSort,
+			onPageChange,
+			onPageSizeChange,
+			refresh,
+		} = useListView('catalog', {
 			sidebarState,
 			objectStore,
 		})
 		const { isAdmin, loaded } = useIsAdmin()
-		return { schema, sortKey, sortOrder, visibleColumns, onSort, onPageChange, onPageSizeChange, refresh, objectStore, isAdmin, loaded }
+		return {
+			schema,
+			sortKey,
+			sortOrder,
+			visibleColumns,
+			onSort,
+			onPageChange,
+			onPageSizeChange,
+			refresh,
+			objectStore,
+			isAdmin,
+			loaded,
+		}
 	},
 	data() {
 		return {
@@ -157,7 +189,11 @@ export default {
 		tableColumns() {
 			return [
 				{ key: 'title', label: t('opencatalogi', 'Title'), sortable: true },
-				{ key: 'listed', label: t('opencatalogi', 'Status'), sortable: true },
+				{
+					key: 'listed',
+					label: t('opencatalogi', 'Status'),
+					sortable: true,
+				},
 				{ key: 'registers', label: t('opencatalogi', 'Registers') },
 				{ key: 'schemas', label: t('opencatalogi', 'Schemas') },
 				{ key: 'organization', label: t('opencatalogi', 'Organization') },
@@ -171,8 +207,14 @@ export default {
 			return collection?.results || []
 		},
 		currentPagination() {
-			return objectStore.getPagination('catalog')
-				|| { total: 0, page: 1, pages: 1, limit: 20 }
+			return (
+				objectStore.getPagination('catalog') || {
+					total: 0,
+					page: 1,
+					pages: 1,
+					limit: 20,
+				}
+			)
 		},
 	},
 	methods: {
@@ -208,7 +250,10 @@ export default {
 		onRowClick(row) {
 			const id = resolveObjectId(row)
 			if (id) {
-				this.$router.push({ name: 'CatalogDetail', params: { id: String(id) } })
+				this.$router.push({
+					name: 'CatalogDetail',
+					params: { id: String(id) },
+				})
 				return
 			}
 			// No id resolvable — log the row so misshapen payloads surface
@@ -226,11 +271,17 @@ export default {
 		viewCatalog(catalog) {
 			const id = resolveObjectId(catalog)
 			if (id) {
-				this.$router.push({ name: 'CatalogDetail', params: { id: String(id) } })
+				this.$router.push({
+					name: 'CatalogDetail',
+					params: { id: String(id) },
+				})
 				return
 			}
 			// eslint-disable-next-line no-console
-			console.warn('[opencatalogi] viewCatalog: no id resolvable from row', catalog)
+			console.warn(
+				'[opencatalogi] viewCatalog: no id resolvable from row',
+				catalog,
+			)
 		},
 		editCatalog(catalog) {
 			objectStore.setActiveObject('catalog', catalog)
@@ -241,14 +292,23 @@ export default {
 		},
 		copyCatalog(catalog) {
 			objectStore.setActiveObject('catalog', catalog)
-			navigationStore.setDialog('copyObject', { objectType: 'catalog', dialogTitle: 'Catalogus' })
+			navigationStore.setDialog('copyObject', {
+				objectType: 'catalog',
+				dialogTitle: 'Catalogus',
+			})
 		},
 		deleteCatalog(catalog) {
 			objectStore.setActiveObject('catalog', catalog)
-			navigationStore.setDialog('deleteObject', { objectType: 'catalog', dialogTitle: 'Catalogus' })
+			navigationStore.setDialog('deleteObject', {
+				objectType: 'catalog',
+				dialogTitle: 'Catalogus',
+			})
 		},
 		getOrganizationName(organizationId) {
-			const organization = objectStore.getObject('organization', organizationId)
+			const organization = objectStore.getObject(
+				'organization',
+				organizationId,
+			)
 			return organization?.name || 'Unknown Organization'
 		},
 	},

--- a/src/views/directory/FederationDirectory.vue
+++ b/src/views/directory/FederationDirectory.vue
@@ -358,7 +358,8 @@ export default {
 
 		<!-- Always render — CnPagination hides itself when a single page fits.
 		     Mirrors the FederationSearch pattern for cross-page consistency. -->
-		<CnPagination v-if="!loading && !error"
+		<CnPagination
+			v-if="!loading && !error"
 			:current-page="page"
 			:total-pages="pages"
 			:total-items="total"

--- a/src/views/settings/Settings.vue
+++ b/src/views/settings/Settings.vue
@@ -366,7 +366,12 @@
 
 		<NcSettingsSection
 			:name="t('opencatalogi', 'Federation sync')"
-			:description="t('opencatalogi', 'Configure how often the app synchronizes with federation peers')">
+			:description="
+				t(
+					'opencatalogi',
+					'Configure how often the app synchronizes with federation peers',
+				)
+			">
 			<div v-if="!loadingSyncOptions" class="sync-options">
 				<div class="option-section">
 					<div class="sync-interval-row">
@@ -377,19 +382,36 @@
 							:max="syncOptions.maxMinutes"
 							:label="t('opencatalogi', 'Sync interval (minutes)')"
 							:disabled="savingSyncOptions" />
-						<span :title="t('opencatalogi', 'Recommended: 60 minutes. Lower values are only useful for debugging or fast-moving networks and put unnecessary load on peer directories.')"
+						<span
+							:title="
+								t(
+									'opencatalogi',
+									'Recommended: 60 minutes. Lower values are only useful for debugging or fast-moving networks and put unnecessary load on peer directories.',
+								)
+							"
 							class="sync-interval-info"
 							role="img"
-							:aria-label="t('opencatalogi', 'Recommended: 60 minutes. Lower values are only useful for debugging or fast-moving networks and put unnecessary load on peer directories.')">
+							:aria-label="
+								t(
+									'opencatalogi',
+									'Recommended: 60 minutes. Lower values are only useful for debugging or fast-moving networks and put unnecessary load on peer directories.',
+								)
+							">
 							<InformationOutline :size="20" />
 						</span>
 					</div>
 					<p class="option-description">
-						{{ t('opencatalogi', 'Allowed range: {min}–{max} minutes. Default: {default} minutes.', {
-							min: syncOptions.minMinutes,
-							max: syncOptions.maxMinutes,
-							default: syncOptions.defaultMinutes,
-						}) }}
+						{{
+							t(
+								'opencatalogi',
+								'Allowed range: {min}–{max} minutes. Default: {default} minutes.',
+								{
+									min: syncOptions.minMinutes,
+									max: syncOptions.maxMinutes,
+									default: syncOptions.defaultMinutes,
+								},
+							)
+						}}
 					</p>
 				</div>
 
@@ -419,7 +441,8 @@
 			</div>
 
 			<!-- Loading State -->
-			<NcLoadingIcon v-else
+			<NcLoadingIcon
+				v-else
 				class="loading-icon"
 				:size="64"
 				appearance="dark" />
@@ -1413,9 +1436,12 @@ export default defineComponent({
 		async loadSyncOptions() {
 			this.loadingSyncOptions = true
 			try {
-				const response = await fetch('/index.php/apps/opencatalogi/api/settings/sync', {
-					headers: { 'OCS-APIRequest': 'true' },
-				})
+				const response = await fetch(
+					'/index.php/apps/opencatalogi/api/settings/sync',
+					{
+						headers: { 'OCS-APIRequest': 'true' },
+					},
+				)
 				const data = await response.json()
 
 				if (!data.error) {
@@ -1423,7 +1449,9 @@ export default defineComponent({
 						intervalMinutes: Math.round(data.sync_interval_seconds / 60),
 						minMinutes: Math.round(data.min_interval_seconds / 60),
 						maxMinutes: Math.round(data.max_interval_seconds / 60),
-						defaultMinutes: Math.round(data.default_interval_seconds / 60),
+						defaultMinutes: Math.round(
+							data.default_interval_seconds / 60,
+						),
 					}
 				}
 			} catch (error) {
@@ -1446,25 +1474,36 @@ export default defineComponent({
 			this.savingSyncOptions = true
 			try {
 				const minutes = Number.parseInt(this.syncOptions.intervalMinutes, 10)
-				const seconds = Number.isFinite(minutes) ? minutes * 60 : this.syncOptions.defaultMinutes * 60
+				const seconds = Number.isFinite(minutes)
+					? minutes * 60
+					: this.syncOptions.defaultMinutes * 60
 
-				const response = await fetch('/index.php/apps/opencatalogi/api/settings/sync', {
-					method: 'POST',
-					headers: {
-						'Content-Type': 'application/json',
-						'OCS-APIRequest': 'true',
+				const response = await fetch(
+					'/index.php/apps/opencatalogi/api/settings/sync',
+					{
+						method: 'POST',
+						headers: {
+							'Content-Type': 'application/json',
+							'OCS-APIRequest': 'true',
+						},
+						body: JSON.stringify({ sync_interval_seconds: seconds }),
 					},
-					body: JSON.stringify({ sync_interval_seconds: seconds }),
-				})
+				)
 				const data = await response.json()
 
 				if (data.error) {
-					showError(this.t('opencatalogi', 'Failed to save sync options') + ': ' + data.error)
+					showError(
+						this.t('opencatalogi', 'Failed to save sync options')
+							+ ': '
+							+ data.error,
+					)
 					return
 				}
 
 				// Reflect the post-clamp value the backend actually persisted.
-				this.syncOptions.intervalMinutes = Math.round(data.sync_interval_seconds / 60)
+				this.syncOptions.intervalMinutes = Math.round(
+					data.sync_interval_seconds / 60,
+				)
 				showSuccess(this.t('opencatalogi', 'Sync options saved'))
 			} catch (error) {
 				console.error('Failed to save sync options:', error)
@@ -1487,32 +1526,49 @@ export default defineComponent({
 		async syncDirectoriesNow() {
 			this.syncingDirectories = true
 			try {
-				const response = await fetch('/index.php/apps/opencatalogi/api/listings/sync', {
-					method: 'POST',
-					headers: {
-						'Content-Type': 'application/json',
-						'OCS-APIRequest': 'true',
+				const response = await fetch(
+					'/index.php/apps/opencatalogi/api/listings/sync',
+					{
+						method: 'POST',
+						headers: {
+							'Content-Type': 'application/json',
+							'OCS-APIRequest': 'true',
+						},
 					},
-				})
+				)
 				const data = await response.json()
 
 				if (!response.ok || data.error) {
-					showError(this.t('opencatalogi', 'Failed to synchronize directories') + ': ' + (data.message || data.error || response.statusText))
+					showError(
+						this.t('opencatalogi', 'Failed to synchronize directories')
+							+ ': '
+							+ (data.message || data.error || response.statusText),
+					)
 					return
 				}
 
 				const synced = data.synced_directories ?? 0
 				const failed = data.failed_directories ?? 0
-				const total = data.total_directories ?? (synced + failed)
+				const total = data.total_directories ?? synced + failed
 
-				showSuccess(this.t('opencatalogi', 'Directories synchronized: {synced} of {total} succeeded, {failed} failed', {
-					synced,
-					total,
-					failed,
-				}))
+				showSuccess(
+					this.t(
+						'opencatalogi',
+						'Directories synchronized: {synced} of {total} succeeded, {failed} failed',
+						{
+							synced,
+							total,
+							failed,
+						},
+					),
+				)
 			} catch (error) {
 				console.error('Failed to synchronize directories:', error)
-				showError(this.t('opencatalogi', 'Failed to synchronize directories') + ': ' + error.message)
+				showError(
+					this.t('opencatalogi', 'Failed to synchronize directories')
+						+ ': '
+						+ error.message,
+				)
 			} finally {
 				this.syncingDirectories = false
 			}


### PR DESCRIPTION
`prettier --check` over the job's own glob now reports every matched file clean (three views were failing). `src/main.js` had the two `Extra spacing between …` import errors, which `eslint --fix` resolves safely.

### What I deliberately did not do — the eslint job stays red

The remaining **73 errors are all `vue/attribute-hyphenation`** on shared nc-vue components (`:show-title` wanting `:showTitle`). `eslint src --fix` does not fix them cleanly — it takes the count from **73 errors to 503** across 62 files, and the new ones aren't cosmetic:

| count | error |
|---:|---|
| 45 | `'NcButton' was used before it was defined` |
| 37 | `'NcLoadingIcon' was used before it was defined` |
| 33 | `'NcNoteCard' was used before it was defined` |
| 14 | `defineOptions() cannot be used to declare props` |

That's an autofix changing **meaning**, not layout — it reorders declarations and rewrites component options. Running prettier afterwards reconciles formatting and leaves all 503, so it isn't a formatter conflict.

The hyphenation debt is left standing and visible rather than 'fixed' into 143 use-before-define errors. It wants doing per-file with the render checked.