### PR TITLE
fix(eslint): the last 43 errors — zero errors now

### DIFF
--- a/src/views/catalogi/CatalogiIndex.vue
+++ b/src/views/catalogi/CatalogiIndex.vue
@@ -81,18 +81,18 @@
 </template>
 
 <script>
-import { inject } from 'vue'
+import { CnIndexPage, CnStatusBadge, useListView } from '@conduction/nextcloud-vue'
 import { translate as t } from '@nextcloud/l10n'
-import { useListView, CnIndexPage, CnStatusBadge } from '@conduction/nextcloud-vue'
-import { objectStore, navigationStore } from '../../store/store.js'
 import { NcNoteCard } from '@nextcloud/vue'
+import { inject } from 'vue'
+import ContentCopy from 'vue-material-design-icons/ContentCopy.vue'
+import Eye from 'vue-material-design-icons/Eye.vue'
+import OpenInApp from 'vue-material-design-icons/OpenInApp.vue'
+import Pencil from 'vue-material-design-icons/Pencil.vue'
+import TrashCanOutline from 'vue-material-design-icons/TrashCanOutline.vue'
 import { useIsAdmin } from '../../composables/useIsAdmin.js'
 import { resolveObjectId } from '../../services/resolveObjectId.js'
-import Eye from 'vue-material-design-icons/Eye.vue'
-import Pencil from 'vue-material-design-icons/Pencil.vue'
-import OpenInApp from 'vue-material-design-icons/OpenInApp.vue'
-import ContentCopy from 'vue-material-design-icons/ContentCopy.vue'
-import TrashCanOutline from 'vue-material-design-icons/TrashCanOutline.vue'
+import { navigationStore, objectStore } from '../../store/store.js'
 
 export default {
 	name: 'CatalogiIndex',
@@ -101,6 +101,7 @@ export default {
 		CnStatusBadge,
 		NcNoteCard,
 	},
+
 	setup() {
 		const sidebarState = inject('sidebarState', null)
 		const {
@@ -131,6 +132,7 @@ export default {
 			loaded,
 		}
 	},
+
 	data() {
 		return {
 			selectedIds: [],
@@ -142,6 +144,7 @@ export default {
 			},
 		}
 	},
+
 	computed: {
 		/**
 		 * Row actions as data rather than a #row-actions slot. CnIndexPage feeds
@@ -199,6 +202,7 @@ export default {
 				{ key: 'organization', label: t('opencatalogi', 'Organization') },
 			]
 		},
+
 		currentObjects() {
 			// useListView expects collections[type] to be an array;
 			// OpenCatalogi's store wraps it in { results: [] }
@@ -206,6 +210,7 @@ export default {
 			if (Array.isArray(collection)) return collection
 			return collection?.results || []
 		},
+
 		currentPagination() {
 			return (
 				objectStore.getPagination('catalog') || {
@@ -217,6 +222,7 @@ export default {
 			)
 		},
 	},
+
 	methods: {
 		/**
 		 * Refresh, driving the spinner via `isRefreshing`. CnIndexPage only
@@ -233,13 +239,16 @@ export default {
 				this.isRefreshing = false
 			}
 		},
+
 		onAdd() {
 			objectStore.clearActiveObject('catalog')
 			navigationStore.setModal('catalog')
 		},
+
 		onSelect(ids) {
 			this.selectedIds = ids
 		},
+
 		/**
 		 * Open the clicked row's catalog detail page by route id.
 		 *
@@ -261,6 +270,7 @@ export default {
 			// eslint-disable-next-line no-console
 			console.warn('[opencatalogi] onRowClick: no id resolvable from row', row)
 		},
+
 		/**
 		 * Open a catalog's detail page from the row action menu.
 		 *
@@ -283,13 +293,16 @@ export default {
 				catalog,
 			)
 		},
+
 		editCatalog(catalog) {
 			objectStore.setActiveObject('catalog', catalog)
 			navigationStore.setModal('catalog')
 		},
+
 		openCatalog(catalog) {
 			this.$router.push(`/publications/${catalog?.slug}`)
 		},
+
 		copyCatalog(catalog) {
 			objectStore.setActiveObject('catalog', catalog)
 			navigationStore.setDialog('copyObject', {
@@ -297,6 +310,7 @@ export default {
 				dialogTitle: 'Catalogus',
 			})
 		},
+
 		deleteCatalog(catalog) {
 			objectStore.setActiveObject('catalog', catalog)
 			navigationStore.setDialog('deleteObject', {
@@ -304,6 +318,7 @@ export default {
 				dialogTitle: 'Catalogus',
 			})
 		},
+
 		getOrganizationName(organizationId) {
 			const organization = objectStore.getObject(
 				'organization',

--- a/src/views/directory/FederationDirectory.vue
+++ b/src/views/directory/FederationDirectory.vue
@@ -8,10 +8,10 @@
 // on the empty state. Modal-open flags use a `federation…` prefix to
 // avoid colliding with the legacy AddDirectoryModal / EditListing keys.
 
+import { CnPagination } from '@conduction/nextcloud-vue'
 import { translate as t } from '@nextcloud/l10n'
 import { generateUrl } from '@nextcloud/router'
 import { NcActionButton, NcActions, NcButton } from '@nextcloud/vue'
-import { CnPagination } from '@conduction/nextcloud-vue'
 import DeleteOutline from 'vue-material-design-icons/DeleteOutline.vue'
 import DotsHorizontal from 'vue-material-design-icons/DotsHorizontal.vue'
 import PencilOutline from 'vue-material-design-icons/PencilOutline.vue'
@@ -128,6 +128,7 @@ export default {
 				this.loading = false
 			}
 		},
+
 		/** @spec exclude presentation-only pagination */
 		onPageChange(newPage) {
 			this.page = newPage

--- a/src/views/settings/Settings.vue
+++ b/src/views/settings/Settings.vue
@@ -452,10 +452,6 @@
 
 <script>
 import { CnAdminSettingsShell } from '@conduction/nextcloud-vue'
-import { showSuccess, showError } from '@nextcloud/dialogs'
-import '@nextcloud/dialogs/style.css'
-import Sync from 'vue-material-design-icons/Sync.vue'
-import InformationOutline from 'vue-material-design-icons/InformationOutline.vue'
 // Every state-changing call below goes through @nextcloud/axios rather than a
 // bare fetch(). It attaches the `requesttoken` header Nextcloud's
 // SecurityMiddleware checks, which is what lets the settings write endpoints
@@ -466,6 +462,7 @@ import InformationOutline from 'vue-material-design-icons/InformationOutline.vue
 // axios also rejects on a non-2xx status, which the previous `await fetch(...)`
 // calls did not check at all: a 403 or 500 was indistinguishable from a save.
 import axios from '@nextcloud/axios'
+import { showError, showSuccess } from '@nextcloud/dialogs'
 import { generateUrl } from '@nextcloud/router'
 import {
 	NcButton,
@@ -480,8 +477,12 @@ import { defineComponent } from 'vue'
 import CheckCircle from 'vue-material-design-icons/CheckCircle.vue'
 import CloseCircle from 'vue-material-design-icons/CloseCircle.vue'
 import Save from 'vue-material-design-icons/ContentSave.vue'
+import InformationOutline from 'vue-material-design-icons/InformationOutline.vue'
 import MinusCircle from 'vue-material-design-icons/MinusCircle.vue'
 import Refresh from 'vue-material-design-icons/Refresh.vue'
+import Sync from 'vue-material-design-icons/Sync.vue'
+
+import '@nextcloud/dialogs/style.css'
 
 /**
  * @class Settings
@@ -728,6 +729,7 @@ export default defineComponent({
 
 				this.loading = false
 			} catch (error) {
+				// eslint-disable-next-line no-console
 				console.error('Failed to load settings:', error)
 				this.loading = false
 			}
@@ -1069,6 +1071,7 @@ export default defineComponent({
 					configToSave,
 				)
 			} catch (error) {
+				// eslint-disable-next-line no-console
 				console.error('Failed to save settings:', error)
 			} finally {
 				this.saving = false
@@ -1136,6 +1139,7 @@ export default defineComponent({
 				const result = response.data
 
 				if (result.error) {
+					// eslint-disable-next-line no-console
 					console.error('Failed to save publishing options:', result.error)
 				} else {
 					// Update local state with the response from the backend
@@ -1147,6 +1151,7 @@ export default defineComponent({
 					}
 				}
 			} catch (error) {
+				// eslint-disable-next-line no-console
 				console.error('Failed to save publishing options:', error)
 			} finally {
 				this.saving = false
@@ -1170,11 +1175,13 @@ export default defineComponent({
 				if (!data.error) {
 					this.versionInfo = data
 				} else {
+					// eslint-disable-next-line no-console
 					console.error('Failed to load version info:', data.error)
 				}
 
 				this.loadingVersionInfo = false
 			} catch (error) {
+				// eslint-disable-next-line no-console
 				console.error('Failed to load version info:', error)
 				this.loadingVersionInfo = false
 			}
@@ -1209,6 +1216,7 @@ export default defineComponent({
 					await Promise.all([this.loadVersionInfo(), this.loadSettings()])
 				}
 			} catch (error) {
+				// eslint-disable-next-line no-console
 				console.error('Failed to perform manual import:', error)
 				this.importResult = {
 					success: false,
@@ -1236,6 +1244,7 @@ export default defineComponent({
 				const data = await response.json()
 				this.wooReadinessReport = data.report || null
 			} catch (error) {
+				// eslint-disable-next-line no-console
 				console.error('Failed to load Woo readiness report:', error)
 			}
 		},
@@ -1274,6 +1283,7 @@ export default defineComponent({
 					return
 				}
 
+				// eslint-disable-next-line no-console
 				console.error('Failed to run Woo readiness check:', error)
 				this.wooReadinessError = this.t(
 					'opencatalogi',
@@ -1303,6 +1313,7 @@ export default defineComponent({
 					woo_index_registration_at: this.registration.registeredAt,
 				})
 			} catch (error) {
+				// eslint-disable-next-line no-console
 				console.error('Failed to save Woo-index registration status:', error)
 			} finally {
 				this.savingRegistration = false
@@ -1455,6 +1466,7 @@ export default defineComponent({
 					}
 				}
 			} catch (error) {
+				// eslint-disable-next-line no-console
 				console.error('Failed to load sync options:', error)
 			} finally {
 				this.loadingSyncOptions = false
@@ -1506,6 +1518,7 @@ export default defineComponent({
 				)
 				showSuccess(this.t('opencatalogi', 'Sync options saved'))
 			} catch (error) {
+				// eslint-disable-next-line no-console
 				console.error('Failed to save sync options:', error)
 				showError(this.t('opencatalogi', 'Failed to save sync options'))
 			} finally {
@@ -1563,6 +1576,7 @@ export default defineComponent({
 					),
 				)
 			} catch (error) {
+				// eslint-disable-next-line no-console
 				console.error('Failed to synchronize directories:', error)
 				showError(
 					this.t('opencatalogi', 'Failed to synchronize directories')


### PR DESCRIPTION
`eslint src` reports **0 errors** (567 warnings remain; the job allows those). prettier clean. **No pre-existing suppression removed**, 13 added.

- **17 in CatalogiIndex.vue** — `--fix` on that one file, then verified: 23 → 0, both suppressions intact, every non-import change a blank line.
- **2 in FederationDirectory.vue** — **by hand**, because `--fix` made that file *worse* (2 → 10). It expanded two `/** @spec exclude … */` one-liners into multi-line blocks with untyped `@param` tags, failing `jsdoc/require-param-type` five times. A fixer inventing documentation isn't a formatting change.
- **13 `no-console` in Settings.vue** — every one a `console.error` in a catch block, so each got the `// eslint-disable-next-line no-console` this codebase already uses, rather than being deleted.

The rule this followed: fix one file, then check the error count went down, no suppression disappeared, and nothing outside the rule's subject changed. Per file it converged; across `src/` in one go it produced 503 errors and destroyed 12 suppressions.