### PR TITLE
fix(quality): prune stale eslint suppressions, clear gate-7 and gate-57

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -878,14 +878,6 @@
       "count": 1
     }
   },
-  "src/views/directory/DirectoryIndex.vue": {
-    "@typescript-eslint/no-unused-vars": {
-      "count": 1
-    },
-    "no-console": {
-      "count": 4
-    }
-  },
   "src/views/directory/FederationDirectory.vue": {
     "jsdoc/require-param-type": {
       "count": 8
@@ -946,9 +938,6 @@
     },
     "jsdoc/require-param-type": {
       "count": 6
-    },
-    "no-console": {
-      "count": 10
     },
     "vue/multi-word-component-names": {
       "count": 1

--- a/lib/Controller/WooController.php
+++ b/lib/Controller/WooController.php
@@ -83,6 +83,13 @@ class WooController extends Controller {
 	 * @NoCSRFRequired
 	 *
 	 * @spec openspec/specs/woo-transparency/spec.md#requirement-weigeringsgronden-refusal-grounds
+	 *
+	 * @no-admin-idor-exempt Returns the WOO Art. 5.1/5.2 refusal-grounds catalogue from
+	 *   the `WooService::WEIGERINGSGRONDEN` class CONSTANT — published Dutch statute, the
+	 *   same rows for every caller. No storage is touched and the only parameter is a
+	 *   `search` substring filter over that constant, so there is no caller-supplied
+	 *   object id and nothing to scope. Verifiable by reading
+	 *   `WooService::getWeigeringsgronden()`: it iterates the constant and returns rows.
 	 */
 	public function weigeringsgronden(): JSONResponse {
 		if ($this->userSession->getUser() === null) {

--- a/lib/Service/FileService.php
+++ b/lib/Service/FileService.php
@@ -397,107 +397,25 @@ class FileService {
 
 	}//end uploadFile()
 
-	/**
-	 * Overwrites an existing file in NextCloud.
-	 *
-	 * @param mixed $content The content of the file.
-	 * @param string $filePath Path (from root) where to save the file.
-	 *                         NOTE: include the name and extension of the file (example.pdf).
-	 * @param boolean $createNew Default = false. If set to true this function will create
-	 *                           a new file if it doesn't exist yet.
-	 *
-	 * @return boolean True if successful.
-	 * @throws Exception In case we can't write to file because it is not permitted.
-	 *
-	 * @psalm-suppress UndefinedInterfaceMethod Node is actually a File here.
-	 *
-	 * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
-	 *
-	 * @spec openspec/specs/file-management/spec.md
-	 */
-	public function updateFile(mixed $content, string $filePath, bool $createNew = false): bool {
-		$filePath = trim(string: $filePath, characters: '/');
-
-		// Get the current user.
-		$currentUser = $this->userSession->getUser();
-		$userId = 'Guest';
-		if ($currentUser !== null) {
-			$userId = $currentUser->getUID();
-		}
-
-		$userFolder = $this->rootFolder->getUserFolder(userId: $userId);
-
-		// Check if file exists and overwrite it if it does.
-		try {
-			try {
-				$file = $userFolder->get(path: $filePath);
-				$file->putContent($content);
-
-				return true;
-			} catch (NotFoundException $e) {
-				if ($createNew === true) {
-					$userFolder->newFile(path: $filePath);
-					$file = $userFolder->get(path: $filePath);
-					$file->putContent($content);
-
-					$this->logger->info("File $filePath did not exist, created a new file for it.");
-					return true;
-				}
-			}//end try
-
-			// File already exists.
-			$this->logger->warning("File $filePath already exists.");
-			return false;
-		} catch (NotPermittedException|GenericFileException|LockedException $e) {
-			$this->logger->error("Can't create file $filePath: " . $e->getMessage());
-
-			throw new Exception("Can't write to file $filePath");
-		}//end try
-
-	}//end updateFile()
-
-	/**
-	 * Deletes a file from NextCloud.
-	 *
-	 * @param string $filePath Path (from root) to the file you want to delete.
-	 *
-	 * @return boolean True if successful.
-	 * @throws Exception In case deleting the file is not permitted.
-	 *
-	 * @spec openspec/specs/file-management/spec.md
-	 */
-	public function deleteFile(string $filePath): bool {
-		$filePath = trim(string: $filePath, characters: '/');
-
-		// Get the current user.
-		$currentUser = $this->userSession->getUser();
-		$userId = 'Guest';
-		if ($currentUser !== null) {
-			$userId = $currentUser->getUID();
-		}
-
-		$userFolder = $this->rootFolder->getUserFolder(userId: $userId);
-
-		// Check if file exists and delete it if it does.
-		try {
-			try {
-				$file = $userFolder->get(path: $filePath);
-				$file->delete();
-
-				return true;
-			} catch (NotFoundException $e) {
-				// File does not exist.
-				$this->logger->warning("File $filePath does not exist.");
-
-				return false;
-			}
-		} catch (NotPermittedException|InvalidPathException $e) {
-			$this->logger->error("Can't delete file $filePath: " . $e->getMessage());
-
-			throw new Exception("Can't delete file $filePath");
-		}
-
-	}//end deleteFile()
+	// ⚠️ `updateFile()` and `deleteFile()` USED TO LIVE HERE. Removed 2026-08-16
+	// as orphaned write capability (gate-57): both overwrote or deleted an
+	// arbitrary path in the CALLER's user folder, and nothing in the app ever
+	// called either one. The only references anywhere were their own unit
+	// tests, which is the shape gate-57 exists to find — a write path that can
+	// be minted but not reached, so no route, no guard and no review ever
+	// applies to it, while the capability sits in the class waiting to be wired
+	// up by someone who assumes it was already vetted.
+	//
+	// Checked before deleting, not after: fleet-wide grep found no PHP caller
+	// outside `tests/`. The `deleteFile(...)` occurrences in
+	// `PublicationDetail.vue` and `ViewObject.vue` are LOCAL VUE METHODS of the
+	// same name calling the HTTP API — same word, different layer.
+	//
+	// The rest of this app already reaches OpenRegister's FileService for file
+	// work (see EventService, PublicationService, DcatService); only
+	// `DownloadService::createPdf` still uses this local one. Anything that
+	// needs to overwrite or delete a file should go through OpenRegister
+	// (ADR-022), where the write is authorised, not be revived here.
 
 	/**
 	 * Creates a pdf file in a /tmp folder using a twig template and given context.

--- a/tests/Unit/Service/FileServiceTest.php
+++ b/tests/Unit/Service/FileServiceTest.php
@@ -768,149 +768,18 @@ class FileServiceTest extends \PHPUnit\Framework\TestCase {
 
 	}//end testUploadFileGenericFileException()
 
-	/**
-	 * Overwrites an existing file and returns true.
-	 *
-	 * @return void
-	 */
-	public function testUpdateFileExistingFile(): void {
-		$userFolder = $this->setupUserFolder('admin');
-
-		$file = $this->createMock(File::class);
-		$file->expects($this->once())->method('putContent')->with('new content');
-		$userFolder->method('get')->with('path/file.txt')->willReturn($file);
-
-		$result = $this->fileService->updateFile(content: 'new content', filePath: '/path/file.txt/');
-		$this->assertTrue($result);
-
-	}//end testUpdateFileExistingFile()
-
-	/**
-	 * Creates a new file when createNew is true and file is missing.
-	 *
-	 * @return void
-	 */
-	public function testUpdateFileNewFileWithCreateNew(): void {
-		$userFolder = $this->setupUserFolder('admin');
-
-		$file = $this->createMock(File::class);
-		$file->expects($this->once())->method('putContent')->with('content');
-
-		$callCount = 0;
-		$userFolder->method('get')->willReturnCallback(
-			function () use ($file, &$callCount) {
-				$callCount++;
-				if ($callCount === 1) {
-					throw new NotFoundException();
-				}
-
-				return $file;
-			}
-		);
-
-		$userFolder->expects($this->once())->method('newFile');
-
-		$result = $this->fileService->updateFile(content: 'content', filePath: 'path/file.txt', createNew: true);
-		$this->assertTrue($result);
-
-	}//end testUpdateFileNewFileWithCreateNew()
-
-	/**
-	 * Returns false when file does not exist and createNew is false.
-	 *
-	 * @return void
-	 */
-	public function testUpdateFileNotFoundWithoutCreateNew(): void {
-		$userFolder = $this->setupUserFolder('admin');
-
-		$userFolder->method('get')
-			->willThrowException(new NotFoundException());
-
-		$this->logger->expects($this->once())
-			->method('warning')
-			->with($this->stringContains('already exists'));
-
-		$result = $this->fileService->updateFile(content: 'content', filePath: 'missing/file.txt', createNew: false);
-		$this->assertFalse($result);
-
-	}//end testUpdateFileNotFoundWithoutCreateNew()
-
-	/**
-	 * Throws Exception when writing is not permitted.
-	 *
-	 * @return void
-	 */
-	public function testUpdateFilePermissionError(): void {
-		$userFolder = $this->setupUserFolder('admin');
-
-		$file = $this->createMock(File::class);
-		$file->method('putContent')
-			->willThrowException(new NotPermittedException());
-		$userFolder->method('get')->willReturn($file);
-
-		$this->expectException(Exception::class);
-		$this->expectExceptionMessageMatches('/Can.*t write to file/');
-
-		$this->fileService->updateFile(content: 'content', filePath: 'locked/file.txt');
-
-	}//end testUpdateFilePermissionError()
-
-	/**
-	 * Removes an existing file and returns true.
-	 *
-	 * @return void
-	 */
-	public function testDeleteFileExists(): void {
-		$userFolder = $this->setupUserFolder('admin');
-
-		$file = $this->createMock(File::class);
-		$file->expects($this->once())->method('delete');
-		$userFolder->method('get')->with('path/file.txt')->willReturn($file);
-
-		$result = $this->fileService->deleteFile('/path/file.txt/');
-		$this->assertTrue($result);
-
-	}//end testDeleteFileExists()
-
-	/**
-	 * Returns false and logs warning when file does not exist.
-	 *
-	 * @return void
-	 */
-	public function testDeleteFileNotFound(): void {
-		$userFolder = $this->setupUserFolder('admin');
-
-		$userFolder->method('get')
-			->willThrowException(new NotFoundException());
-
-		$this->logger->expects($this->once())
-			->method('warning')
-			->with($this->stringContains('does not exist'));
-
-		$result = $this->fileService->deleteFile('missing/file.txt');
-		$this->assertFalse($result);
-
-	}//end testDeleteFileNotFound()
-
-	/**
-	 * Throws Exception when deletion is not permitted.
-	 *
-	 * @return void
-	 */
-	public function testDeleteFilePermissionError(): void {
-		$userFolder = $this->setupUserFolder('admin');
-
-		$file = $this->createMock(File::class);
-		$file->method('delete')
-			->willThrowException(new NotPermittedException());
-		$userFolder->method('get')->willReturn($file);
-
-		$this->expectException(Exception::class);
-		$this->expectExceptionMessageMatches('/Can.*t delete file/');
-
-		$this->fileService->deleteFile('restricted/file.txt');
-
-	}//end testDeleteFilePermissionError()
+	// The seven testUpdateFile* / testDeleteFile* cases that stood here were
+	// removed with the methods they called, exactly as the testCreateZip* note
+	// further down records. `FileService::updateFile()` / `deleteFile()` were
+	// orphaned write capability (gate-57): nothing in the app called either,
+	// and THESE TESTS WERE THE ONLY REFERENCES TO THEM ANYWHERE.
+	//
+	// That is worth naming rather than quietly deleting. A well-tested method
+	// with no caller does not read as dead code — it reads as a supported API,
+	// because the tests assert it works. The coverage was real and the
+	// capability was unreachable, and it is the second half that decides.
+	// Anything needing to overwrite or delete a file should go through
+	// OpenRegister's FileService (ADR-022), where the write is authorised.
 
 	/**
 	 * Uses Guest user folder when no user is authenticated.
@@ -1008,45 +877,11 @@ class FileServiceTest extends \PHPUnit\Framework\TestCase {
 
 	}//end testUploadFileGuestUser()
 
-	/**
-	 * Uses Guest user ID for update when no user is authenticated.
-	 *
-	 * @return void
-	 */
-	public function testUpdateFileGuestUser(): void {
-		$this->userSession->method('getUser')->willReturn(null);
-
-		$userFolder = $this->createMock(Folder::class);
-		$this->rootFolder->method('getUserFolder')->with('Guest')->willReturn($userFolder);
-
-		$file = $this->createMock(File::class);
-		$file->expects($this->once())->method('putContent')->with('updated');
-		$userFolder->method('get')->willReturn($file);
-
-		$result = $this->fileService->updateFile(content: 'updated', filePath: 'path/file.txt');
-		$this->assertTrue($result);
-
-	}//end testUpdateFileGuestUser()
-
-	/**
-	 * Uses Guest user ID for delete when no user is authenticated.
-	 *
-	 * @return void
-	 */
-	public function testDeleteFileGuestUser(): void {
-		$this->userSession->method('getUser')->willReturn(null);
-
-		$userFolder = $this->createMock(Folder::class);
-		$this->rootFolder->method('getUserFolder')->with('Guest')->willReturn($userFolder);
-
-		$file = $this->createMock(File::class);
-		$file->expects($this->once())->method('delete');
-		$userFolder->method('get')->willReturn($file);
-
-		$result = $this->fileService->deleteFile('path/file.txt');
-		$this->assertTrue($result);
-
-	}//end testDeleteFileGuestUser()
+	// testUpdateFileGuestUser / testDeleteFileGuestUser removed with the same
+	// two methods — see the note above. The Guest-folder fallback they covered
+	// is still exercised by testUploadFileGuestUser, testCreateFolderGuestUser
+	// and testAddFileInfoToDataGuestUser, so the BEHAVIOUR keeps its coverage;
+	// only the two dead entry points into it are gone.
 
 	// The three testCreateZip* cases that stood here were removed with the
 	// methods they called. `FileService::createZip()` / `downloadZip()` are


### PR DESCRIPTION
Three independent reds, none of which was a lint error or a security hole.

## eslint — 0 errors, 567 warnings, exit 2

The job failed on a line that's easy to read past:

> There are suppressions left that do not occur anymore. To resolve this, re-run the command with `--prune-suppressions`.

`eslint-suppressions.json` carried entries for problems the code no longer has, and ESLint treats a stale suppression as a failure — correctly, since a suppression that no longer matches is a claim about the codebase that has stopped being true.

I diffed the file rather than trusting the flag's name: **637 → 622** occurrences, **0 added**, 15 removed across three rule/file pairs (`DirectoryIndex.vue` `no-console` ×4 + `no-unused-vars` ×1, `Settings.vue` `no-console` ×10). A prune that quietly *added* a suppression would be a lint regression wearing a cleanup's clothes, so that's the number worth checking. `npm run lint` now exits 0.

## gate-57 — two orphaned write capabilities

`FileService::updateFile()` and `deleteFile()` overwrote or deleted an arbitrary path in the **caller's** user folder, and nothing in the app called either one. The only references anywhere were their own unit tests — exactly the shape gate-57 exists to find: a write path that can be minted but not reached, so no route, no guard and no review ever applies to it, while the capability sits in the class waiting for someone to wire it up assuming it was already vetted.

Checked before deleting, not after. Fleet-wide grep found no PHP caller outside `tests/`. The `deleteFile(...)` hits in `PublicationDetail.vue` and `ViewObject.vue` are **local Vue methods** of the same name calling the HTTP API — same word, different layer, and the reason a bare grep isn't enough here.

Removed both, plus the nine tests that were their only callers. Worth naming rather than deleting quietly: **a well-tested method with no caller doesn't read as dead code — it reads as a supported API, because the tests assert it works.** The coverage was real; the capability was unreachable; the second half decides. `FileServiceTest` **28 tests / 56 assertions green** (was 37).

The rest of this app already reaches OpenRegister's `FileService` (EventService, PublicationService, DcatService); only `DownloadService::createPdf` still uses the local one. Anything needing to overwrite or delete a file should go through OpenRegister (ADR-022), where the write is authorised.

## gate-7 — `WooController::weigeringsgronden`

Returns the WOO Art. 5.1/5.2 refusal-grounds catalogue from the `WooService::WEIGERINGSGRONDEN` class **constant** — published Dutch statute, the same rows for every caller. No storage is touched and the only parameter is a `search` substring filter over that constant, so there's no caller-supplied object id and nothing to scope. That's exemption 4's exact shape, and the reason is checkable in one read of `getWeigeringsgronden()`.

---

**E2E is still red on this app and is not addressed here.** It's a separate regression — the SPA shell stops mounting, so every UI spec times out waiting for `[data-testid="cn-nav"]` while the API-only specs (OOAPI, openapi-document) pass. It bisects to a different window (last green E2E `3a1f7b0e5`, first red `51fc5f525`).
