### PR TITLE
fix(tests): DownloadServiceTest still mocked a method I had removed

### DIFF
--- a/tests/Unit/Service/DownloadServiceTest.php
+++ b/tests/Unit/Service/DownloadServiceTest.php
@@ -261,7 +261,16 @@ class DownloadServiceTest extends \PHPUnit\Framework\TestCase {
 
 		$this->fileService->method('createPdf')->willReturn($mpdf);
 
-		$this->fileService->expects($this->never())->method('updateFile');
+		// `updateFile` was listed here too until it was removed from FileService as
+		// orphaned write capability (gate-57). Its absence is a STRONGER guarantee
+		// than this assertion was: a method that does not exist cannot be called,
+		// whereas `expects($this->never())` only proves this one path avoids it.
+		// The requirement is still enforced by the two below, which are the
+		// remaining ways FileService can reach Nextcloud user storage.
+		//
+		// ⚠️ Keeping the line would not have failed loudly for the right reason —
+		// PHPUnit raises MethodCannotBeConfiguredException, which reads like a
+		// mock-setup mistake rather than "the method is gone".
 		$this->fileService->expects($this->never())->method('createFolder');
 		$this->fileService->expects($this->never())->method('createPublicShareLink');
 


### PR DESCRIPTION
All six PHPUnit cells went red on #900:

```
MethodCannotBeConfiguredException: Trying to configure method "updateFile"
which cannot be configured because it does not exist
```

**My own regression**, and the reason I missed it is worth writing down: I removed `FileService::updateFile()` / `deleteFile()` as orphaned write capability (gate-57), verified no *production* caller with a fleet-wide grep, then ran `FileServiceTest` — the file I'd edited — and took 28/28 green as proof. It wasn't. `DownloadServiceTest` mocked `updateFile` from a different file, inside an `expects($this->never())` assertion — which no grep for *callers* turns up, because it's a mock configuration, not a call.

🔑 **Run the whole suite, not the file you touched.** Full suite now **1311 tests / 3284 assertions green** in-container.

The assertion isn't lost coverage — it's strictly stronger now. The test pins DWN-OR-003 ("never writes the rendered PDF to Nextcloud user storage"), and **a method that does not exist cannot be called**, while `expects($this->never())` only ever proved this one path avoided it. The two remaining expectations (`createFolder`, `createPublicShareLink`) are the other ways `FileService` can reach user storage, so the requirement keeps its guard.

I noted in the test why the line went, because the failure it produces doesn't say so: `MethodCannotBeConfiguredException` reads like a mock-setup mistake, not like "the method is gone".
