### PR TITLE
docs(openspec): change proposals for the AI-tooling and leaf-integration sweep

### DIFF
--- a/openspec/changes/hermiq-ai-tooling/.openspec.yaml
+++ b/openspec/changes/hermiq-ai-tooling/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: conduction
+created: 2026-08-18

--- a/openspec/changes/hermiq-ai-tooling/design.md
+++ b/openspec/changes/hermiq-ai-tooling/design.md
@@ -1,0 +1,67 @@
+# Design: hermiq-ai-tooling
+
+## Context
+
+After `opencatalogi-mcp-adoption`, the MCP surface is: 10 derived read tools (`{publication,catalog,document,organization,theme}.{search,get}`) + 2 curated reads (`searchCatalogPublications`, `listPublicationFiles`) on `PublicationService`, discovered via `OpenCatalogiScannableServices` (`IMcpScannableServices::opencatalogi`). Writes were refused with a mechanism-specific rationale: the dialect cannot constrain which properties a write touches, and `publicationDate` (verified: `publication.authorization.read = [{"group": "public", "match": {"publicationDate": {"$lte": "$now"}}}, "authenticated"]`) is the publication gate itself. The parent change's Open Questions explicitly hold the door open for a write path that CAN constrain properties.
+
+Fleet context: decidesk `lib/Mcp/` (gate + argument validator + scope resolver) is the reference for governed write tools; hermiq governs via scope × reach (`ToolReachResolver`: `self`/`user`/`instance`/`external`), default-deny grants, `ApprovalService`, guardrail policies, audit.
+
+Verified schema facts this design leans on: `publication` properties include `title`, `summary`, `description`, `organization`, `themes`, `publicationDate`, `depublicationDate`, `status` (enum `published|archived`), `retentionCategory` and friends; `document` and `catalog` carry their own date/`published` gates; there is no draft value in `status` — "draft" IS the absence of `publicationDate`.
+
+## Goals / Non-Goals
+
+**Goals**
+- Draft-creation, publish, depublish, and archive callable by a governed agent, with the publish act structurally unable to happen without a human.
+- The canonical chat scenario: *"publish the draft dataset descriptions"* end-to-end with one reviewed batch approval.
+- Honest blast-radius labelling: publish/depublish are reach `external` because harvest/sitemap/federation distribution is irreversible.
+
+**Non-Goals**
+- Any second publish path (no writes on `catalog`/`document`), no `delete` scope, no dialect write verbs, no authorization changes.
+
+## Decisions
+
+### Decision 1: Four tools, one schema, allow-listed properties
+
+| Tool id | Scope | Reach | Gate | Writes (exhaustive) |
+|---|---|---|---|---|
+| `opencatalogi.createDraftPublication` | create | instance | none (single-phase) | `title`, `summary`, `description`, `organization`, `themes` |
+| `opencatalogi.publishPublication` | update | **external** | **two-phase human approval** | `publicationDate` only |
+| `opencatalogi.depublishPublication` | update | **external** | **two-phase human approval** | `depublicationDate` only |
+| `opencatalogi.archivePublication` | update | instance | **approval-gated** | `status: "archived"` only |
+
+The allow-lists are enforced server-side (argument schema + a hard filter before the object write), not by prompt. `createDraftPublication` rejecting the date/status/retention fields is what makes it safe enough to be single-phase: the worst a rogue agent can do is create invisible drafts.
+
+### Decision 2: Publish is an action, not an update
+
+Modelling publish as `publication.update` (dialect or curated) would hide the act inside a generic verb. Modelling it as its own tool: (a) gives Hermiq a distinct grantable unit — an admin can grant drafting without granting publishing; (b) lets the description carry the irreversibility warning ("harvested copies are not recalled by depublication" — the parent change's Risk 1 fact, restated to the agent and the approver); (c) makes the audit trail read as intent ("publishPublication approved by X") rather than a property diff.
+
+### Decision 3: Server-side two-phase approval (decidesk-gate pattern)
+
+Phase 1 validates, resolves the target publication(s), and stages a batch proposal (publication ids + intended date + requesting agent + granting user); no property is written. Phase 2 executes only with an approval token Scholiq-style verified server-side: minted for a human approver, distinct from the acting agent, unexpired, bound to that batch. Hermiq's `ApprovalService` is the intended UX; a non-Hermiq MCP client without a token simply cannot publish. The batch is the approval unit (Risk 3): the approver sees the full item list; one approval, one reviewed batch.
+
+### Decision 4: Every write goes through the existing RBAC'd service path as the granting user
+
+Phase-2 writes (and draft creation) delegate to the same `PublicationService`/ObjectService path with `_rbac: true` that the UI uses. Consequences: an agent can never publish what its granting user could not; catalog-scope checks keep running; gate parity is testable (REQ-008 scenario: a write the UI would refuse fails identically through the tool).
+
+### Decision 5: Attribution — agent principal in the audit trail
+
+Every tool write records agent identity, granting user, tool id, batch/proposal reference, and approval token id (where gated), on top of OpenRegister's normal audit fields. "Who published this?" must answer "agent A proposed, editor B approved, on behalf of user C" from the trail alone.
+
+### Decision 6: Chat scenarios as verification fixtures
+
+1. **Batch publish** — "Publish the draft dataset descriptions." → derived `publication.search` (authenticated read; drafts visible to the agent's principal) → `publishPublication` phase 1 stages the batch → editor approves in Hermiq → phase 2 sets `publicationDate` per item → records appear on the public surface/sitemap/harvest.
+2. **Email-to-draft-to-publish** (with the `leaf-integrations` change): desk turns request emails into drafts via the Mail sidebar; the agent tidies titles/summaries via `createDraftPublication`-adjacent editing? — no: editing existing drafts is an `update` this change does not grant; the agent instead creates *new* well-formed drafts from pasted source text and flags the originals for the editor. Scoping honesty stated in the tool descriptions.
+3. **Depublish sweep** — "The court ruling means these three publications must come down." → `depublishPublication` staged with the reason recorded in the proposal → approver confirms → `depublicationDate` set; the tool's response restates that harvested copies are not recalled and names the federation contacts step from the runbook.
+
+## Risks / Trade-offs
+
+- Staged batch proposals are a small new internal state (no register schema exposure); accepted for gate integrity.
+- Scenario 2 reveals a gap (no `updateDraftPublication`); deliberately deferred — an update tool needs its own allow-list argument and is easy to add once drafting proves out.
+
+## Migration Plan
+
+Additive; ships after `opencatalogi-mcp-adoption`. Rollback = revert; approved-and-published records stay published (a human approved them).
+
+## Open Questions
+
+Carried in proposal.md (fail-early quality checks; batch cap; archive reach classification).

--- a/openspec/changes/hermiq-ai-tooling/proposal.md
+++ b/openspec/changes/hermiq-ai-tooling/proposal.md
@@ -1,0 +1,101 @@
+# Proposal: hermiq-ai-tooling
+
+## Summary
+
+Extend OpenCatalogi's MCP surface from "read-only + two curated reads" to **full action coverage under Hermiq governance**. `opencatalogi-mcp-adoption` (which this change builds on and does not duplicate) derives 10 read tools from 5 schemas, preserves `searchCatalogPublications` and `listPublicationFiles` as curated `#[McpTool]` methods, and refuses every write verb because in this app **a write verb is a publish verb**: `publicationDate` is an ordinary writable property *inside* the RBAC rule that grants the `public` group read access, so an agent that can write it can publish a government record to the public internet by writing one date. This change adds writes anyway — but as curated, property-allow-listed, approval-gated `#[McpTool]` methods that make that exact attack structurally impossible: `opencatalogi.createDraftPublication` (cannot set any date/status field), `opencatalogi.publishPublication` / `opencatalogi.depublishPublication` (two-phase, mandatory human approval, classified reach `external`), and `opencatalogi.archivePublication` (approval-gated; `status` enum is `published|archived`, verified). Governance is Hermiq's existing model: scope (`read`/`create`/`update`/`delete`) × reach (`self`/`user`/`instance`/`external` per `ToolReachResolver`), default-deny write grants per agent, human approval gates, full agent-principal audit. The PO's canonical chat scenario becomes real: *"publish the draft dataset descriptions"* → the agent stages a publish batch, a human editor approves it, the records go live — with every step attributed.
+
+## Motivation
+
+- **PO framing (fleet-wide):** every app provides MCP tooling for all its actions so any action can in principle be automated; users grant rights per agent, granularly; even without automation, chat is a command surface for the app.
+- **The read-only refusal named its own exit.** `opencatalogi-mcp-adoption` Risk 1 refuses dialect writes because the dialect cannot constrain which properties a write touches, and records exactly that as the open question ("Can the dialect constrain *which properties* a write verb may touch?"). Curated service methods answer it: the method's argument schema and server-side allow-list ARE the property constraint. The fleet reference for gated write tools is `decidesk/lib/Mcp/` (`McpMeetingGate`, `McpArgumentValidator`, scope resolver).
+- **Publishing is the one act that must never be a plain write.** Once `publicationDate <= now`, the DCAT harvester, the sitemap, and federated listings distribute the record; depublication does not un-distribute it. So `publishPublication` is modelled as an explicitly approval-gated action with reach `external` — not as an `update` on a schema — making the blast radius visible in Hermiq's grant UI.
+- **The drafting half is safe and valuable now.** Turning "here are twelve dataset descriptions in this email/document" into twelve well-formed drafts is exactly what an agent is good at, and a draft (no `publicationDate`) is invisible to the public by construction.
+
+## Affected Projects
+
+- [ ] Project: opencatalogi — new `#[McpTool]` write methods on `lib/Service/PublicationService.php` (or a dedicated `PublicationAgentTools` service listed by the existing `OpenCatalogiScannableServices`), staged-approval handling, tests
+- [ ] Project: openregister — **no code change**; `AttributeToolScanner` discovers the methods
+- [ ] Project: hermiq — **no code change**; consumes declared scope/reach hints as it already does
+
+## Capabilities
+
+- `mcp-tool-surface` — extended: governed write-action tools join the capability created by `opencatalogi-mcp-adoption` (REQ-001…REQ-006 remain; this change adds REQ-007…REQ-011)
+
+## Scope
+
+### In Scope
+
+- Four curated write tools, discovered via the existing `IMcpScannableServices::opencatalogi` registration:
+  - `opencatalogi.createDraftPublication` — scope `create`, reach `instance`; property allow-list: `title`, `summary`, `description`, `organization`, `themes` (all verified `publication` properties); MUST NOT accept `publicationDate`, `depublicationDate`, `status`, or any retention field
+  - `opencatalogi.publishPublication` — scope `update`, reach `external`, **two-phase with mandatory human approval**; phase 2 sets `publicationDate` (and nothing else)
+  - `opencatalogi.depublishPublication` — scope `update`, reach `external`, **two-phase with mandatory human approval**; sets `depublicationDate`; its description MUST state that depublication does not un-distribute already-harvested copies
+  - `opencatalogi.archivePublication` — scope `update`, reach `instance`, **approval-gated**; sets `status: "archived"` on an already-depublished record, per the retention flow
+- Server-side approval enforcement in the tool path (not delegated to the MCP client), decidesk-gate style
+- Agent-principal attribution on every write in the OpenRegister audit trail
+- 2–3 documented chat scenarios as verification fixtures
+
+### Out of Scope
+
+- Any `x-openregister-mcp` write verb on any schema — REQ-002 of `opencatalogi-mcp-adoption` stands unmodified
+- Write tools for `catalog`, `document`, `organization`, `theme`, `page`, `menu`, or any other schema (publication is the workflow; a writable `catalog.published` would be a second publish path and is refused here for the same reason the dialect write was)
+- `delete` scope anywhere (WOO records are retention-governed, not deletable by agents)
+- Changing `publication.authorization` (the embargoed-read question from `opencatalogi-mcp-adoption` Risk 3 stays a product decision)
+- Hermiq-side UI or approval-flow changes
+
+## Approach
+
+1. Depend on `opencatalogi-mcp-adoption` landing first (this change continues its REQ numbering and reuses its scannable-services registration).
+2. Add the four `#[McpTool]` methods with honest `scope`/`reach`/hint metadata and argument validation; every method delegates to the existing guarded object-write path (`_rbac: true`) so OpenRegister RBAC and the catalog-scope checks keep running.
+3. Implement the two-phase approval (stage → human token → execute) server-side, mirroring the decidesk gate pattern.
+4. Verify Hermiq classifies publish/depublish as external-reach writes and default-denies them until granted.
+
+## New Dependencies
+
+None.
+
+## Impact
+
+- Tool count grows from 12 to 16.
+- A new (governed) write path to `publicationDate`/`depublicationDate`/`status` exists; it is narrower than the existing UI/REST write paths (allow-listed properties, approval token), never wider.
+- No schema, register, or manifest change; no migration.
+
+## Cross-Project Dependencies
+
+- **opencatalogi-mcp-adoption** MUST be merged first.
+- **openregister** ≥ the commit carrying `AttributeToolScanner` + `IMcpScannableServices` (present at `origin/development`).
+- **hermiq** ≥ the commit honouring declared hints on 2-segment curated tools (hermiq #57, merged).
+
+## Risks
+
+### Risk 1: The publish tool is exactly the attack `opencatalogi-mcp-adoption` refused
+
+- **Severity**: High
+- **Detail**: Risk 1 of the parent change: an agent that can write `publicationDate` can publish a government record to the public internet, and distribution is irreversible.
+- **Mitigation**: Three independent layers, each sufficient alone: (1) Hermiq default-denies the tool until a human grants it to a specific agent; (2) the tool is two-phase and Scholiq-style server-side gated — no valid human approval token, no property write, regardless of client; (3) the phase-2 write goes through the existing RBAC'd path as the granting user, so an agent can never publish what its human may not. A prompt-injected agent must defeat all three.
+
+### Risk 2: Draft-spam from over-eager agents
+
+- **Severity**: Low
+- **Detail**: `createDraftPublication` is single-phase; a misbehaving agent could create many drafts.
+- **Mitigation**: Drafts are invisible to the public by construction, attributed per REQ-010, and bulk-deletable by editors; Hermiq budgets/rate limits apply. Accepted.
+
+### Risk 3: Approval fatigue on batch publishes
+
+- **Severity**: Medium
+- **Detail**: "Publish these 30 dataset descriptions" as 30 approvals trains rubber-stamping.
+- **Mitigation**: The staged proposal is batch-shaped: one approval covers one reviewed batch whose full item list the approver sees; per-item approval remains available.
+
+### Risk 4: Two publish paths drift (UI vs tool)
+
+- **Severity**: Low
+- **Mitigation**: The tool writes through the same service path as the UI; REQ-008 pins gate parity with a test.
+
+## Rollback Strategy
+
+Revert the commit. The tool methods and staged proposals disappear; the derived read surface and the two curated reads from the parent change are untouched. Publications already published via approved batches remain published — correctly, since a human approved them.
+
+## Open Questions
+
+- Should `publishPublication` also require the publication to pass `QualityService`/WOO-readiness checks before staging (fail-early), or is the human approver the quality gate? Leaning fail-early; needs PO confirmation.
+- Batch size cap for a single approval (30? 100?) — a number an approver can actually review.
+- Should `archivePublication` be reach `external` too (archival changes what federated consumers see)? Current classification: `instance`, because archive does not add public exposure; revisit with the federation team.

--- a/openspec/changes/hermiq-ai-tooling/specs/mcp-tool-surface/spec.md
+++ b/openspec/changes/hermiq-ai-tooling/specs/mcp-tool-surface/spec.md
@@ -1,0 +1,90 @@
+# MCP Tool Surface — hermiq-ai-tooling delta
+
+Extends the capability created by `opencatalogi-mcp-adoption` with governed write-action tools. REQ-001…REQ-006 are claimed by that change and stand unmodified — in particular REQ-002 (no dialect write verb on any schema) remains binding; every write in this delta is a curated `#[McpTool]` method. This delta adds REQ-007…REQ-011.
+
+## ADDED Requirements
+
+### Requirement: Write actions are curated tools with allow-listed properties (REQ-007)
+OpenCatalogi MUST expose exactly four write tools as `#[McpTool]` methods discovered via the existing `IMcpScannableServices::opencatalogi` registration: `opencatalogi.createDraftPublication` (scope `create`, reach `instance`), `opencatalogi.publishPublication` (scope `update`, reach `external`), `opencatalogi.depublishPublication` (scope `update`, reach `external`), and `opencatalogi.archivePublication` (scope `update`, reach `instance`). Each tool MUST write only its allow-listed properties, enforced server-side before the object write: `createDraftPublication` → `title`, `summary`, `description`, `organization`, `themes` (and MUST reject any argument naming `publicationDate`, `depublicationDate`, `status`, or a retention property); `publishPublication` → `publicationDate` only; `depublishPublication` → `depublicationDate` only; `archivePublication` → `status: "archived"` only. No write tool may exist for `catalog`, `document`, `organization`, `theme`, or any other schema, and no tool may declare scope `delete`. Reach values MUST use Hermiq's `ToolReachResolver` vocabulary; publish/depublish MUST declare reach `external` because harvested, sitemapped, and federated copies of a published record are not recalled by depublication, and their descriptions MUST state that irreversibility.
+
+#### Scenario: The catalogue carries exactly four write tools with honest metadata
+
+- GIVEN the MCP tool catalogue for app id `opencatalogi`,
+- WHEN every tool with a non-read scope is inspected,
+- THEN exactly the four tools above are found with the scope and reach stated here,
+- AND the publish and depublish descriptions state that distribution is irreversible.
+
+> @e2e exclude backend catalogue metadata — covered by PHPUnit against the attribute scanner output; no UI surface.
+
+#### Scenario: A draft cannot arrive published
+
+- GIVEN an agent calls `opencatalogi.createDraftPublication` with a `publicationDate` argument,
+- WHEN the tool validates its arguments,
+- THEN the call is rejected with a structured invalid-arguments error,
+- AND no object is created; a call without forbidden arguments creates an object with no `publicationDate`, invisible to the `public` group.
+
+> @e2e exclude backend argument-validation path — covered by PHPUnit; the public-invisibility consequence is asserted in the REQ-009 e2e flow.
+
+### Requirement: Every write runs the existing RBAC'd path as the granting user (REQ-008)
+Each write tool MUST delegate to the same `PublicationService`/ObjectService write path the UI uses, with `_rbac: true` and the catalog-scope checks running unchanged, acting as the granting user of the agent's session. A write the UI path would refuse for that user MUST fail identically through the tool, with the same domain error. The tool layer owns argument validation, the property allow-list, staging, and attribution — never a bypass of an existing check.
+
+#### Scenario: An agent cannot publish what its human may not
+
+- GIVEN a user without write access to a publication,
+- WHEN an agent granted by that user stages and (hypothetically) executes `opencatalogi.publishPublication` for it,
+- THEN the phase-2 write is denied by OpenRegister RBAC exactly as the UI write would be,
+- AND `publicationDate` is unchanged.
+
+> @e2e exclude backend gate parity — covered by PHPUnit invoking the tool path and the service path against the same fixture user.
+
+### Requirement: Publish, depublish, and archive execute only after a server-verified human approval (REQ-009)
+`publishPublication`, `depublishPublication`, and `archivePublication` MUST be two-phase: phase 1 validates and stages a batch proposal (target publication ids, intended property write, requesting agent, granting user) and writes no property; phase 2 executes only when presented with an approval token the server verifies was minted for a human approver distinct from the acting agent, unexpired, and bound to that exact batch. The gate MUST be enforced in OpenCatalogi's tool path — a client that never presents a valid token can never reach the property write, whether or not that client is Hermiq. The batch is the approval unit: the approver MUST be shown the full item list, and one approval covers exactly one staged batch. `createDraftPublication` MUST be single-phase (a draft is invisible to the public by construction).
+
+#### Scenario: The canonical batch-publish chat flow
+
+- GIVEN twelve draft dataset descriptions and a user asking their agent to publish them,
+- WHEN the agent stages one `publishPublication` batch and the editor approves it in Hermiq,
+- THEN phase 2 sets `publicationDate` on each item and the records become publicly readable, sitemapped, and harvestable,
+- AND a batch the editor rejects writes nothing.
+
+@e2e tests/e2e/spec-coverage/hermiq-ai-tooling.spec.ts
+
+#### Scenario: An unapproved publish proposal never publishes
+
+- GIVEN a staged publish batch for which no approval token is ever presented,
+- WHEN the staging period ends,
+- THEN no `publicationDate` was written for any item in the batch,
+- AND the expired proposal is visible in the audit trail as proposed-but-not-approved.
+
+> @e2e exclude backend two-phase state machine — covered by PHPUnit.
+
+#### Scenario: A token cannot be replayed onto a different batch
+
+- GIVEN an approval token minted for batch A,
+- WHEN phase 2 of batch B is invoked with it,
+- THEN the execution is refused and batch B remains staged.
+
+> @e2e exclude backend token-binding check — covered by PHPUnit.
+
+### Requirement: Every agent write is attributed to the agent principal in the audit trail (REQ-010)
+Every write performed through a curated write tool MUST record, alongside OpenRegister's normal audit fields: the acting agent identity (from the MCP session context), the granting user, the tool id, the batch/proposal reference, and the approval token id where a gate applies. An agent-proposed, human-approved publication MUST be answerable as such from the audit trail alone — never as a purely human act.
+
+#### Scenario: A published record is traceable to agent, approver, and grant
+
+- GIVEN a publication published via an approved batch,
+- WHEN its audit trail is read,
+- THEN it names the agent, the granting user, the tool id, the batch reference, and the approval token id.
+
+> @e2e exclude backend audit assertion — covered by PHPUnit reading the audit trail after a tool-path publish.
+
+### Requirement: Hermiq governance is honoured but never relied upon (REQ-011)
+The tools MUST declare metadata such that Hermiq classifies all four as writes, default-denied per agent until granted, with publish/depublish surfaced as external-reach; verifying that classification is part of this change's acceptance. At the same time, no OpenCatalogi-side check may assume the caller is Hermiq: the property allow-lists (REQ-007), the RBAC path (REQ-008), and the approval gate (REQ-009) MUST each hold against an arbitrary MCP client, so the app's own guarantees stand even if the agent layer is misconfigured or replaced.
+
+#### Scenario: An ungoverned MCP client gains no extra power
+
+- GIVEN an MCP client that is not Hermiq and performs no grant or approval bookkeeping,
+- WHEN it invokes `opencatalogi.publishPublication` phases 1 and 2 without a valid approval token,
+- THEN staging succeeds at most, no property is ever written,
+- AND the failed execution attempt is auditable.
+
+> @e2e exclude backend client-independence check — covered by PHPUnit driving the tool methods directly, bypassing Hermiq entirely.

--- a/openspec/changes/hermiq-ai-tooling/tasks.md
+++ b/openspec/changes/hermiq-ai-tooling/tasks.md
@@ -1,0 +1,77 @@
+# Tasks: hermiq-ai-tooling
+
+> Depends on `opencatalogi-mcp-adoption` being merged first (continues its REQ numbering; reuses its `OpenCatalogiScannableServices` registration).
+
+## Implementation Tasks
+
+### Task 1: Four `#[McpTool]` write methods with property allow-lists (must / MVP)
+- **spec_ref**: `openspec/specs/mcp-tool-surface/spec.md#requirement-write-actions-are-curated-tools-with-allow-listed-properties-req-007`
+- **files**: `lib/Mcp/PublicationAgentTools.php` (new), `lib/Mcp/McpArgumentValidator.php` (new, decidesk pattern), `lib/Mcp/OpenCatalogiScannableServices.php` (add the new service to the returned list)
+- **acceptance_criteria**:
+  - GIVEN the tool catalogue WHEN enumerated THEN it contains exactly 16 opencatalogi tools (12 from the parent change + the 4 writes), all curated ids 2-segment
+  - GIVEN each write tool WHEN its metadata is read THEN scope/reach match REQ-007 (`publishPublication`/`depublishPublication` = reach `external`) and both external-reach descriptions state distribution irreversibility
+  - GIVEN `createDraftPublication` WHEN called with `publicationDate`, `depublicationDate`, `status`, or a retention property THEN it rejects with a structured invalid-arguments error and creates nothing
+  - GIVEN the new PHP WHEN `composer check:strict` runs THEN it is clean
+- [ ] Implement
+- [ ] Test
+
+### Task 2: Delegation through the RBAC'd service path (must / MVP) — BLOCKS Task 3
+- **spec_ref**: `openspec/specs/mcp-tool-surface/spec.md#requirement-every-write-runs-the-existing-rbacd-path-as-the-granting-user-req-008`
+- **files**: `lib/Mcp/PublicationAgentTools.php`, `tests/Unit/Mcp/`
+- **acceptance_criteria**:
+  - GIVEN any write tool WHEN its implementation is reviewed THEN every object write goes through the existing `PublicationService`/ObjectService path with `_rbac: true` as the granting user; no direct un-RBAC'd write exists
+  - GIVEN a fixture user without write access to a publication WHEN the tool path and the UI path both attempt the write THEN both fail with the same domain error (gate-parity test)
+  - GIVEN the phase-2 publish write WHEN executed THEN it writes `publicationDate` and no other property (assert the object diff key set)
+- [ ] Implement
+- [ ] Test
+
+### Task 3: Two-phase batch approval, server-enforced (must / MVP)
+- **spec_ref**: `openspec/specs/mcp-tool-surface/spec.md#requirement-publish-depublish-and-archive-execute-only-after-a-server-verified-human-approval-req-009`
+- **files**: `lib/Mcp/PublicationAgentTools.php`, `lib/Service/` (staged-batch handling), `tests/Unit/Mcp/`
+- **acceptance_criteria**:
+  - GIVEN phase 1 of publish/depublish/archive WHEN it completes THEN a staged batch exists with the full item list, and no property was written
+  - GIVEN phase 2 WHEN invoked without a token, with an expired token, with a token minted for the acting agent, or with a token bound to a different batch THEN it is refused and nothing is written
+  - GIVEN phase 2 WHEN invoked with a valid human-approver token bound to the batch THEN each item's allow-listed property is written via Task 2's path
+  - GIVEN `createDraftPublication` WHEN invoked THEN it is single-phase (no token concept)
+- [ ] Implement
+- [ ] Test
+
+### Task 4: Agent-principal attribution (must / MVP)
+- **spec_ref**: `openspec/specs/mcp-tool-surface/spec.md#requirement-every-agent-write-is-attributed-to-the-agent-principal-in-the-audit-trail-req-010`
+- **files**: `lib/Mcp/PublicationAgentTools.php`, `tests/Unit/Mcp/`
+- **acceptance_criteria**:
+  - GIVEN any tool-path write WHEN the object's audit trail is read THEN it carries agent identity, granting user, tool id, batch reference, and (for gated writes) approval token id
+  - GIVEN an expired unapproved batch WHEN the trail is read THEN the proposal is visible as proposed-but-not-approved
+  - GIVEN the same write performed through the UI WHEN audited THEN it carries no agent fields (control)
+- [ ] Implement
+- [ ] Test
+
+### Task 5: Hermiq classification check + chat-scenario e2e + docs (must / MVP)
+- **spec_ref**: `openspec/specs/mcp-tool-surface/spec.md#requirement-hermiq-governance-is-honoured-but-never-relied-upon-req-011`
+- **files**: `tests/e2e/spec-coverage/hermiq-ai-tooling.spec.ts` (new), `docs/`, `CHANGELOG.md`
+- **acceptance_criteria**:
+  - GIVEN Hermiq enumerates the opencatalogi tools WHEN the four writes are classified THEN all are default-denied writes and publish/depublish show reach `external` (verified once against a live Hermiq, recorded in the change)
+  - GIVEN the e2e suite WHEN it runs THEN the batch-publish flow passes: drafts staged → approval → publicly readable + present in sitemap; and a rejected batch publishes nothing
+  - GIVEN `docs/` WHEN read THEN it records the tool table (scope × reach × gate), the batch-approval model, the irreversibility warning, and the refusal of write tools on other schemas
+  - GIVEN `CHANGELOG.md` WHEN read THEN it records the governed write surface
+- [ ] Implement
+- [ ] Test
+
+## Verification
+- [ ] All tasks checked off
+- [ ] `openspec validate hermiq-ai-tooling --type change --strict` passes
+- [ ] Manual testing against acceptance criteria (denied grant, rejected batch, approved batch, token replay)
+- [ ] Code review against spec requirements
+
+## Tests (company-wide ADR-009)
+- [ ] PHPUnit: metadata, allow-lists, gate parity, two-phase state machine, token binding, attribution (Tasks 1–4); zero new failures vs a self-measured baseline
+- [ ] Browser tests (Playwright MCP): `tests/e2e/spec-coverage/hermiq-ai-tooling.spec.ts` (Task 5)
+- [ ] All tests pass (CI-way, in the container)
+- Newman/Postman: N/A — no HTTP endpoint is added; the MCP surface is served by OpenRegister's `/api/mcp`.
+
+## Documentation (company-wide ADR-010)
+- [ ] `docs/` records the governed write surface and the approval model (Task 5)
+- Screenshots: N/A for OpenCatalogi UI — the approval flow lives in Hermiq; published results use existing UI.
+
+## i18n (company-wide ADR-005)
+- N/A — tool descriptions and staged-batch fields are agent-facing/backend prose, not UI copy. Approval-flow copy is Hermiq's.

--- a/openspec/changes/leaf-integrations/.openspec.yaml
+++ b/openspec/changes/leaf-integrations/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: conduction
+created: 2026-08-18

--- a/openspec/changes/leaf-integrations/design.md
+++ b/openspec/changes/leaf-integrations/design.md
@@ -1,0 +1,76 @@
+# Design: leaf-integrations
+
+## Context
+
+OpenRegister's integration-leaf machinery (verified at `origin/development`):
+
+- ~17 providers under `lib/Service/Integration/Providers/` (ids include `email`, `calendar`, `contacts`, `forms`, `deck`, `polls`, `talk`, `maps`, `photos`, `shares`, `bookmarks`, `collectives`, `notes`, `activity`, `time-tracker`, `analytics`) plus built-ins (`files`, `tags`, `tasks`, `notes`, `audit-trail`).
+- Stage 2 of the three-stage filter reads the schema; stage 3 is the manifest integration widget.
+- The Mail sidebar (`src/mail-sidebar/`, `CreateConnectedObjectDialog.vue`) is a distinct surface: `configuration.linkedTypes: ["mail"]` marks a schema as a link target from an email, and `configuration.mailObjectTemplate` (validated by `Schema::validateMailObjectTemplateValue()` — flat map, scalar values, `{{subject}}`/`{{sender}}`/`{{senderName}}`/`{{date}}`/`{{date30}}`/`{{datetime}}`/`{{preview}}`/`{{messageId}}`/`{{mailRef}}` placeholders) adds the create-object-from-email button. Only schemas declaring the template get the button.
+
+OpenCatalogi today (verified): 4 integration widgets (`pub-files`, `pub-photos`, `pub-links`, `org-image`); no `linkedTypes` and no mail configuration anywhere in `lib/Settings/publication_register.json`; every schema's `configuration` object currently holds `autoPublish: false` (plus `implements` on `organization`, `x-openregister-shareable` on `catalog`).
+
+The load-bearing fact for everything below: **publication state is a data field.** `publication.authorization.read` is `[{"group": "public", "match": {"publicationDate": {"$lte": "$now"}}}, "authenticated"]` — an object without `publicationDate` is invisible to the public by construction.
+
+## Goals / Non-Goals
+
+**Goals**
+- Email → draft publication in one click, with publication impossible from that path.
+- Publication planning events, intake forms, and organization contacts linked where editors work.
+- Zero PHP, zero Vue; the whole leaf surface enumerable from two JSON files.
+
+**Non-Goals**
+- Automating publication (that is `auto-publishing`'s capability and the hermiq-ai-tooling change's governed tools — not leaves).
+- Mail intake for schemas other than `publication`.
+- Deriving calendar events from date properties.
+
+## Decisions
+
+### Decision 1: The ON matrix
+
+| Schema | New configuration | Widget (page) | Why |
+|---|---|---|---|
+| `publication` | `linkedTypes: ["mail", "calendar"]`, `mailObjectTemplate` | `pub-calendar` on PublicationDetail, title "Planning (does not publish)" | Mail is the intake channel that exists in practice; calendar is where publish/depublish planning already lives. The mail leaf itself renders in the NC Mail sidebar, not as an OpenCatalogi widget — hence one widget, two linked types. |
+| `organization` | `linkedTypes: ["forms", "contacts"]` | `org-intake-form`, `org-contacts` on OrganizationDetail | The submitting organization is the stable anchor for an intake form (there is no CatalogDetail page — verified: manifest detail pages are Publication, Organization, Theme, Glossary, Page, Menu) and for contact persons. |
+
+### Decision 2: The mail template maps only safe, prose-shaped properties
+
+```
+"mailObjectTemplate": {
+  "title": "{{subject}}",
+  "summary": "{{preview}}",
+  "description": "Received by email from {{senderName}} <{{sender}}> on {{date}}.\n\n{{preview}}"
+}
+```
+
+All three keys are verified `publication` properties. The template deliberately omits `publicationDate`, `depublicationDate`, `status`, `organization`, `themes`, and every retention field: dates because their presence is the publication gate (Risk 1 of the proposal — this is the same property-is-the-gate fact that made `opencatalogi-mcp-adoption` refuse write verbs), `status` because its enum (`published|archived`) has no draft value and an emailed request is neither, and the classification fields because a human editor must classify. REQ-002 makes the omissions normative.
+
+### Decision 3: Calendar is planning, never mechanism
+
+The calendar leaf links VEVENTs to a publication. It does not read or write `publicationDate`. Rationale: two clocks ("planned" vs "actual") diverge in every real newsroom/desk; conflating them would either make a calendar drag-drop a publish act (an authorization hole — publishing would move from the guarded property write to any calendar editor) or make the property write move an event nobody owns. Divergence is a feature: the leaf shows the plan, the property shows the fact.
+
+### Decision 4: The OFF list
+
+- `email` as a **leaf on detail pages** (as opposed to the Mail-sidebar intake): deferred — the sidebar intake is the workflow that exists; a linked-emails tab on PublicationDetail is plausible but unrequested.
+- `deck`, `talk`, `polls` — publishing is not card- or conversation-shaped in this app's workflow today; adding comms surfaces to a records app needs a real user ask.
+- `maps` — no geo property on any schema.
+- `shares`, `collectives`, `notes`, `activity`, `time-tracker`, `analytics`, `tasks` — generic; nothing asked for them; every widget costs page space.
+- `photos`, `bookmarks`, `files` — already adopted; untouched.
+- Mail intake on `document` / `catalog` / `page` — one intake archetype first (proposal Open Questions).
+
+### Decision 5: No PHP
+
+The Mail sidebar, template expansion, linked-type validation, and widget rendering are all OpenRegister's. OpenCatalogi's change is register JSON + manifest JSON + one e2e file. If a future change wants intake-time classification (auto-assign `organization` from the sender domain, say), that is a listener and its own change.
+
+## Risks / Trade-offs
+
+- Mail-created drafts can accumulate unclassified (no `organization`, no `themes`). Accepted: they are visible only to authenticated editors, and the existing editorial list views surface them; a cleanup view is a follow-up if volume warrants.
+- The intake form leaf links a form; submissions do not become objects by themselves. Accepted and documented (proposal Open Questions — an openconnector flow can close that loop later).
+
+## Migration Plan
+
+Pure addition; register re-import applies the configuration keys. Rollback = revert (mail-created publications remain as ordinary drafts, correctly).
+
+## Open Questions
+
+Carried in proposal.md.

--- a/openspec/changes/leaf-integrations/proposal.md
+++ b/openspec/changes/leaf-integrations/proposal.md
@@ -1,0 +1,88 @@
+# Proposal: leaf-integrations
+
+## Summary
+
+Adopt OpenRegister's app-agnostic integration leaves beyond the three OpenCatalogi uses today. Current verified state (`src/manifest.json`): **files** (PublicationDetail "Attachments"), **photos** (PublicationDetail "Images", OrganizationDetail "Logo & images"), **bookmarks** (PublicationDetail "Links") — and no schema declares `linkedTypes` or any mail configuration. This change adds four leaves where they genuinely serve the publishing workflow: **mail** (publication requests arriving by email become draft publications — `configuration.linkedTypes: ["mail"]` makes `publication` a Mail-sidebar link target, and `configuration.mailObjectTemplate` puts a create-publication-from-email button in the NC Mail sidebar), **calendar** (planned publication/depublication dates as linked events on PublicationDetail), **forms** (a publication-submission intake form linked at the organization level), and **contacts** (an organization's contact persons as linked NC Contacts cards). Everything is declarative: schema `configuration` keys in `lib/Settings/publication_register.json` plus manifest integration widgets — no new PHP, no new Vue.
+
+## Motivation
+
+- **Publication requests arrive by email today and are retyped by hand.** A WOO/transparency desk receives requests and source material in a shared mailbox; the `mailObjectTemplate` mechanism (verified in openregister `lib/Db/Schema.php`: a flat property→template map with `{{subject}}`/`{{sender}}`/`{{preview}}`/`{{date}}` placeholders; only schemas declaring the template get the button) exists precisely for this and no schema in the fleet's publishing app uses it yet.
+- **Publication planning happens in calendars nobody links.** Editors plan "publish the council decisions Friday, depublish the draft after recess" in personal agendas; the authoritative fields (`publicationDate`, `depublicationDate` — verified properties of `publication`) then get set late or wrong. A calendar leaf ties the planning events to the publication object without touching the authoritative fields.
+- **The leaf infrastructure is already paid for.** OpenRegister ships the providers (`EmailProvider`, `CalendarProvider`, `FormsProvider`, `ContactsProvider`, verified in `lib/Service/Integration/Providers/`), the `Schema::linkedTypes` filter and the manifest widget render path; OpenCatalogi already renders four integration widgets, so the pattern is proven in this app.
+
+## Affected Projects
+
+- [ ] Project: opencatalogi — `lib/Settings/publication_register.json` (configuration keys on `publication` and `organization`), `src/manifest.json` (3 new widgets), one new e2e spec-coverage file
+- [ ] Project: openregister — **no code change**; consumed read-only as the leaf registry, Mail-sidebar host, and render layer
+
+## Capabilities
+
+- `integration-leaves` — new capability: which OpenRegister integration leaves OpenCatalogi declares, the mail-intake contract, and why the rest are OFF
+
+## Scope
+
+### In Scope
+
+- `configuration.linkedTypes: ["mail"]` + `configuration.mailObjectTemplate` on the `publication` schema (mail intake; the template maps `title`/`summary`/`description` from `{{subject}}`/`{{preview}}`/sender-and-date prose and deliberately never sets `publicationDate`, so an emailed request can never arrive published)
+- `calendar` in `publication`'s linked types + one calendar widget on PublicationDetail (planning events; the authoritative gate stays the `publicationDate` property)
+- `forms` + `contacts` in `organization`'s linked types + one widget each on OrganizationDetail (submission-intake form; contact persons)
+- A Playwright spec-coverage test for the new widgets
+- Documentation of the OFF list with reasons
+
+### Out of Scope
+
+- Any change to `publication.authorization`, `autoPublish`, or the publication gate itself — the mail template creates **unpublished** objects and nothing in this change can publish
+- Mail intake on `document`, `catalog`, or any other schema (one intake archetype first; see Open Questions)
+- Auto-creating calendar events from `publicationDate`/`depublicationDate` (derivation needs an idempotency design; the leaf links user-curated events)
+- Deck/talk/polls/maps/shares/collectives/notes/time-tracker/analytics leaves — no publishing workflow asked for them (see design OFF list)
+- Changes to OpenRegister providers or the Mail sidebar itself
+
+## Approach
+
+1. Add the `configuration` keys to `publication` and `organization` in `lib/Settings/publication_register.json`, alongside the existing `autoPublish` key (both schemas already carry a `configuration` object, verified).
+2. Add three manifest widgets shaped like the existing four: PublicationDetail `pub-calendar` (calendar), OrganizationDetail `org-intake-form` (forms) and `org-contacts` (contacts).
+3. Add `tests/e2e/spec-coverage/integration-leaves.spec.ts`.
+
+## New Dependencies
+
+None. The Mail, Calendar, Forms, and Contacts NC apps are runtime-optional: providers self-disable (`isEnabled()`) when the app is absent, and the Mail-sidebar surface only exists inside the Mail app.
+
+## Impact
+
+- `lib/Settings/publication_register.json` is re-imported; the added keys are validated by `Schema::validateLinkedTypesValue()` / `validateMailObjectTemplateValue()` at import and touch no property, no `authorization` block, no `autoPublish` value.
+- 3 new manifest widgets (total integration widgets: 7); no existing widget changes.
+- A new object-creation path for `publication` (from email). Objects so created are ordinary draft publications: no `publicationDate`, invisible to the `public` group per the existing RBAC match rule, editable in the normal UI.
+
+## Cross-Project Dependencies
+
+- **openregister** ≥ the commit carrying the pluggable integration registry, the Mail sidebar (`src/mail-sidebar/`, `CreateConnectedObjectDialog`), and `mailObjectTemplate` validation (all present at `origin/development`).
+
+## Risks
+
+### Risk 1: Mail intake creates publications from arbitrary inbound mail
+
+- **Severity**: Medium
+- **Detail**: Anyone can email the desk; the create-from-email button turns a hostile or spam mail into a register object containing attacker-chosen text.
+- **Mitigation**: The button is a **user action** inside the NC Mail sidebar — a human clicks it per email; nothing is automatic. The created object is unpublished by construction (REQ-002: the template MUST NOT contain `publicationDate`, `depublicationDate`, or `status`), so nothing reaches the public surface, the sitemap, or the DCAT harvester without the normal editorial publish act.
+
+### Risk 2: A calendar leaf is mistaken for the publication gate
+
+- **Severity**: Medium
+- **Detail**: An editor links a "publish Friday" event, Friday passes, nothing publishes — or worse, someone assumes deleting the event depublishes.
+- **Mitigation**: REQ-003 pins that the leaf is planning-only and the widget copy says "Planning (does not publish)"; the authoritative fields stay `publicationDate`/`depublicationDate`, unchanged by any leaf action.
+
+### Risk 3: Contact cards drift from the register's own organization fields
+
+- **Severity**: Low
+- **Detail**: `organization` has `name`, `oin`, `tooi`, `rsin` etc.; a linked contact card carries its own name/email/phone that nobody reconciles.
+- **Mitigation**: The leaf links, never copies (REQ-004); register properties remain the authoritative organization identity, the card is reachability info for humans.
+
+## Rollback Strategy
+
+Revert the commit. Re-importing the register drops the added configuration keys (nothing else in the schemas moves); the widgets disappear with the manifest. Publications already created from email are ordinary objects and remain, as intended. Linked events/forms/cards live in their NC apps and only lose their OpenCatalogi-side rendering.
+
+## Open Questions
+
+- Should `document` also become a mail link target (a request email often carries the bijlage as attachment)? Deferred: attachment-to-file intake is a different mechanism than property templating.
+- Should the intake form (`forms` leaf) eventually feed a draft publication automatically (Forms → OpenConnector → OpenRegister)? That is an openconnector flow, not a leaf; noted for the openconnector backlog.
+- Does the mail-derived `description` need a fixed provenance suffix ("Received by email from … on …") as normative spec text, or is template guidance enough? Currently normative in REQ-002.

--- a/openspec/changes/leaf-integrations/specs/integration-leaves/spec.md
+++ b/openspec/changes/leaf-integrations/specs/integration-leaves/spec.md
@@ -1,0 +1,88 @@
+# Integration Leaves
+
+Which OpenRegister integration leaves OpenCatalogi declares, the mail-intake contract for publications, and why the rest are OFF. A leaf is declared in `lib/Settings/publication_register.json` (schema `configuration`) and rendered either by a manifest integration widget or, for mail, by OpenRegister's Mail-sidebar surface. OpenCatalogi ships no leaf provider code.
+
+## ADDED Requirements
+
+### Requirement: Leaves are declared in the register and the manifest, nowhere else (REQ-001)
+Every OpenCatalogi integration leaf MUST consist solely of schema `configuration` keys in `lib/Settings/publication_register.json` (`linkedTypes`, and for mail additionally `mailObjectTemplate`) plus manifest integration widgets in `src/manifest.json`. OpenCatalogi MUST NOT implement an `IntegrationProvider` and MUST NOT add per-leaf Vue components. The declared surface after this change MUST be exactly: `publication` → `linkedTypes: ["mail", "calendar"]` + `mailObjectTemplate`; `organization` → `linkedTypes: ["forms", "contacts"]`; widgets `pub-calendar` (PublicationDetail), `org-intake-form` and `org-contacts` (OrganizationDetail) added beside the four pre-existing integration widgets, which MUST NOT change. No other schema may carry `linkedTypes` or `mailObjectTemplate`.
+
+#### Scenario: The leaf surface is enumerable from two files
+
+- GIVEN the repository at this change's completion,
+- WHEN `lib/Settings/publication_register.json` is searched for `linkedTypes`/`mailObjectTemplate` and `src/manifest.json` for `"type": "integration"`,
+- THEN the results MUST list exactly the surface above (7 integration widgets total),
+- AND `lib/` MUST contain no `IntegrationProvider` implementation.
+
+> @e2e exclude static repo-shape assertion — verified by the task acceptance-criteria greps and the register-import validation, not a DOM behaviour.
+
+#### Scenario: The register imports with valid leaf declarations
+
+- GIVEN the edited register,
+- WHEN it is imported into OpenRegister,
+- THEN `Schema::validateLinkedTypesValue()` and `Schema::validateMailObjectTemplateValue()` MUST accept every declared value,
+- AND no pre-existing configuration key (`autoPublish`, `implements`, `x-openregister-shareable`) is dropped or changed.
+
+> @e2e exclude backend import validation — covered by OpenRegister's validators; asserted via the JSON round-trip check in Task 1.
+
+### Requirement: A publication created from email is unpublished by construction (REQ-002)
+The `publication` schema MUST declare `configuration.linkedTypes` containing `"mail"` and a `configuration.mailObjectTemplate` mapping exactly `title` → `"{{subject}}"`, `summary` → `"{{preview}}"`, and `description` → a provenance string naming `{{senderName}}`, `{{sender}}`, and `{{date}}` followed by `{{preview}}`. The template MUST NOT contain `publicationDate`, `depublicationDate`, `status`, `organization`, `themes`, or any retention property. Rationale (binding): `publication.authorization.read` grants the `public` group access via `{"publicationDate": {"$lte": "$now"}}` — the date property IS the publication gate — so an object created without it is invisible to the public, absent from the sitemap, and ignored by the DCAT harvester until an editor performs the normal publish act. Creating a publication from an email MUST remain a per-email human action in the NC Mail sidebar; nothing in this capability may create objects from mail automatically.
+
+#### Scenario: An emailed publication request becomes a draft, not a publication
+
+- GIVEN a desk employee viewing a request email in NC Mail,
+- WHEN they use the create-publication-from-email button,
+- THEN a `publication` object exists with `title` from the subject, `summary` from the preview, and a provenance `description`,
+- AND the object has no `publicationDate` and is not readable by the `public` group, not in the sitemap, and not harvested.
+
+@e2e tests/e2e/spec-coverage/integration-leaves.spec.ts
+
+#### Scenario: The template cannot smuggle publication state
+
+- GIVEN the `mailObjectTemplate` in the imported register,
+- WHEN its key set is inspected,
+- THEN it MUST equal exactly `{title, summary, description}`,
+- AND adding any date, status, or classification key to the template is a violation of this requirement, not a configuration choice.
+
+> @e2e exclude static template-shape assertion — covered by the Task 1 acceptance criteria; the runtime consequence (draft invisibility) is the previous scenario.
+
+### Requirement: The calendar leaf on publications is planning-only and never the gate (REQ-003)
+The `publication` schema MUST declare `"calendar"` in `configuration.linkedTypes`, and PublicationDetail MUST carry one calendar integration widget titled "Planning (does not publish)". The leaf links user-curated CalDAV events to a publication for publish/depublish planning. No leaf action may read or write `publicationDate`, `depublicationDate`, or `status`: linking, editing, or deleting an event MUST leave the publication's visibility unchanged, and the authoritative publish/depublish acts remain the guarded property writes they are today.
+
+#### Scenario: An editor plans a publish date without publishing
+
+- GIVEN an unpublished publication,
+- WHEN an editor links a "publish Friday" calendar event via the leaf widget,
+- THEN the event is shown on PublicationDetail,
+- AND the publication remains unpublished when Friday passes (no property changed).
+
+@e2e tests/e2e/spec-coverage/integration-leaves.spec.ts
+
+#### Scenario: Deleting a planning event depublishes nothing
+
+- GIVEN a published publication with a linked planning event,
+- WHEN the event is unlinked or deleted,
+- THEN `publicationDate` is unchanged and the publication remains publicly readable.
+
+> @e2e exclude negative-coupling assertion — the leaf has no write path to object properties by construction (OpenRegister `CalendarProvider` links VEVENTs only); covered by the Task 2 review criterion and OpenRegister's provider tests.
+
+### Requirement: Organization leaves link intake forms and contact persons without copying data (REQ-004)
+The `organization` schema MUST declare `"forms"` and `"contacts"` in `configuration.linkedTypes`, with one forms widget (publication-submission intake) and one contacts widget (contact persons) on OrganizationDetail. Both leaves link entities owned by their NC apps: form definitions and submissions stay in Forms; contact cards stay in Contacts. No register property may be written from a linked entity and no card or form field may be copied into the register by the leaf; the `organization` properties (`name`, `oin`, `tooi`, `rsin`, …) remain the authoritative organization identity. Leaves MUST render only after the OpenRegister RBAC read of the organization object succeeds.
+
+#### Scenario: A desk links the intake form and a contact person
+
+- GIVEN an organization object,
+- WHEN an editor opens OrganizationDetail,
+- THEN the forms leaf lets them link the organization's submission-intake form and the contacts leaf lets them link a contact card,
+- AND the organization object's own properties are unchanged by either linking act.
+
+@e2e tests/e2e/spec-coverage/integration-leaves.spec.ts
+
+#### Scenario: Form submissions do not become publications by themselves
+
+- GIVEN a linked intake form with new submissions,
+- WHEN the submissions are inspected,
+- THEN they exist only in the Forms app,
+- AND no publication object was created by the leaf (closing that loop is an OpenConnector flow, out of this capability's scope).
+
+> @e2e exclude absence-of-side-effect assertion — the leaf has no object-creation path by construction; covered by the Task 2 review criterion.

--- a/openspec/changes/leaf-integrations/tasks.md
+++ b/openspec/changes/leaf-integrations/tasks.md
@@ -1,0 +1,61 @@
+# Tasks: leaf-integrations
+
+## Implementation Tasks
+
+### Task 1: Declare the leaf configuration on `publication` and `organization` (must / MVP)
+- **spec_ref**: `openspec/specs/integration-leaves/spec.md#requirement-a-publication-created-from-email-is-unpublished-by-construction-req-002`
+- **files**: `lib/Settings/publication_register.json`
+- **acceptance_criteria**:
+  - GIVEN the register JSON WHEN edited THEN `publication.configuration` carries `linkedTypes: ["mail", "calendar"]` and the REQ-002 `mailObjectTemplate` (key set exactly `{title, summary, description}`), and `organization.configuration` carries `linkedTypes: ["forms", "contacts"]` — each added **alongside** the existing keys (`autoPublish`, `implements`), which are byte-identical before/after
+  - GIVEN the file WHEN grepped for `linkedTypes`/`mailObjectTemplate` THEN only `publication` and `organization` carry them; `document`, `catalog`, `listing`, `page`, `theme`, `menu`, `glossary`, `usageCounter` carry neither
+  - GIVEN the template WHEN inspected THEN it contains no `publicationDate`, `depublicationDate`, `status`, `organization`, `themes`, or retention key
+  - GIVEN each edit WHEN `python3 -m json.tool lib/Settings/publication_register.json` runs THEN it exits 0 and no pre-existing key is dropped
+- [ ] Implement
+- [ ] Test
+
+### Task 2: Add the three manifest widgets (must / MVP)
+- **spec_ref**: `openspec/specs/integration-leaves/spec.md#requirement-the-calendar-leaf-on-publications-is-planning-only-and-never-the-gate-req-003`
+- **files**: `src/manifest.json`
+- **acceptance_criteria**:
+  - GIVEN the manifest WHEN edited THEN PublicationDetail gains `pub-calendar` (`integrationId: "calendar"`, title "Planning (does not publish)") and OrganizationDetail gains `org-intake-form` (`integrationId: "forms"`) and `org-contacts` (`integrationId: "contacts"`), each shaped like the existing `pub-files` widget (`id`, `type: "integration"`, `integrationId`, `title`, `icon`)
+  - GIVEN the manifest WHEN grepped for `"type": "integration"` THEN the count is 7 and the four pre-existing widgets (`pub-files`, `pub-photos`, `pub-links`, `org-image`) are unchanged
+  - GIVEN the widgets and the register template WHEN reviewed THEN no leaf has a write path to `publicationDate`/`depublicationDate`/`status` (REQ-003/REQ-004 review criterion)
+- [ ] Implement
+- [ ] Test
+
+### Task 3: e2e spec-coverage for mail intake and the new widgets (must / MVP)
+- **spec_ref**: `openspec/specs/integration-leaves/spec.md#requirement-a-publication-created-from-email-is-unpublished-by-construction-req-002`
+- **files**: `tests/e2e/spec-coverage/integration-leaves.spec.ts`
+- **acceptance_criteria**:
+  - GIVEN the Mail, Calendar, Forms, and Contacts apps enabled in the test env WHEN the suite runs THEN it covers: create-publication-from-email (draft exists; public/anonymous request for it is denied; absent from sitemap), the planning-event link on PublicationDetail (publication stays unpublished), and widget presence on OrganizationDetail
+  - GIVEN a leaf NC app is disabled WHEN the page renders THEN the test tolerates the absent widget (provider `isEnabled()` behaviour)
+- [ ] Implement
+- [ ] Test
+
+### Task 4: Documentation (must / MVP)
+- **spec_ref**: `openspec/specs/integration-leaves/spec.md#requirement-leaves-are-declared-in-the-register-and-the-manifest-nowhere-else-req-001`
+- **files**: `docs/`, `CHANGELOG.md`
+- **acceptance_criteria**:
+  - GIVEN `docs/` WHEN read THEN it records the mail-intake flow for desk employees (with the "arrives as draft, publish is the normal editorial act" framing), the planning-vs-gate distinction, and the OFF list with reasons
+  - GIVEN `CHANGELOG.md` WHEN read THEN it records the four new leaves
+- [ ] Implement
+- [ ] Test
+
+## Verification
+- [ ] All tasks checked off
+- [ ] `openspec validate leaf-integrations --type change --strict` passes
+- [ ] Manual testing against acceptance criteria (create a publication from a real email; link an event, a form, a contact)
+- [ ] Code review against spec requirements
+
+## Tests (company-wide ADR-009)
+- [ ] Browser tests (Playwright MCP): `tests/e2e/spec-coverage/integration-leaves.spec.ts` (Task 3)
+- [ ] All tests pass; zero new failures vs a self-measured baseline
+- PHPUnit: N/A — this change ships no PHP.
+- Newman/Postman: N/A — no HTTP endpoint is added; the mail-intake write goes through OpenRegister's existing object API.
+
+## Documentation (company-wide ADR-010)
+- [ ] `docs/` records the intake flow and the leaf matrix (Task 4)
+- [ ] Screenshot of the Mail-sidebar create-publication button and the PublicationDetail planning widget committed to `docs/images/`
+
+## i18n (company-wide ADR-005)
+- [ ] Widget titles ("Planning (does not publish)", "Intake form", "Contacts") are new user-facing strings: `nl_NL` and `en_US` entries added via the mechanism the existing widget titles use. The `mailObjectTemplate` provenance string is stored object data, not UI copy — it ships in English per the all-code-is-English rule.


### PR DESCRIPTION
OpenSpec change proposals — **artifacts only**. Every task box is unticked; nothing here is wired to anything yet, and each change gets picked up by `/opsx-apply` when it is scheduled.

Opened because these were sitting **untracked in the shared dev checkout across ten apps at once**. An untracked directory is one file-sweep away from being swept into an unrelated commit, and one branch switch away from being gone. These carry the design reasoning, not just a title, so losing them loses the thinking.

Each proposal is a complete artifact set — `proposal.md`, `design.md`, `tasks.md` and its spec delta.
