### PR TITLE
fix(openapi): sync the document version with info.xml

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "OpenCatalogi",
-    "version": "0.7.54",
+    "version": "1.0.9-unstable.20260819214116",
     "description": "OpenCatalogi's public, anonymously-reachable API surface: full-text search, catalog and publication read access, DCAT-AP-NL and schema.org harvest feeds, DIWOO sitemaps/robots.txt, the federation read surface, the federated-directory sync endpoint, and the CMS read APIs (pages/menus/themes/glossary/listings). Every path in this document corresponds to a route in `appinfo/routes.php` whose controller method carries `@PublicPage` / `#[PublicPage]` — admin-gated and authenticated-only endpoints (settings, retention, Woo batches, setup, OOAPI 5.0 resource reads, DCAT/DIWOO/OOAPI validation reports) are out of scope; see the `public-api-openapi-document` OpenSpec change.",
     "license": {
       "name": "EUPL-1.2",


### PR DESCRIPTION
`OpenApiParityTest::testDocumentVersionMatchesInfoXml` asserts `openapi.json`'s `info.version` equals `appinfo/info.xml`'s `<version>`. The release merge (#909) bumped info.xml and left openapi.json behind:

```
Failed asserting that two strings are identical.
-'1.0.9-unstable.20260819214116'
+'0.7.54'
```

This was the **only** failing test on `development` — `Tests: 1339, Assertions: 3346, Failures: 1`.

Hand-edited on purpose: `composer openapi` maps to `generate-spec`, which is **not installed** (`sh: 1: generate-spec: not found`), so there is no generator to re-run — this document is maintained by hand.

⚠️ **This will recur on every release.** The release process bumps `info.xml` and nothing bumps `openapi.json`, so the parity test fails after each version bump until someone syncs it by hand. Either the release workflow should rewrite `info.version`, or the test should compare only the parts meant to match. Worth a follow-up; out of scope for restoring `development` to green.