### PR TITLE
docs(openspec): propose woo-category-mapping-intake — take ownership of the schema→informatiecategorie map

### DIFF
--- a/openspec/changes/woo-category-mapping-intake/.openspec.yaml
+++ b/openspec/changes/woo-category-mapping-intake/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-19

--- a/openspec/changes/woo-category-mapping-intake/design.md
+++ b/openspec/changes/woo-category-mapping-intake/design.md
@@ -1,0 +1,171 @@
+## Context
+
+See `proposal.md` — Why. Two facts shape the approach:
+
+1. **opencatalogi already owns the canonical vocabulary.** `TooiVocabularyService` bundles the 17 official
+   Woo informatiecategorieen as `code → {id, label, aliases}` (`lib/Service/TooiVocabularyService.php:62-104`)
+   and exposes them publicly via `informatiecategorieList(): array<code, {uri, label}>`
+   (`lib/Service/TooiVocabularyService.php:217-224`). `SitemapService::mapDiwooDocument()` already resolves a
+   *per-publication* category value against this vocabulary
+   (`lib/Service/SitemapService.php:546-565`, calling `resolveInformatiecategorie()` at
+   `lib/Service/TooiVocabularyService.php:138-154`). There is no equivalent *per-type default* concept in
+   opencatalogi today — every publication must carry its own category or the axis is omitted and reported as
+   a violation.
+2. **decidesk's mapping is a per-type default, seeded with placeholders.** decidesk's `WooCategorieMapping`
+   (`decidesk/lib/Settings/register.d/58-woo-diwoo-publication.json:87-181`) is exactly that missing
+   per-type-default concept, but scoped to decidesk's own 8 schema slugs, with a closed `enum` on `objectType`
+   (`...:142-152`), and every one of its 8 seed rows carries a `c_PLACEHOLDER_...` URI
+   (`...:10,18,26,34,42,50,58,66`) rather than a real TOOI concept URI, because the mapping's seed author had
+   no access to `TooiVocabularyService`'s real value list from inside decidesk.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Generalise the mapping's key from a single closed enum to `(app, objectType)` so any Conduction app can
+  register a default without touching opencatalogi code.
+- Resolve every migrated row against the real vocabulary at intake time, closing the placeholder gap.
+- Give `SitemapService` a per-type-default fallback for its own publications, and give every other publishing
+  app a way to read the same defaults without a bespoke API.
+
+**Non-Goals:**
+- Retiring decidesk's `WooCategorieMapping` schema/data — that is the named companion change
+  (`decidesk-retire-woo-category-mapping`), sequenced strictly after this one via `depends_on`.
+- Building `DiWooMetadataService`, `WooIndexController`, or `WooIndexConnectorService` — decidesk's own
+  seed-data comment (`58-woo-diwoo-publication.json:4`) already scopes those as separate, later, imperative
+  work; this change only has to make the mapping *readable* by whatever consumes it next.
+- Changing the 17-member TOOI vocabulary itself, or `TooiVocabularyService`'s public surface.
+- An admin UI for editing mapping rows. Rows ship as seed data; a future change can add UI if a real admin
+  workflow need appears (default-per-type mappings change rarely — this is the same judgement decidesk's own
+  seed comment made for `WooBestuursorgaan`).
+
+## Decisions
+
+### D1 — Key by `(app, objectType)`, not `objectType` alone
+
+decidesk's `objectType` enum is closed to 8 decidesk-specific strings. Two apps' schema slugs can collide
+(`"decision"` is a plausible slug in more than one domain), so uniqueness must be scoped by the owning app.
+Alternative considered: prefix `objectType` with the app name (`"decidesk:decision"`) to avoid a second
+field — rejected because it turns a structured value into string-parsing convention or duplicates a filter
+that a normal indexed property already handles, and it forces every consumer to remember the delimiter.
+
+### D2 — Store the resolved URI + label directly on the row, not a lookup code
+
+Two options: (a) store `informatiecategorieCode` (e.g. `"infocat008"`) and require every consumer to
+call back into `TooiVocabularyService` to resolve it, or (b) store the resolved `informatiecategorie` URI +
+`informatiecategorieLabel` directly on the row (decidesk's original shape, minus placeholders), pattern-validated
+against the TOOI URI prefix exactly as decidesk's schema already did
+(`58-woo-diwoo-publication.json:158`).
+
+Chose (b). `TooiVocabularyService` is a PHP class private to opencatalogi; a cross-app consumer reading the
+mapping via a plain OpenRegister object query (D4) cannot call it. Storing the resolved URI + label makes the
+mapping self-contained and readable by any app with zero PHP coupling — the OR object *is* the API. The
+17-member vocabulary changes rarely (KOOP publishes revisions infrequently), so the durability cost of
+"resolved value can drift from the source list" is low, and is caught the same way decidesk's original schema
+already caught it: pattern validation on write, `informatiecategorieLabel` shown alongside the URI for human
+review, and this change's own intake step re-resolving every row from the *current* vocabulary rather than
+hand-copying the old placeholders.
+
+### D3 — `objectType` becomes a free-text string, not an enum
+
+An enum forces opencatalogi to edit its own schema every time a new app or a new schema slug wants a mapping.
+A free-text string (still `required`, still indexed/facetable for the admin list view) lets any app register a
+row without a schema change here. Duplicate-key detection ((D1) uniqueness) is a review/validation concern,
+same posture decidesk's schema already documented for its own single-field uniqueness
+(`58-woo-diwoo-publication.json:141`: "OR has no cross-object unique constraint — uniqueness is a
+review/validation concern").
+
+### D4 — Consumption is a direct OpenRegister object query, not a new controller
+
+Per ADR-022 (apps consume OpenRegister abstractions) and the existing pattern in this very codebase —
+`WooReadinessService::getWooEnabledCatalogs()` already resolves another schema's objects via
+`ObjectService::searchObjectsPaginated()` with an `@self` register/schema filter plus a property filter
+(`lib/Service/WooReadinessService.php:243-257`) — a bespoke `WooCategoryMappingController` or
+`WooCategoryMappingService::resolveFor()` RPC surface for other apps to call would be exactly the "phantom
+cross-app RPC" pattern the fleet gate `hydra-gate-no-phantom-cross-app-rpc` exists to catch: PHP classes
+cannot be called across app boundaries at all, so the only real consumption path was always the OR object API.
+opencatalogi's own `SitemapService` consumes it the same way, for consistency, even though it *could*
+theoretically inject a new opencatalogi-local service — using the same path proves the path actually works
+for a stranger app before decidesk depends on it.
+
+### D5 — `SitemapService`'s fallback stays inside `mapDiwooDocument()`, not a new service class
+
+The fallback is three lines of logic (look up a mapping row, use its `informatiecategorie`/`Label` instead of
+treating the axis as unresolved) inserted into the existing branch at
+`lib/Service/SitemapService.php:546-565`. It shares the same `$violations`-reporting contract as every other
+axis in that method. A new service class for a three-line lookup would be the kind of gratuitous indirection
+`hydra-gate-redundant-controller` flags on the wrapper side of that pattern.
+
+## Declarative-vs-imperative decision (ADR-031)
+
+| Behaviour | Path chosen | Rationale |
+|---|---|---|
+| Type-level default resolution for `diwoo:informatiecategorie` when a publication declares no category | **Imperative** — extends the existing imperative `SitemapService::mapDiwooDocument()` | Exception category: *document generation* / *external integration*. This method already generates a DIWOO XML document for the national Woo-index (KOOP), an external standard with its own resolution and fallback rules (see WOO-TOOI-001..004) that predate and are unrelated to OpenRegister's declarative primitives. The fallback is one more branch in an already-imperative, already-spec'd resolution chain — not a new derived/calculated field on an object that x-openregister-calculations would be a better fit for. |
+| Storing the mapping rows themselves | **Declarative** — plain OR schema + seed data, no lifecycle, no service class needed to read them | Mapping rows are static configuration (per decidesk's own prior schema comment: "mappings have no lifecycle... deliberately no x-openregister-lifecycle"). No new precedent needed; carried over unchanged from the schema this change generalises. |
+
+## Migration Plan
+
+1. Add the `WooCategoryMapping` schema + attach it to the `publication` register via a new
+   `lib/Settings/register.d/*.json` fragment (ADR-037 pattern — mirrors
+   `lib/Settings/register.d/fix-woo-capability-provisioning.json`), so it gets a magic table and shows up in
+   the admin schema selector without editing the monolithic `publication_register.json`.
+2. Seed the 8 migrated rows in the same fragment (see Seed Data below) — each row's `informatiecategorie` /
+   `informatiecategorieLabel` is the **real** resolved value from `TooiVocabularyService::informatiecategorieList()`,
+   not the placeholder decidesk shipped.
+3. Extend `SitemapService::mapDiwooDocument()` with the fallback lookup (D5).
+4. No rollback complexity: this change adds a new schema and a new fallback branch; it does not modify or
+   remove any existing opencatalogi behavior. Rollback is "revert the fragment + the `SitemapService` diff."
+5. decidesk-side retirement is explicitly deferred to the companion change — this migration plan does not
+   touch decidesk.
+
+## Seed Data
+
+Migrated from `decidesk/lib/Settings/register.d/58-woo-diwoo-publication.json:6-71`, `app: "decidesk"` added
+to every row, and every placeholder URI resolved against
+`TooiVocabularyService::informatiecategorieList()` (`lib/Service/TooiVocabularyService.php:62-104`):
+
+| slug | app | objectType | informatiecategorie (resolved) | label | active | notes |
+|---|---|---|---|---|---|---|
+| `woo-map-decidesk-meeting-agenda` | decidesk | `meeting-agenda` | `.../c_db4862c3` | Vergaderstukken decentrale overheden | true | Meeting agenda payload. Migrated from decidesk `woo-map-meeting-agenda`; placeholder resolved to infocat008. |
+| `woo-map-decidesk-decision-list` | decidesk | `decision-list` | `.../c_db4862c3` | Vergaderstukken decentrale overheden | true | Generated decision-list document. Migrated from decidesk `woo-map-besluitenlijst`; placeholder resolved to infocat008. |
+| `woo-map-decidesk-minutes` | decidesk | `minutes` | `.../c_db4862c3` | Vergaderstukken decentrale overheden | true | ORI Verslag. Migrated from decidesk `woo-map-minutes`; placeholder resolved to infocat008. |
+| `woo-map-decidesk-decision` | decidesk | `decision` | `.../c_db4862c3` | Vergaderstukken decentrale overheden | true | ORI Besluit. Migrated from decidesk `woo-map-decision`; placeholder resolved to infocat008. |
+| `woo-map-decidesk-motion` | decidesk | `motion` | `.../c_db4862c3` | Vergaderstukken decentrale overheden | true | Inert until decidesk's Motie schema lands (WOO-CAT-004). Migrated from decidesk `woo-map-motie`; placeholder resolved to infocat008. |
+| `woo-map-decidesk-commitment` | decidesk | `commitment` | `.../c_db4862c3` | Vergaderstukken decentrale overheden | true | Predicate-published. Migrated from decidesk `woo-map-toezegging`; placeholder resolved to infocat008. |
+| `woo-map-decidesk-council-information-letter` | decidesk | `council-information-letter` | `.../c_db4862c3` | Vergaderstukken decentrale overheden | true | Predicate-published. Migrated from decidesk `woo-map-raadsinformatiebrief`; placeholder resolved to infocat008. |
+| `woo-map-decidesk-arrangement` | decidesk | `arrangement` | `.../c_139c6280` | Wetten en algemeen verbindende voorschriften | true | Inert until decidesk's Regeling schema lands (WOO-CAT-004). Migrated from decidesk `woo-map-regeling`; placeholder resolved to infocat001. |
+
+(URIs abbreviated to their `c_...` suffix for table width; full form is
+`https://identifier.overheid.nl/tooi/def/thes/kern/c_db4862c3` and
+`https://identifier.overheid.nl/tooi/def/thes/kern/c_139c6280` respectively — both taken verbatim from
+`TooiVocabularyService::INFORMATIECATEGORIEEN['infocat008'|'infocat001']`,
+`lib/Service/TooiVocabularyService.php:80-90,63-67`.)
+
+No general-organization example row is added beyond the migrated decidesk set — the capability's only
+current consumer is decidesk, and inventing a synthetic "municipality" or "consultancy" row without a real
+consumer would just recreate the placeholder problem this change exists to close.
+
+## Risks / Trade-offs
+
+- **[Risk] The resolved URIs above were mapped by re-reading decidesk's `informatiecategorieLabel` text
+  against opencatalogi's vocabulary, not by an automated tool** → **Mitigation**: both of decidesk's two
+  distinct label strings ("Vergaderstukken decentrale overheden", "Wetten en algemeen verbindende
+  voorschriften") are exact, case-identical matches to `TooiVocabularyService::INFORMATIECATEGORIEEN['infocat008'|'infocat001']['label']`,
+  so the mapping is a label-identity match, not a judgement call. A reviewer should re-verify by diffing the
+  seed fragment's labels against `lib/Service/TooiVocabularyService.php:62-104` at implementation time.
+- **[Risk] `SitemapService::mapDiwooDocument()`'s fallback introduces one more OR query per document with no
+  declared category** → **Mitigation**: bounded by the same publication-batch size the method already
+  iterates; the mapping table has at most a handful of rows per app, so this is a small indexed lookup, not an
+  unbounded scan (`hydra-gate-listener-work-placement` does not apply — this executes inside an already-paginated
+  request handler, not a listener on a write path).
+- **[Risk] A future app registers a mapping row with the wrong `app` value (typo) and silently gets no
+  fallback** → **Mitigation**: WOO-CAT-004 already treats "no match" as inert/non-blocking by design — a typo
+  just means no default applies, which is the same safe failure mode as today (axis omitted, violation
+  reported), not a wrong category being emitted.
+- **[Trade-off] Mixed-spec shape** — see `proposal.md` "Mixed-spec rationale". Accepted for this iteration;
+  flagged for human confirmation rather than silently split.
+
+## Open Questions
+
+- Should the mapping schema additionally validate `objectType` against a known-schemas list at write time
+  (rather than leaving unknown types purely inert per WOO-CAT-004)? Left open — the "inert, never blocking"
+  behavior is deliberately the same posture decidesk's own schema already chose for exactly this situation.

--- a/openspec/changes/woo-category-mapping-intake/proposal.md
+++ b/openspec/changes/woo-category-mapping-intake/proposal.md
@@ -1,0 +1,86 @@
+---
+kind: mixed
+depends_on: []
+---
+
+# Proposal: woo-category-mapping-intake
+
+## Why
+
+OpenCatalogi already owns the canonical, TOOI-sourced Woo informatiecategorie vocabulary
+(`TooiVocabularyService::INFORMATIECATEGORIEEN`, `lib/Service/TooiVocabularyService.php:62-104`) and the
+publication-layer DiWoo mapping pipeline that resolves against it (`SitemapService::mapDiwooDocument()`,
+`lib/Service/SitemapService.php:508-583`). decidesk currently owns a *duplicate* schema-slug →
+informatiecategorie mapping — `WooCategorieMapping`
+(`decidesk/lib/Settings/register.d/58-woo-diwoo-publication.json:87-181`) — with 8 seed rows. Every one of
+those 8 rows still carries an OBVIOUS SHAPE-ONLY PLACEHOLDER TOOI URI
+(`https://identifier.overheid.nl/tooi/def/thes/kern/c_PLACEHOLDER_...`), because the mapping lives inside a
+*consuming* app that has no access to the canonical vocabulary — nobody has had the real value list in reach
+at the moment the seed data was authored. Per the decidesk "Back to Six" programme decision (2026-08-19),
+decidesk keeps only `WooBestuursorgaan` (which binds a decidesk-owned `GovernanceBody` entity); the category
+mapping is pure publication-layer configuration with no decidesk-owned entity to bind, and belongs beside the
+TOOI vocabulary it draws its values from — not duplicated into every app that publishes Woo documents.
+
+## What Changes
+
+- New opencatalogi-owned OpenRegister schema `WooCategoryMapping`: generalises decidesk's
+  `WooCategorieMapping` beyond a single app. `objectType` becomes a free-text schema slug (was a
+  decidesk-only closed enum of 8 values) and a new required `app` field names the owning app, so the pair
+  `(app, objectType)` is the mapping key across every Conduction app that publishes Woo documents, not just
+  decidesk.
+- Migration/intake: the 8 decidesk seed rows are re-seeded here with their placeholder TOOI URIs **resolved**
+  to the real canonical URIs already present in `TooiVocabularyService::informatiecategorieList()`
+  (`lib/Service/TooiVocabularyService.php:217-224`) — this is a genuine data-quality fix, not a mechanical
+  copy: the placeholder problem only exists because the mapping was authored somewhere that never had the
+  real value list in reach.
+- Consumption path: `SitemapService::mapDiwooDocument()` gains a type-level default fallback for the
+  `diwoo:informatiecategorie` axis — when a publication carries no per-object `category` /
+  `tooiCategorieUri` override (the existing WOO-TOOI-001 axis is unchanged), the mapper looks up an active
+  `WooCategoryMapping` row for `(app: "opencatalogi", objectType: <publication's schema slug>)` before the
+  axis is treated as unresolved. Other publishing apps (decidesk's own future imperative
+  `DiWooMetadataService`, or any later app) read the same mapping the same way any app reads OR-owned shared
+  config today — a direct `ObjectService::searchObjectsPaginated()` query scoped to the `woo-category-mapping`
+  schema slug, exactly the pattern `WooReadinessService::getWooEnabledCatalogs()` already uses for its own
+  register (`lib/Service/WooReadinessService.php:224-263`). No new bespoke controller/API is introduced —
+  per ADR-022 (apps consume OpenRegister abstractions), the OR object API *is* the consumption path.
+- **BREAKING** (companion change, named but not authored here — `decidesk-retire-woo-category-mapping`):
+  once this change ships, decidesk's `WooCategorieMapping` schema and its 8 seed rows are retired, and any
+  future decidesk Woo-decoration service is pointed at opencatalogi's mapping instead. That companion change
+  must declare `depends_on: [woo-category-mapping-intake]`.
+
+## Capabilities
+
+### New Capabilities
+- `woo-category-mapping`: opencatalogi-owned, cross-app schema-slug → TOOI informatiecategorie mapping;
+  intake of decidesk's 8 seed rows with resolved (non-placeholder) URIs; read contract for publishing apps.
+
+### Modified Capabilities
+- `woo-compliance`: `SitemapService::mapDiwooDocument()`'s `diwoo:informatiecategorie` axis (WOO-TOOI-001)
+  gains a type-level default fallback sourced from `woo-category-mapping` before an unresolved category is
+  reported as a violation.
+
+## Impact
+
+- `lib/Settings/register.d/` — new fragment (ADR-037 pattern, mirrors
+  `lib/Settings/register.d/fix-woo-capability-provisioning.json`) adding the `WooCategoryMapping` schema,
+  attaching it to the `publication` register, and seeding the 8 migrated rows.
+- `lib/Service/SitemapService.php` — `mapDiwooDocument()` (`lib/Service/SitemapService.php:508-583`) gains
+  the type-level fallback lookup ahead of the existing violation-reporting branch (lines 546-565).
+- `lib/Service/TooiVocabularyService.php` — unchanged. Consumed as the single source of truth for
+  URI/label pairs, both at seed-authoring time here and at request time inside the new fallback.
+- decidesk (companion change, **not** touched by this change): `lib/Settings/register.d/58-woo-diwoo-publication.json`'s
+  `WooCategorieMapping` schema definition and its 8 `woo-categorie-mapping` seed objects are slated for
+  retirement.
+
+## Mixed-spec rationale (ADR-032)
+
+This proposal bundles a config change (new schema + seed data) with a code change
+(`SitemapService::mapDiwooDocument()` fallback + a migration/backfill path for the 8 rows) rather than
+chaining `{slug}-schema-declaration` → `{slug}-consumer-rewrite` per ADR-032's default guidance, because the
+task that produced this proposal explicitly scoped it as one change covering schema + migration + consumption
+path, with the decidesk-side retirement already carved out as a separate, named companion change. This is
+larger than the thin-glue exception (>20 LOC, >2 files), so it is flagged here for human confirmation rather
+than silently accepted — see `DEFERRED_QUESTIONS` in the authoring session. If the reviewing human prefers
+strict ADR-032 compliance, split at `tasks.md`'s existing task boundaries: Task 1-2 (schema + seed) become
+`woo-category-mapping-schema-declaration` (kind: config), Task 3 (`SitemapService` fallback) becomes
+`woo-category-mapping-sitemap-consumption` (kind: code, `depends_on: [woo-category-mapping-schema-declaration]`).

--- a/openspec/changes/woo-category-mapping-intake/specs/woo-category-mapping/spec.md
+++ b/openspec/changes/woo-category-mapping-intake/specs/woo-category-mapping/spec.md
@@ -1,0 +1,105 @@
+## Purpose
+
+Owns the cross-app configuration mapping from a publishing app's schema slug to a canonical Woo
+informatiecategorie, so every app that publishes Woo documents resolves the same official TOOI URI for the
+same kind of publishable object, sourced from a single vocabulary instead of app-local copies.
+
+## ADDED Requirements
+
+### Requirement: WooCategoryMapping is keyed by (app, objectType) (WOO-CAT-001)
+
+The system MUST store each Woo category mapping row as an `(app, objectType)` pair bound to one
+informatiecategorie. `app` identifies the owning app whose schema is being mapped (e.g. `"decidesk"`,
+`"opencatalogi"`); `objectType` identifies that app's schema slug or payload kind. The pair MUST be
+unique — the same `(app, objectType)` MUST NOT appear in more than one active mapping row.
+
+#### Scenario: two apps map the same objectType string independently
+
+- **GIVEN** decidesk has an active mapping for `(app: "decidesk", objectType: "decision")`
+- **AND** a different app has an active mapping for `(app: "other-app", objectType: "decision")`
+- **WHEN** either app's publications are resolved
+- **THEN** each app's mapping MUST be resolved independently by its own `(app, objectType)` pair
+- **AND** neither app's resolution MUST be affected by the other's mapping for the same `objectType` string
+
+### Requirement: Mapped informatiecategorie MUST resolve to a real TOOI value-list member (WOO-CAT-002)
+
+Every `WooCategoryMapping` row MUST store an informatiecategorie value that resolves to a member of the
+bundled TOOI informatiecategorieen value list. A row whose informatiecategorie value does not resolve to a
+value-list member MUST NOT be treated as active for resolution purposes — it MUST be surfaced as invalid
+rather than silently emitting a non-canonical URI downstream.
+
+#### Scenario: seeded row resolves to a canonical URI
+
+- **GIVEN** a `WooCategoryMapping` row seeded from decidesk's `woo-map-besluitenlijst` intake, mapping
+  `(app: "decidesk", objectType: "decision-list")` to the informatiecategorie
+  "Vergaderstukken decentrale overheden"
+- **WHEN** the mapping is resolved
+- **THEN** it MUST resolve to the TOOI URI `https://identifier.overheid.nl/tooi/def/thes/kern/c_db4862c3`
+- **AND** the resolved value MUST NOT be a `c_PLACEHOLDER_...` segment
+
+#### Scenario: a row with an unresolvable value is not used
+
+- **GIVEN** a `WooCategoryMapping` row whose informatiecategorie value does not match any of the 17 bundled
+  value-list members
+- **WHEN** a publishing app resolves its `(app, objectType)` pair
+- **THEN** the resolution MUST report no default (behave as if no active mapping exists for that pair)
+- **AND** MUST NOT emit the unresolved value as a free-text TOOI URI
+
+### Requirement: Mapping rows are per-type defaults, never per-object overrides (WOO-CAT-003)
+
+A `WooCategoryMapping` row MUST only ever supply the *default* informatiecategorie for objects of its
+`(app, objectType)` pair. Any individual publication's own declared category (set at publish time on the
+publication object itself) MUST take precedence over the type-level default; the mapping row itself MUST NOT
+be written to by a publish action.
+
+#### Scenario: a publication's own category overrides the type-level default
+
+- **GIVEN** a `WooCategoryMapping` row maps `(app: "decidesk", objectType: "decision")` to
+  informatiecategorie "Vergaderstukken decentrale overheden"
+- **AND** a specific decision publication declares its own category as
+  "Woo-verzoeken en -besluiten" (infocat014)
+- **WHEN** that publication's Woo metadata is resolved
+- **THEN** the resolved informatiecategorie MUST be "Woo-verzoeken en -besluiten", not the type-level default
+- **AND** the `WooCategoryMapping` row for `(decidesk, decision)` MUST remain unchanged
+
+### Requirement: A mapping for a not-yet-installed schema is inert, never blocking (WOO-CAT-004)
+
+A `WooCategoryMapping` row whose `objectType` names a schema that is not installed in the target app (a
+sibling capability not yet shipped) MUST be inert: it MUST NOT block import of the mapping data, MUST NOT
+block any publication flow, and MUST NOT be reported as a compliance failure. It simply resolves to nothing
+until the named schema exists.
+
+#### Scenario: mapping for an unshipped schema does not block intake
+
+- **GIVEN** a `WooCategoryMapping` row for `(app: "decidesk", objectType: "motion")` is seeded
+- **AND** decidesk's `motion` schema has not yet been installed
+- **WHEN** the mapping data is imported
+- **THEN** the import MUST succeed
+- **AND** no error or compliance-gap report MUST be raised for that row until the `motion` schema exists
+
+### Requirement: Publishing apps read the mapping through OpenRegister, not a bespoke API (WOO-CAT-005)
+
+A publishing app MUST resolve its `(app, objectType)` default informatiecategorie by querying OpenRegister
+objects of the `woo-category-mapping` schema directly (the same generic object-query abstraction every app
+already uses for shared OR-owned data), filtered by `app`, `objectType`, and `active: true`. OpenCatalogi
+MUST NOT expose a bespoke controller/REST endpoint solely to serve this lookup to other apps.
+
+#### Scenario: a publishing app resolves its default via a direct OpenRegister query
+
+- **GIVEN** a publishing app knows its own app identifier and a publication's schema slug
+- **WHEN** it needs the type-level default informatiecategorie
+- **THEN** it MUST query OpenRegister objects of schema `woo-category-mapping` filtered by
+  `app`, `objectType`, and `active: true`
+- **AND** MUST NOT call an opencatalogi-specific HTTP endpoint or PHP service class to obtain the same data
+
+### Requirement: Mapping rows carry no secrets or credentials (WOO-CAT-006)
+
+`WooCategoryMapping` rows MUST contain only public configuration data (app identifier, object type,
+informatiecategorie reference, active flag, optional notes). No credential, token, or connection-string
+value MUST ever be stored on a mapping row.
+
+#### Scenario: mapping schema rejects credential-shaped fields
+
+- **GIVEN** the `WooCategoryMapping` schema definition
+- **WHEN** its property list is reviewed
+- **THEN** it MUST contain no property intended to hold a secret, API key, or credential

--- a/openspec/changes/woo-category-mapping-intake/specs/woo-compliance/spec.md
+++ b/openspec/changes/woo-category-mapping-intake/specs/woo-compliance/spec.md
@@ -1,0 +1,51 @@
+## MODIFIED Requirements
+
+### Requirement: `diwoo:informatiecategorie` is bound to the official TOOI value list (WOO-TOOI-001)
+
+The system MUST resolve each `diwoo:informatiecategorie` to an official TOOI
+informatiecategorie URI drawn from the bundled 17-category waardelijst, rather
+than trusting free-object `tooiCategorieNaam`/`tooiCategorieUri` fields. A
+publication's own category value MUST resolve to a value-list member; when it does,
+the emitted `diwoo:informatiecategorie` MUST carry both the official `@resource`
+URI and its canonical label. When a publication carries no per-object category
+value at all, the system MUST fall back to the type-level default sourced from
+the `woo-category-mapping` capability — an active `WooCategoryMapping` row keyed
+by `(app: "opencatalogi", objectType: <the publication's schema slug>)` — before
+treating the axis as unresolved. A category value (per-object or type-level
+default) that does not resolve to a value-list member MUST NOT be emitted as a
+free-text `@resource`.
+
+#### Scenario: mapped category emits the official TOOI URI
+
+- **GIVEN** a publication in WOO category "Woo-verzoeken en -besluiten" (infocat014)
+- **WHEN** its `diwoo:Document` is generated
+- **THEN** `diwoo:informatiecategorie @resource` MUST be the official TOOI URI
+  for that category
+- **AND** the element text MUST be the category's canonical label
+
+#### Scenario: unresolved category is not leaked as a literal
+
+- **GIVEN** a publication whose category value has no TOOI value-list mapping
+- **AND** no active `WooCategoryMapping` row exists for the publication's schema slug
+- **WHEN** its `diwoo:Document` is generated
+- **THEN** the document MUST NOT carry a free-text `diwoo:informatiecategorie @resource`
+- **AND** the document MUST be reported by the DIWOO validator (WOO-TOOI-004)
+
+#### Scenario: publication with no declared category falls back to the type-level default
+
+- **GIVEN** a publication whose `category`, `tooiCategorieUri`, and `tooiCategorieNaam`
+  fields are all absent
+- **AND** an active `WooCategoryMapping` row exists for
+  `(app: "opencatalogi", objectType: <the publication's schema slug>)`
+- **WHEN** its `diwoo:Document` is generated
+- **THEN** `diwoo:informatiecategorie @resource` MUST be the TOOI URI resolved from that
+  `WooCategoryMapping` row
+- **AND** the element text MUST be that row's resolved canonical label
+
+#### Scenario: a publication's own category still wins over the type-level default
+
+- **GIVEN** a publication that declares its own `category` value
+- **AND** an active `WooCategoryMapping` row also exists for the publication's schema slug
+- **WHEN** its `diwoo:Document` is generated
+- **THEN** `diwoo:informatiecategorie` MUST reflect the publication's own declared category
+- **AND** MUST NOT be overridden by the type-level default

--- a/openspec/changes/woo-category-mapping-intake/tasks.md
+++ b/openspec/changes/woo-category-mapping-intake/tasks.md
@@ -1,0 +1,57 @@
+# Tasks: woo-category-mapping-intake
+
+## 1. Schema + register fragment
+
+- [ ] 1.1 Add the `WooCategoryMapping` schema (`app`, `objectType`, `informatiecategorie`,
+      `informatiecategorieLabel`, `active`, `notes`) in a new `lib/Settings/register.d/*.json` fragment
+      (ADR-037 pattern), pattern-validate `informatiecategorie` against the TOOI URI prefix, and attach the
+      schema to the `publication` register (`magicMapping: true`, `autoCreateTable: true`)
+- [ ] 1.2 Seed the 8 migrated decidesk rows in the same fragment using the resolved URIs/labels from
+      `design.md`'s Seed Data table — never the `c_PLACEHOLDER_...` values decidesk shipped
+
+## 2. SitemapService consumption fallback
+
+- [ ] 2.1 Extend `SitemapService::mapDiwooDocument()` (`lib/Service/SitemapService.php:546-565`) with a
+      type-level default lookup against an active `WooCategoryMapping` row for
+      `(app: "opencatalogi", objectType: <publication's schema slug>)`, used only when the publication
+      declares no `category`/`tooiCategorieUri`/`tooiCategorieNaam` of its own, before the axis is reported
+      as an unresolved violation
+- [ ] 2.2 Add `@spec openspec/changes/woo-category-mapping-intake/specs/woo-compliance/spec.md` PHPDoc tag to
+      the modified method
+
+## 3. Unit tests
+
+- [ ] 3.1 Test: publication with no declared category + an active mapping for its schema slug →
+      `diwoo:informatiecategorie` resolves to the mapping's URI/label
+- [ ] 3.2 Test: publication with no declared category + no mapping for its schema slug → axis omitted,
+      violation reported (existing behavior unchanged)
+- [ ] 3.3 Test: publication with its own declared category + an active mapping also present → the
+      publication's own category wins; the mapping is not consulted
+- [ ] 3.4 Test: a `WooCategoryMapping` row whose `informatiecategorie` does not resolve to a value-list
+      member is never used as a fallback (WOO-CAT-002)
+
+## 4. Seed data verification
+
+- [ ] 4.1 Confirm all 8 migrated rows resolve against `TooiVocabularyService::informatiecategorieList()` with
+      zero `c_PLACEHOLDER_...` segments remaining
+- [ ] 4.2 Confirm `(app, objectType)` uniqueness across the 8 seeded rows
+
+## 5. Deduplication + integration verification
+
+- [ ] 5.1 Search opencatalogi `lib/Service/` and openregister `lib/Service/` for any existing app-scoped
+      category-mapping capability that overlaps with this schema; document "no overlap found" or the overlap
+      found
+- [ ] 5.2 Verify `ObjectService::searchObjectsPaginated()` (the same abstraction
+      `WooReadinessService::getWooEnabledCatalogs()` already uses, `lib/Service/WooReadinessService.php:243-257`)
+      is the only query path used for the new fallback, and confirm no new controller/REST endpoint was added
+      to serve this lookup to other apps (D4)
+
+## 6. Documentation
+
+- [ ] 6.1 Document the `WooCategoryMapping` schema, its `(app, objectType)` key, and the cross-app OR-query
+      read pattern in `docs/features/woo-compliance.md` (create the section if absent)
+
+## 7. Spec sync
+
+- [ ] 7.1 After verification, sync both delta specs (`woo-category-mapping` new capability, `woo-compliance`
+      MODIFIED `WOO-TOOI-001`) back to `openspec/specs/` per the project's sync step


### PR DESCRIPTION
Authored during the decidesk **Back to Six** programme (2026-08-19/20). Proposal only — no code changes.

opencatalogi owns Woo/DiWoo publication and the TOOI vocabularies, so the schema-slug → informatiecategorie map belongs beside them rather than inside a consuming app. Today it lives in decidesk as `WooCategorieMapping`.

**The migration also fixes a real bug** that proves the ownership argument: all 8 of decidesk's seed rows carry unresolved `c_PLACEHOLDER_…` TOOI URIs — because the mapping lived in an app with no access to the actual vocabulary. The migration resolves all 8 against this repo's own `TooiVocabularyService` (7 → infocat008 "Vergaderstukken decentrale overheden", 1 → infocat001).

Design notes: the key is `(app, objectType)` rather than `objectType` alone, since generalising beyond one app means slugs from different apps can collide. Consumption is a plain OpenRegister object query — no new controller and no cross-app RPC (ADR-022).

decidesk keeps `WooBestuursorgaan` (it binds a decidesk-owned entity); its retirement change is named but deliberately not authored here.

Needs this repo's owners to review before implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)