### PR TITLE
fix(manifest): process and audit fields are no longer editable inputs

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -498,7 +498,8 @@
 								"publicationDate",
 								"depublicationDate",
 								"status"
-							]
+							],
+							"overrides": { "status": { "editable": false } }
 						}
 					},
 					{
@@ -557,7 +558,8 @@
 								"retentionExpiresAt",
 								"retentionNote",
 								"retentionLastEvaluatedAt"
-							]
+							],
+							"overrides": { "retentionExpiresAt": { "editable": false }, "retentionLastEvaluatedAt": { "editable": false } }
 						}
 					},
 					{


### PR DESCRIPTION
`CnObjectDataWidget.editable` defaults to **`true`**, so every property in a data widget's `include` list becomes a text box. That put lifecycle state and audit stamps in front of users as editable fields.

Those are written by the backend when a transition lands (`TransitionEngine` stamps them through `saveObject()`), so an input for them is a control that can only fail or confuse — the guarded path is the lifecycle buttons.

Locked with per-field `overrides.<field>.editable: false` rather than `editable: false` on the widget, because these panels mix process state with fields the user legitimately edits.

**Not fixed here:** widgets with no `include` render *every* schema property; enumerating them would drift as schemas change. 52 such widgets fleet-wide expose 124 process fields. That needs a server-side system-owned marker OpenRegister lacks — filed as ConductionNL/openregister#2644.

Inserted textually, one compact line per widget, so the diff is the change and nothing else. A verifier re-parses both files and asserts the only structural difference is the added overrides. `check:manifest` passes.