### PR TITLE
chore(appinfo): point bugs, repository and screenshots at GitHub

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -68,12 +68,25 @@ Doe een [featureverzoek](https://github.com/OpenCatalogi/.github/issues/new/choo
     </documentation>
     <category>integration</category>
     <website>https://opencatalogi.conduction.nl/</website>
-	<bugs>https://codeberg.org/Conduction/opencatalogi/issues</bugs>
-    <repository type="git">https://codeberg.org/Conduction/opencatalogi.git</repository>
+    <!--
+        GitHub, not Codeberg. The fleet dropped Forgejo/Codeberg on
+        2026-08-19 and GitHub is the only forge again.
 
-	<screenshot>https://codeberg.org/Conduction/opencatalogi/raw/branch/main/img/screenshot-dashboard.png</screenshot>
-	<screenshot>https://codeberg.org/Conduction/opencatalogi/raw/branch/main/img/screenshot-catalog.png</screenshot>
-    <screenshot>https://codeberg.org/Conduction/opencatalogi/raw/branch/main/img/screenshot-publications.png</screenshot>
+        `website` is left alone deliberately — it points at the product
+        site, which is still correct and is not a forge link.
+
+        The URLs below all still answered 200 from a stale mirror, which is
+        why this lasted: a dead link gets found, a live link to an issue
+        tracker nobody reads does not. Each screenshot was checked on the
+        new host before being swapped — all three answer 200 image/png from
+        raw.githubusercontent on `main`.
+    -->
+    <bugs>https://github.com/ConductionNL/opencatalogi/issues</bugs>
+    <repository type="git">https://github.com/ConductionNL/opencatalogi.git</repository>
+
+    <screenshot>https://raw.githubusercontent.com/ConductionNL/opencatalogi/main/img/screenshot-dashboard.png</screenshot>
+    <screenshot>https://raw.githubusercontent.com/ConductionNL/opencatalogi/main/img/screenshot-catalog.png</screenshot>
+    <screenshot>https://raw.githubusercontent.com/ConductionNL/opencatalogi/main/img/screenshot-publications.png</screenshot>
 
    	<dependencies>
         <!--


### PR DESCRIPTION
## What

`bugs`, `repository` and all three `screenshot` URLs in `appinfo/info.xml`
named **Codeberg**, which the fleet dropped on 2026-08-19 in favour of GitHub
as the only forge.

`website` is **deliberately unchanged** — it points at
`https://opencatalogi.conduction.nl/`, the product site, which is still
correct and is not a forge link.

## Why it survived

Every Codeberg URL still answers **200** from a stale mirror. That is exactly
why nobody noticed: a dead link gets found and fixed; a live link to an issue
tracker nobody reads does not.

The screenshots matter beyond tidiness — **the App Store fetches those URLs
itself**, so they are part of what the public listing serves.

## Verification

- Each screenshot checked on the new host *before* being swapped: all three
  answer `200 image/png` from raw.githubusercontent on `main`.
- XSD-valid against `apps.nextcloud.com/schema/apps/info.xsd`
- zero `codeberg` strings remain
- the release workflow's version extraction still returns
  `1.0.9-unstable.20260821042911`

That last assertion is not idle. The equivalent change to nldesign
(ConductionNL/nldesign#367) **broke exactly there**: its explanatory comment
wrote the opening version tag literally in prose, and the workflow's
lookbehind takes the *first* match in the file — so the release read
`" in the"` as its version. The comment added here says what it needs to
without ever writing that tag.
