### PR TITLE
chore: drop the orphaned .hydra gitlink and ignore the path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,22 @@ tests/e2e/test-results/
 # look: server/apps/<app>/playwright-report/ and .../test-results/.
 /playwright-report/
 /test-results/
+
+# `.hydra` — a LOCAL tool directory, never a submodule.
+#
+# It was committed as a gitlink (mode 160000) by 6366bcb on 2026-07-05
+# ("chore: preserve WIP before development sync") without a `.gitmodules`
+# entry, and this repository has never had a `.gitmodules` at all. A gitlink
+# with no URL cannot be cloned, so the entry pointed at a commit
+# (017108c) that is unreachable from anywhere.
+#
+# The visible symptom was in every CI checkout, in the post-job cleanup:
+#     fatal: No url found for submodule path '.hydra' in .gitmodules
+#     The process '/usr/bin/git' failed with exit code 128
+# — a hard `fatal` on every run of every workflow, attached to no failing
+# step, which is why it read as background noise for six weeks.
+#
+# Ignored as well as removed on purpose. Deleting the gitlink alone leaves
+# the trap armed: the next `git add -A` in a tree that has this directory
+# re-commits exactly the same broken entry.
+/.hydra/


### PR DESCRIPTION
## The entry could never have worked

`.hydra` was committed as a **gitlink** (mode `160000`, `017108c`) by `6366bcb`
on 2026-07-05 — *"chore: preserve WIP before development sync"* — without a
`.gitmodules` entry.

This repository has **never had a `.gitmodules` at all** — the path has no
history whatsoever. A gitlink with no URL cannot be resolved, so the entry
named a commit unreachable from anywhere. `git submodule` can't clone it,
checkout can't populate it, nothing has ever been able to use it.

## The symptom, on every single run

In the post-job cleanup of `actions/checkout`:

```
fatal: No url found for submodule path '.hydra' in .gitmodules
The process '/usr/bin/git' failed with exit code 128
```

A hard `fatal` and a `128`, on **every run of every workflow** — attached to no
failing step. That is exactly why it survived six weeks: it cost nothing
visible, so nothing pointed at it.

## Ignored as well as removed — on purpose

Deleting the gitlink alone leaves the trap armed: the next `git add -A` in a
working tree that still has this directory re-commits the identical broken
entry, and the `fatal` returns with no obvious cause.

Same reasoning as ConductionNL/.github#529, where shortening one over-long
string would have left every other branch able to overflow the same way.

## Scope

opencatalogi is the **only** app carrying this — portaliq, nldesign and
launchpad have no `.hydra` entry in their trees.
