### PR TITLE
chore(deps): refresh the shared Conduction locks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2128,9 +2128,9 @@
       }
     },
     "node_modules/@conduction/nextcloud-vue": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.11.1.tgz",
-      "integrity": "sha512-E5oB7KUXL2JO68nMItsmL8kepmx6omI6SqDnKm04U7y81ipRASeyyh9bIB9ViT8/yHsqjBIF2VkwnvIwcuTfFQ==",
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.15.0.tgz",
+      "integrity": "sha512-/CSsaMcprVMYEemvGGorEQgvDRefMi/EFLTpK35A1BqgBu/fP/nMN1V+5r+fPaylEc1LeSdCShKPYwU79rd1eQ==",
       "license": "EUPL-1.2",
       "dependencies": {
         "@ckpack/vue-color": "^1.6.0",
@@ -2153,6 +2153,10 @@
         "@toast-ui/editor": "^3.2.2",
         "@types/react": "^18.0.0",
         "@uiw/codemirror-theme-github": "^4.25.8",
+        "@vue-flow/background": "^1.3.2",
+        "@vue-flow/core": "^1.48.2",
+        "@vue-flow/minimap": "^1.5.4",
+        "@vue-flow/node-resizer": "^1.5.1",
         "ajv": "^8.20.0",
         "ajv-formats": "^3.0.1",
         "apexcharts": "^4.7.0",
@@ -7964,6 +7968,102 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vue-flow/background": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@vue-flow/background/-/background-1.3.2.tgz",
+      "integrity": "sha512-eJPhDcLj1wEo45bBoqTXw1uhl0yK2RaQGnEINqvvBsAFKh/camHJd5NPmOdS1w+M9lggc9igUewxaEd3iCQX2w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@vue-flow/core": "^1.23.0",
+        "vue": "^3.3.0"
+      }
+    },
+    "node_modules/@vue-flow/core": {
+      "version": "1.48.2",
+      "resolved": "https://registry.npmjs.org/@vue-flow/core/-/core-1.48.2.tgz",
+      "integrity": "sha512-raxhgKWE+G/mcEvXJjGFUDYW9rAI3GOtiHR3ZkNpwBWuIaCC1EYiBmKGwJOoNzVFgwO7COgErnK7i08i287AFA==",
+      "license": "MIT",
+      "dependencies": {
+        "@vueuse/core": "^10.5.0",
+        "d3-drag": "^3.0.0",
+        "d3-interpolate": "^3.0.1",
+        "d3-selection": "^3.0.0",
+        "d3-zoom": "^3.0.0"
+      },
+      "peerDependencies": {
+        "vue": "^3.3.0"
+      }
+    },
+    "node_modules/@vue-flow/core/node_modules/@types/web-bluetooth": {
+      "version": "0.0.20",
+      "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.20.tgz",
+      "integrity": "sha512-g9gZnnXVq7gM7v3tJCWV/qw7w+KeOlSHAhgF9RytFyifW6AF61hdT2ucrYhPq9hLs5JIryeupHV3qGk95dH9ow==",
+      "license": "MIT"
+    },
+    "node_modules/@vue-flow/core/node_modules/@vueuse/core": {
+      "version": "10.11.1",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-10.11.1.tgz",
+      "integrity": "sha512-guoy26JQktXPcz+0n3GukWIy/JDNKti9v6VEMu6kV2sYBsWuGiTU8OWdg+ADfUbHg3/3DlqySDe7JmdHrktiww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/web-bluetooth": "^0.0.20",
+        "@vueuse/metadata": "10.11.1",
+        "@vueuse/shared": "10.11.1",
+        "vue-demi": ">=0.14.8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vue-flow/core/node_modules/@vueuse/metadata": {
+      "version": "10.11.1",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-10.11.1.tgz",
+      "integrity": "sha512-IGa5FXd003Ug1qAZmyE8wF3sJ81xGLSqTqtQ6jaVfkeZ4i5kS2mwQF61yhVqojRnenVew5PldLyRgvdl4YYuSw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vue-flow/core/node_modules/@vueuse/shared": {
+      "version": "10.11.1",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-10.11.1.tgz",
+      "integrity": "sha512-LHpC8711VFZlDaYUXEBbFBCQ7GS3dVU9mjOhhMhXP6txTV4EhYQg/KGnQuvt/sPAtoUKq7VVUnL6mVtFoL42sA==",
+      "license": "MIT",
+      "dependencies": {
+        "vue-demi": ">=0.14.8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vue-flow/minimap": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@vue-flow/minimap/-/minimap-1.5.4.tgz",
+      "integrity": "sha512-l4C+XTAXnRxsRpUdN7cAVFBennC1sVRzq4bDSpVK+ag7tdMczAnhFYGgbLkUw3v3sY6gokyWwMl8CDonp8eB2g==",
+      "license": "MIT",
+      "dependencies": {
+        "d3-selection": "^3.0.0",
+        "d3-zoom": "^3.0.0"
+      },
+      "peerDependencies": {
+        "@vue-flow/core": "^1.23.0",
+        "vue": "^3.3.0"
+      }
+    },
+    "node_modules/@vue-flow/node-resizer": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@vue-flow/node-resizer/-/node-resizer-1.5.1.tgz",
+      "integrity": "sha512-DNYgXTF39GXPAygVMFmgn5azgFztaWfqbWvv8D/X0HGgeunRrexJ0W94DyXH1rnndGyYAJ0KexEjyelsb+Nlbg==",
+      "license": "MIT",
+      "dependencies": {
+        "d3-drag": "^3.0.0",
+        "d3-selection": "^3.0.0"
+      },
+      "peerDependencies": {
+        "@vue-flow/core": "^1.23.0",
+        "vue": "^3.3.0"
       }
     },
     "node_modules/@vue-macros/common": {


### PR DESCRIPTION
Weekly refresh of the two shared Conduction packages. **Lock-only** - both are
already declared with caret ranges that permit these versions, so what this app
*accepts* is unchanged; only what it currently resolves to moves.

| package | was | now |
|---|---|---|
| conduction/hydra-gates | v1.9.0 | v1.9.0 |
| @conduction/nextcloud-vue | 2.11.1 | 2.15.0 |

**Why this is automated.** Nothing here was ever pinned on purpose. The caret
always allowed the newer release; the lockfile is what froze it, and nobody
re-resolves a lock unless they happen to be touching dependencies. Measured
across the fleet on 2026-08-20: every app sat on hydra-gates v1.8.0 while
v1.8.1 was out, and fourteen sat below nc-vue 2.7.0 - twelve of them on 2.3.0.
Neither number was a decision.

**Why it is a PR and not a push.** Because a shared bump is not always safe and
this repository's suite is what knows. Taking hydra-gates v1.8.1 added
patchObject() to a published interface, which is a load-time fatal for any
concrete test double implementing it without the method - the suite dies before
a single test runs. Two apps needed stub updates first.

**If this PR is red, fix it on this branch.** While it stays open the weekly run
skips this app entirely and will not touch your commits - it never force-pushes
and never reuses a branch.

Opened by fleet-shared-dep-bump.yml in ConductionNL/.github.
