### PR TITLE
docs: repoint openregister cross-repo links from Codeberg to GitHub

### DIFF
--- a/openspec/changes/add-document-content-search/design.md
+++ b/openspec/changes/add-document-content-search/design.md
@@ -49,7 +49,7 @@ A content-matched document row is **byte-shape-identical** to a metadata-matched
 
 ## Database Changes
 
-**None on the OpenCatalogi side.** The chunk store (`openregister_chunks`) + PostgreSQL `tsvector` GIN index already exist in OpenRegister via the merged [`hybrid-document-search`](https://codeberg.org/Conduction/openregister/src/branch/development/openspec/changes/hybrid-document-search) change (migration `Version1Date20260706101000`). No new tables, columns, or migrations required by WOO-517.
+**None on the OpenCatalogi side.** The chunk store (`openregister_chunks`) + PostgreSQL `tsvector` GIN index already exist in OpenRegister via the merged [`hybrid-document-search`](https://github.com/ConductionNL/openregister/tree/development/openspec/changes/hybrid-document-search) change (migration `Version1Date20260706101000`). No new tables, columns, or migrations required by WOO-517.
 
 ## Nextcloud Integration
 

--- a/openspec/changes/add-document-content-search/discovery.md
+++ b/openspec/changes/add-document-content-search/discovery.md
@@ -39,7 +39,7 @@ Read-only exploration of `~/woo506-test/openregister/` — no code changes. Focu
 ### Chunk store + index (present, complete)
 
 - **Table `openregister_chunks`** — columns include `text_content` (TEXT), `source_type` (`'file'` or `'object'`), `source_id`, plus language metadata.
-- **PostgreSQL functional GIN index** on `to_tsvector('simple', text_content)` shipped by migration `Version1Date20260706101000` under the merged [`hybrid-document-search`](https://codeberg.org/Conduction/openregister/src/branch/development/openspec/changes/hybrid-document-search) change.
+- **PostgreSQL functional GIN index** on `to_tsvector('simple', text_content)` shipped by migration `Version1Date20260706101000` under the merged [`hybrid-document-search`](https://github.com/ConductionNL/openregister/tree/development/openspec/changes/hybrid-document-search) change.
 - **Query API present**: `ChunkMapper::searchByKeyword()` uses `ts_rank` scoring and returns chunk hits with `source_type` + `source_id` — exactly the shape needed to join back to the owning document.
 
 ### Missing wire (the only OR-side gap)

--- a/openspec/changes/add-document-content-search/migration.md
+++ b/openspec/changes/add-document-content-search/migration.md
@@ -2,7 +2,7 @@
 
 ## Current State
 
-No OpenCatalogi database schema state is relevant to this change. The chunk store the feature reads from — `openregister_chunks` (with `text_content` column + PostgreSQL `tsvector` GIN index) — already exists in OpenRegister via the merged [`hybrid-document-search`](https://codeberg.org/Conduction/openregister/src/branch/development/openspec/changes/hybrid-document-search) change (migration `Version1Date20260706101000`). No prior OpenCatalogi table, column, or index is touched by this feature.
+No OpenCatalogi database schema state is relevant to this change. The chunk store the feature reads from — `openregister_chunks` (with `text_content` column + PostgreSQL `tsvector` GIN index) — already exists in OpenRegister via the merged [`hybrid-document-search`](https://github.com/ConductionNL/openregister/tree/development/openspec/changes/hybrid-document-search) change (migration `Version1Date20260706101000`). No prior OpenCatalogi table, column, or index is touched by this feature.
 
 ## Target State
 


### PR DESCRIPTION
Part of the fleet Codeberg -> GitHub link sweep.

## What changed (3 files, 3 URLs)
`openspec/changes/add-document-content-search/{discovery,design,migration}.md` — the same link to openregister's `hybrid-document-search` change, three times.

```
- https://codeberg.org/Conduction/openregister/src/branch/development/openspec/changes/hybrid-document-search
+ https://github.com/ConductionNL/openregister/tree/development/openspec/changes/hybrid-document-search
```

Host **and path shape** converted together: Codeberg's `/src/branch/<B>/<DIR>` is GitHub's `/tree/<B>/<DIR>`. The target is a directory, so `/blob/` would have 404'd — a host-only swap produces a GitHub host wearing a Codeberg path shape.

**Checked the target is not dead on both hosts**: `gh api repos/ConductionNL/openregister/contents/openspec/changes/hybrid-document-search?ref=development` lists the change (not archived), and the new URL returns **HTTP 200**.

## Deliberately left alone
- `lib/Settings/register.d/publiccode-software.json:159` — `codeberg.org` appears in the description of *the forge a publiccode file was harvested from*. That is a **feature**, not a stale link; and register.d prose is rewritten wholesale by `Schema::hydrate()` on import, so it is edited only with intent.
- `openspec/changes/archive/**` (5 hits incl. `hydra.json` `repo` fields and a `pr-create.sh`) — frozen historical records.
- `appinfo/info.xml:72` — prose that already states the fleet uses GitHub, not Codeberg. Correct as written.
- `tests/e2e/visual/README.md` — accurate history that the Forgejo/Codeberg visual step was removed.

No issue or PR numbers were mapped to GitHub (numbering does not correspond, and GitHub serves `/pulls/<N>` as a 200 list page).

## Verification
Markdown-only. `grep -rn 'codeberg\.org'` outside `changes/archive/` now returns only the register.d feature line. New URL spot-checked: 200.