### PR TITLE
refactor(lib): move background jobs out of lib/Cron into lib/BackgroundJob

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -134,8 +134,8 @@ Doe een [featureverzoek](https://github.com/OpenCatalogi/.github/issues/new/choo
 	</dependencies>
 
 	<background-jobs>
-		<job>OCA\OpenCatalogi\Cron\DirectorySync</job>
-		<job>OCA\OpenCatalogi\Cron\RetentionEvaluation</job>
+		<job>OCA\OpenCatalogi\BackgroundJob\DirectorySync</job>
+		<job>OCA\OpenCatalogi\BackgroundJob\RetentionEvaluation</job>
 	</background-jobs>
 
 	<repair-steps>

--- a/lib/BackgroundJob/Broadcast.php
+++ b/lib/BackgroundJob/Broadcast.php
@@ -8,7 +8,7 @@
  * directories about this instance.
  *
  * @category Cron
- * @package  OCA\OpenCatalogi\Cron
+ * @package  OCA\OpenCatalogi\BackgroundJob
  *
  * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
@@ -24,7 +24,7 @@
  * @spec openspec/specs/dashboard/spec.md
  */
 
-namespace OCA\OpenCatalogi\Cron;
+namespace OCA\OpenCatalogi\BackgroundJob;
 
 use OCA\OpenCatalogi\Service\BroadcastService;
 use OCP\AppFramework\Utility\ITimeFactory;

--- a/lib/BackgroundJob/DirectorySync.php
+++ b/lib/BackgroundJob/DirectorySync.php
@@ -4,7 +4,7 @@
  * Directory sync cron job.
  *
  * @category Cron
- * @package  OCA\OpenCatalogi\Cron
+ * @package  OCA\OpenCatalogi\BackgroundJob
  *
  * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
@@ -20,7 +20,7 @@
  * @spec openspec/specs/dashboard/spec.md
  */
 
-namespace OCA\OpenCatalogi\Cron;
+namespace OCA\OpenCatalogi\BackgroundJob;
 
 use OCA\OpenCatalogi\Service\DirectoryService;
 use OCA\OpenCatalogi\Service\SettingsService;

--- a/lib/BackgroundJob/RetentionEvaluation.php
+++ b/lib/BackgroundJob/RetentionEvaluation.php
@@ -13,7 +13,7 @@
  * that previously left fleet jobs never running).
  *
  * @category Cron
- * @package  OCA\OpenCatalogi\Cron
+ * @package  OCA\OpenCatalogi\BackgroundJob
  *
  * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
@@ -29,7 +29,7 @@
  * @spec openspec/specs/publication-retention-lifecycle/spec.md#requirement-daily-retention-evaluation-job-ret-005
  */
 
-namespace OCA\OpenCatalogi\Cron;
+namespace OCA\OpenCatalogi\BackgroundJob;
 
 use OCA\OpenCatalogi\Service\RetentionService;
 use OCP\AppFramework\Utility\ITimeFactory;

--- a/lib/Controller/SetupController.php
+++ b/lib/Controller/SetupController.php
@@ -422,7 +422,7 @@ class SetupController extends Controller {
 	 * this step brings them all up to date in one go — the wizard equivalent
 	 * of the admin-settings "Sync directories now" button, which routes to
 	 * the same `DirectoryService::doCronSync()` used by the periodic cron
-	 * (`Cron\DirectorySync`).
+	 * (`BackgroundJob\DirectorySync`).
 	 *
 	 * Non-fatal by design: a peer that is briefly offline should not block
 	 * setup completion. The message surfaces the succeeded / failed split so

--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -55,7 +55,7 @@ use RuntimeException;
  * CouplingBetweenObjects is suppressed at 13 (threshold is "under 13"), and
  * this is the one finding in this change I could not close honestly.
  *
- * What was closed: the class also referenced OCA\OpenCatalogi\Cron\DirectorySync
+ * What was closed: the class also referenced OCA\OpenCatalogi\BackgroundJob\DirectorySync
  * purely to read three interval constants, which took it to 14. Those constants
  * now live here — on the class that publishes them via getSyncOptions() and
  * enforces them in updateSyncOptions() — and DirectorySync aliases them. That

--- a/openspec/changes/beta-surface-alignment/proposal.md
+++ b/openspec/changes/beta-surface-alignment/proposal.md
@@ -39,8 +39,8 @@ Fleet-wide beta-readiness audit (2026-07-07) found:
 |---|---|---|
 | DCAT-AP export | Verified — kept | `lib/Controller/DcatController.php`, `DcatService`/`DcatSerializer` |
 | Woo / DIWOO compliance, 17 categories | Verified, count corrected (was "eleven") | `openspec/specs/woo-compliance/spec.md` WOO-003, `WooController`, `SitemapController` |
-| Federated directory sync | Verified — kept | `lib/Cron/DirectorySync.php`, `DirectoryController` |
-| Retention lifecycle + dashboard widget | Verified — kept | `lib/Cron/RetentionEvaluation.php`, `src/views/widgets/RetentionWidget.vue` |
+| Federated directory sync | Verified — kept | `lib/BackgroundJob/DirectorySync.php`, `DirectoryController` |
+| Retention lifecycle + dashboard widget | Verified — kept | `lib/BackgroundJob/RetentionEvaluation.php`, `src/views/widgets/RetentionWidget.vue` |
 | AI Chat Companion / LLM support | Verified but overclaimed — narrowed | `lib/Mcp/OpenCatalogiToolProvider.php` exposes 2 read-only MCP tools, not open-ended "ask in plain language" semantic search |
 | XWiki wiki-macro integration | **Removed — no code** | `grep -rli xwiki` across lib/src: zero hits |
 | Mail/Files sidebar integration | **Removed — no code** | No `FilesPlugin`/`MailPlugin`/sidebar-search controller or component exists |

--- a/openspec/changes/beta-surface-alignment/specs/beta-alignment/spec.md
+++ b/openspec/changes/beta-surface-alignment/specs/beta-alignment/spec.md
@@ -10,7 +10,7 @@ The app metadata (`appinfo/info.xml`), the product page (`conduction.nl/apps/ope
 
 #### Scenario: marketing claims map to shipped code
 - GIVEN a claim on the product page (e.g. an integration, a standard, a compliance regime)
-- WHEN the claim is checked against `lib/Controller/*`, `lib/Mcp/*`, `lib/Cron/*`, and `src/manifest.json`
+- WHEN the claim is checked against `lib/Controller/*`, `lib/Mcp/*`, `lib/BackgroundJob/*`, and `src/manifest.json`
 - THEN there MUST exist a corresponding controller, cron job, MCP tool provider, or manifest entry; otherwise the claim MUST be removed or corrected
 
 #### Scenario: quantitative claims are verified against the spec/code

--- a/openspec/changes/dashboard/context-brief.md
+++ b/openspec/changes/dashboard/context-brief.md
@@ -99,11 +99,11 @@ The `boot()` method is intentionally empty. Initialization is handled by the `In
 
 ## Broadcast Cron Job Registration Bug (Gap 12)
 
-The `Broadcast` cron job class exists at `lib/Cron/Broadcast.php` and is fully implemented (extends `TimedJob`, runs every 4 hours, calls `BroadcastService::broadcast(null)`). However, it is **NOT registered** in `info.xml`:
+The `Broadcast` cron job class exists at `lib/BackgroundJob/Broadcast.php` and is fully implemented (extends `TimedJob`, runs every 4 hours, calls `BroadcastService::broadcast(null)`). However, it is **NOT registered** in `info.xml`:
 
 ```xml
 <background-jobs>
-    <job>OCA\OpenCatalogi\Cron\DirectorySync</job>
+    <job>OCA\OpenCatalogi\BackgroundJob\DirectorySync</job>
     <!-- Broadcast is MISSING from this list -->
 </background-jobs>
 ```

--- a/openspec/changes/dashboard/design.md
+++ b/openspec/changes/dashboard/design.md
@@ -6,7 +6,7 @@ OpenCatalogi's main entry point is `DashboardController::page()` which renders t
 
 **Known gaps to address:**
 - **Gap 17 (DSH-004)**: `DashboardController::index()` was deleted but the `dashboard#index` GET route still exists in `routes.php`. Any call to `/apps/opencatalogi/index` results in a method-not-found runtime error.
-- **Gap 12 (DIR-007)**: `lib/Cron/Broadcast.php` is a fully implemented `TimedJob` (runs every 4 hours, calls `BroadcastService::broadcast(null)`) but is not listed under `<background-jobs>` in `appinfo/info.xml`. Nextcloud only discovers background jobs declared there, so broadcasting never runs.
+- **Gap 12 (DIR-007)**: `lib/BackgroundJob/Broadcast.php` is a fully implemented `TimedJob` (runs every 4 hours, calls `BroadcastService::broadcast(null)`) but is not listed under `<background-jobs>` in `appinfo/info.xml`. Nextcloud only discovers background jobs declared there, so broadcasting never runs.
 - **Gap 21 (DSH-005..008)**: `Application.php` bootstrap registers widgets, event listeners, and vendor autoload — documented here for traceability, no code change expected.
 
 **Constraints:**
@@ -151,7 +151,7 @@ Stored in OpenRegister (register resolved from `IAppConfig:listing_register`, sc
 | File | Change |
 |------|--------|
 | `appinfo/routes.php` | Remove dead `['name' => 'dashboard#index', ...]` route entry |
-| `appinfo/info.xml` | Add `<job>OCA\OpenCatalogi\Cron\Broadcast</job>` under `<background-jobs>` |
+| `appinfo/info.xml` | Add `<job>OCA\OpenCatalogi\BackgroundJob\Broadcast</job>` under `<background-jobs>` |
 | `lib/AppInfo/Application.php` | Verify widget + event listener registrations (no code change expected) |
 | `lib/Controller/ListingController.php` | Verify CRUD methods, CORS, and auth annotations |
 | `lib/Controller/DirectoryController.php` | Verify sync endpoints and CORS |

--- a/openspec/changes/dashboard/specs/dashboard/spec.md
+++ b/openspec/changes/dashboard/specs/dashboard/spec.md
@@ -12,7 +12,7 @@ OpenCatalogi is a government transparency publication platform deployed by Dutch
 
 **Known gaps addressed by this spec:**
 - **DSH-004 / Gap 17**: `DashboardController::index()` was deleted but the `dashboard#index` GET route remains in `routes.php`, causing a runtime error on `GET /index`.
-- **DIR-007 / Gap 12**: `lib/Cron/Broadcast.php` is fully implemented but not listed in `appinfo/info.xml`, so automatic broadcasting never runs.
+- **DIR-007 / Gap 12**: `lib/BackgroundJob/Broadcast.php` is fully implemented but not listed in `appinfo/info.xml`, so automatic broadcasting never runs.
 
 **Relation to existing specs:**
 - `auto-publishing` spec: `ObjectCreatedEventListener` and `ObjectUpdatedEventListener` (registered in `Application.php`) implement auto-publishing behaviour.
@@ -242,7 +242,7 @@ The `DirectorySync` background job MUST be registered in `appinfo/info.xml` and 
 The `Broadcast` background job MUST be declared in `appinfo/info.xml` under `<background-jobs>`.
 
 #### Scenario: Broadcast job registered in info.xml
-- GIVEN `OCA\OpenCatalogi\Cron\Broadcast` is listed in `appinfo/info.xml`
+- GIVEN `OCA\OpenCatalogi\BackgroundJob\Broadcast` is listed in `appinfo/info.xml`
 - WHEN the Nextcloud background job system discovers jobs
 - THEN the `Broadcast` job MUST be discovered and scheduled
 - AND `BroadcastService::broadcast(null)` MUST be called every 4 hours

--- a/openspec/changes/dashboard/tasks.md
+++ b/openspec/changes/dashboard/tasks.md
@@ -8,9 +8,9 @@
 
 ## 2. Bug Fix — Broadcast Cron Not Registered (DIR-007 / Gap 12)
 
-- [ ] 2.1 Open `appinfo/info.xml` and add `<job>OCA\OpenCatalogi\Cron\Broadcast</job>` inside the `<background-jobs>` block alongside `DirectorySync`
-- [ ] 2.2 Verify `lib/Cron/Broadcast.php` exists, extends `TimedJob`, and calls `BroadcastService::broadcast(null)` (no code change expected)
-- [ ] 2.3 Smoke test: confirm Nextcloud lists `OCA\OpenCatalogi\Cron\Broadcast` in the background job table after app reload
+- [ ] 2.1 Open `appinfo/info.xml` and add `<job>OCA\OpenCatalogi\BackgroundJob\Broadcast</job>` inside the `<background-jobs>` block alongside `DirectorySync`
+- [ ] 2.2 Verify `lib/BackgroundJob/Broadcast.php` exists, extends `TimedJob`, and calls `BroadcastService::broadcast(null)` (no code change expected)
+- [ ] 2.3 Smoke test: confirm Nextcloud lists `OCA\OpenCatalogi\BackgroundJob\Broadcast` in the background job table after app reload
 
 ## 3. Dashboard Bootstrap Verification (DSH-005..008)
 

--- a/openspec/coverage-report.json
+++ b/openspec/coverage-report.json
@@ -71,8 +71,8 @@
       {"file": "lib/Controller/UiController.php", "method": "pages", "reason": "single-line-SPA-template-delegation"},
       {"file": "lib/Controller/UiController.php", "method": "menus", "reason": "single-line-SPA-template-delegation"},
       {"file": "lib/Controller/UiController.php", "method": "directory", "reason": "single-line-SPA-template-delegation"},
-      {"file": "lib/Cron/Broadcast.php", "method": "__construct", "reason": "TimedJob-setup-boilerplate"},
-      {"file": "lib/Cron/DirectorySync.php", "method": "__construct", "reason": "TimedJob-setup-boilerplate"},
+      {"file": "lib/BackgroundJob/Broadcast.php", "method": "__construct", "reason": "TimedJob-setup-boilerplate"},
+      {"file": "lib/BackgroundJob/DirectorySync.php", "method": "__construct", "reason": "TimedJob-setup-boilerplate"},
       {"file": "lib/Dashboard/CatalogWidget.php", "method": "__construct", "reason": "constructor"},
       {"file": "lib/Dashboard/CatalogWidget.php", "method": "getId", "reason": "IWidget-getter"},
       {"file": "lib/Dashboard/CatalogWidget.php", "method": "getTitle", "reason": "IWidget-getter"},
@@ -206,8 +206,8 @@
       {"file": "lib/Controller/SitemapController.php", "method": "sitemap", "capability": "woo-compliance", "req_id": "WOO-002/005/006/009/010", "confidence": 0.95, "needs_review": false, "signal": "GET /api/{catalogSlug}/sitemaps/{categoryCode}/publications via sitemapService.buildSitemap; paginated"},
       {"file": "lib/Controller/ThemesController.php", "method": "index", "capability": "content-management", "req_id": "CMS-020/022/023/024", "confidence": 0.95, "needs_review": false, "signal": "GET /api/themes with pagination and facets; CORS"},
       {"file": "lib/Controller/ThemesController.php", "method": "show", "capability": "content-management", "req_id": "CMS-021/024", "confidence": 0.95, "needs_review": false, "signal": "GET /api/themes/{id}"},
-      {"file": "lib/Cron/Broadcast.php", "method": "run", "capability": "dashboard", "req_id": "DIR-007", "confidence": 0.9, "needs_review": false, "signal": "TimedJob run() body — spec explicitly notes DIR-007 is 'Bug (Not Registered)' because info.xml lacks this class; the run() method itself implements the contract"},
-      {"file": "lib/Cron/DirectorySync.php", "method": "run", "capability": "dashboard", "req_id": "DIR-004", "confidence": 0.95, "needs_review": false, "signal": "TimedJob run() body — calls DirectoryService::doCronSync hourly"},
+      {"file": "lib/BackgroundJob/Broadcast.php", "method": "run", "capability": "dashboard", "req_id": "DIR-007", "confidence": 0.9, "needs_review": false, "signal": "TimedJob run() body — spec explicitly notes DIR-007 is 'Bug (Not Registered)' because info.xml lacks this class; the run() method itself implements the contract"},
+      {"file": "lib/BackgroundJob/DirectorySync.php", "method": "run", "capability": "dashboard", "req_id": "DIR-004", "confidence": 0.95, "needs_review": false, "signal": "TimedJob run() body — calls DirectoryService::doCronSync hourly"},
       {"file": "lib/Dashboard/CatalogWidget.php", "method": "load", "capability": "dashboard", "req_id": "DSH-005", "confidence": 0.9, "needs_review": false, "signal": "IWidget::load() — registers CatalogWidget JS+CSS"},
       {"file": "lib/Dashboard/UnpublishedAttachmentsWidget.php", "method": "load", "capability": "dashboard", "req_id": "DSH-005", "confidence": 0.9, "needs_review": false, "signal": "IWidget::load() — registers widget JS+CSS"},
       {"file": "lib/Dashboard/UnpublishedPublicationsWidget.php", "method": "load", "capability": "dashboard", "req_id": "DSH-005", "confidence": 0.9, "needs_review": false, "signal": "IWidget::load() — registers widget JS+CSS"},
@@ -507,7 +507,7 @@
         {"file": "lib/Service/FileService.php", "note": "Spec notes a `use Mpdf\\MpMpdfdf;` typo. Worth a quick fix even though code works because it references the class directly."}
       ],
       "broadcast-cron-not-registered": [
-        {"file": "appinfo/info.xml", "note": "Spec WOO-008 & DIR-007 both flag this: Broadcast cron class exists at lib/Cron/Broadcast.php but is not listed under <background-jobs>. Either register it or delete the class. (Out of opsx-coverage-scan scope but surfaced for human triage.)"}
+        {"file": "appinfo/info.xml", "note": "Spec WOO-008 & DIR-007 both flag this: Broadcast cron class exists at lib/BackgroundJob/Broadcast.php but is not listed under <background-jobs>. Either register it or delete the class. (Out of opsx-coverage-scan scope but surfaced for human triage.)"}
       ],
       "robots-controller-misses-haswoosite-check": [
         {"file": "lib/Controller/RobotsController.php", "note": "Spec WOO-008 (Must) is implemented as 'Bug' — robots.txt emits sitemap URLs for every catalog with a slug regardless of `hasWooSitemap`. SitemapService::isValidSitemapRequest does the right check; controller should mirror."}

--- a/openspec/coverage-report.md
+++ b/openspec/coverage-report.md
@@ -140,8 +140,8 @@ Grouped by capability, then file. Confidence ≥ 0.85 unless flagged `NEEDS-REVI
 | lib/Controller/ListingsController.php | destroy | LST-005 | 0.95 | DELETE /api/listings/{id} |
 | lib/Controller/ListingsController.php | synchronise | DIR-002/003/004 | 0.92 | POST /api/listings/sync — both single & all |
 | lib/Controller/ListingsController.php | add | DIR-005/008 | 0.95 | POST /api/listings/add (PublicPage) |
-| lib/Cron/Broadcast.php | run | DIR-007 | 0.9 | Method exists; spec acknowledges info.xml registration BUG |
-| lib/Cron/DirectorySync.php | run | DIR-004 | 0.95 | Hourly cron → doCronSync |
+| lib/BackgroundJob/Broadcast.php | run | DIR-007 | 0.9 | Method exists; spec acknowledges info.xml registration BUG |
+| lib/BackgroundJob/DirectorySync.php | run | DIR-004 | 0.95 | Hourly cron → doCronSync |
 | lib/Dashboard/CatalogWidget.php | load | DSH-005 | 0.9 | Widget asset registration |
 | lib/Dashboard/UnpublishedAttachmentsWidget.php | load | DSH-005 | 0.9 | Widget asset registration |
 | lib/Dashboard/UnpublishedPublicationsWidget.php | load | DSH-005 | 0.9 | Widget asset registration |

--- a/tests/Unit/BackgroundJob/BroadcastTest.php
+++ b/tests/Unit/BackgroundJob/BroadcastTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Unit\Cron;
+namespace Unit\BackgroundJob;
 
-use OCA\OpenCatalogi\Cron\Broadcast;
+use OCA\OpenCatalogi\BackgroundJob\Broadcast;
 use OCA\OpenCatalogi\Service\BroadcastService;
 use OCP\AppFramework\Utility\ITimeFactory;
 use PHPUnit\Framework\TestCase;

--- a/tests/Unit/BackgroundJob/DirectorySyncTest.php
+++ b/tests/Unit/BackgroundJob/DirectorySyncTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Unit\Cron;
+namespace Unit\BackgroundJob;
 
-use OCA\OpenCatalogi\Cron\DirectorySync;
+use OCA\OpenCatalogi\BackgroundJob\DirectorySync;
 use OCA\OpenCatalogi\Service\DirectoryService;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\IAppConfig;

--- a/tests/Unit/BackgroundJob/RetentionEvaluationTest.php
+++ b/tests/Unit/BackgroundJob/RetentionEvaluationTest.php
@@ -15,16 +15,16 @@
 
 declare(strict_types=1);
 
-namespace Unit\Cron;
+namespace Unit\BackgroundJob;
 
-use OCA\OpenCatalogi\Cron\RetentionEvaluation;
+use OCA\OpenCatalogi\BackgroundJob\RetentionEvaluation;
 use OCA\OpenCatalogi\Service\RetentionService;
 use OCP\AppFramework\Utility\ITimeFactory;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
 /**
- * @covers \OCA\OpenCatalogi\Cron\RetentionEvaluation
+ * @covers \OCA\OpenCatalogi\BackgroundJob\RetentionEvaluation
  */
 class RetentionEvaluationTest extends TestCase {
 


### PR DESCRIPTION
Nextcloud's convention for background jobs is `lib/BackgroundJob/`; `lib/Cron/` is a directory the app framework has no notion of. Part of the 2026-08-25 fleet structure audit — **ADR-100 Decision 3**. Five apps use `lib/Cron/`; two more carry *both* directories.

Moved `Broadcast`, `DirectorySync` and `RetentionEvaluation` plus their three tests, carrying namespaces, `@package` tags, the tests' own `Unit\Cron` namespace and their `use` statements.

## The line that would have broken silently

`appinfo/info.xml` registers jobs by **fully-qualified class name**. A move without updating it leaves the registration pointing at a class that no longer exists — and Nextcloud does not fail the install for that. The job simply never runs, which is indistinguishable from a job that ran and found nothing to do.

Verified after the move: both registered classes resolve to real files, and all six files pass `php -l`.

## Docs

Updated in the **active** openspec changes (`beta-surface-alignment`, `dashboard`) and the generated coverage report, so no live instruction points at a path that no longer exists. `openspec/changes/archive/` is deliberately untouched — it records what was true when written.

## Not fixed here, but worth knowing

`lib/BackgroundJob/Broadcast.php` is fully implemented but **is not registered** in `info.xml`, so broadcasting has never run. That is already tracked as **DIR-007 / Gap 12** in the `dashboard` change, whose `tasks.md` still has the registration unchecked. Registering it would start a job that has never executed on any instance — a behavioural change that belongs to that change, not to a directory move.