### PR TITLE
fix(repair): remove the oc_jobs rows the Cron → BackgroundJob move orphaned

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -147,6 +147,24 @@ Doe een [featureverzoek](https://github.com/OpenCatalogi/.github/issues/new/choo
 				non-destructive; safe to re-run.
 			-->
 			<step>OCA\OpenCatalogi\Repair\RenameDutchPublicationColumns</step>
+			<!--
+				The background jobs moved from OCA\OpenCatalogi\Cron to
+				OCA\OpenCatalogi\BackgroundJob in #1119. The <job> entries above
+				are a REGISTRATION instruction, not a description of state: on
+				upgrade Nextcloud ADDS a job it does not have, but never removes
+				one whose class disappeared — it cannot tell a renamed class
+				from one merely unavailable this boot.
+
+				Measured on a live instance carrying that merge: oc_jobs still
+				held OCA\OpenCatalogi\Cron\DirectorySync and
+				...\Cron\RetentionEvaluation next to their replacements. A row
+				naming a missing class fails to build on every cron tick, and
+				logs rather than raises.
+
+				post-migration only: a fresh install has no rows to remove, and
+				the step is idempotent either way.
+			-->
+			<step>OCA\OpenCatalogi\Repair\RemoveRetiredCronJobs</step>
 		</post-migration>
 		<!--
 			Nextcloud runs migrateSchemaOnly() on a FIRST install, so NEITHER

--- a/lib/Repair/RemoveRetiredCronJobs.php
+++ b/lib/Repair/RemoveRetiredCronJobs.php
@@ -129,6 +129,14 @@ class RemoveRetiredCronJobs implements IRepairStep {
 	public function run(IOutput $output): void {
 		foreach (self::RETIRED_JOB_CLASSES as $class) {
 			try {
+				// PHPStan: remove() is typed `class-string<IJob>|IJob`, and a
+				// plain string is exactly what this step must pass — the
+				// classes are GONE, which is the whole reason the row has to be
+				// removed. A class-string is unobtainable by construction, and
+				// remove() only ever uses the value as the `class` column to
+				// delete on, so the narrower type is about callers registering
+				// jobs, not callers retiring them.
+				/* @phpstan-ignore argument.type */
 				$this->jobList->remove($class);
 				$output->info('Removed retired background job registration: ' . $class);
 			} catch (Throwable $e) {

--- a/lib/Repair/RemoveRetiredCronJobs.php
+++ b/lib/Repair/RemoveRetiredCronJobs.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @license EUPL-1.2
+ * @copyright Copyright (c) 2026, Conduction B.V. <info@conduction.nl>
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+
+namespace OCA\OpenCatalogi\Repair;
+
+use OCP\BackgroundJob\IJobList;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+/**
+ * Removes the `oc_jobs` rows left behind when this app's background jobs moved
+ * out of the retired `OCA\OpenCatalogi\Cron` namespace into
+ * `OCA\OpenCatalogi\BackgroundJob` (ADR-100 Decision 3, PR #1119).
+ *
+ * THIS IS NOT PRECAUTIONARY — THE ORPHANS WERE MEASURED. On a live instance
+ * carrying the merged move, `oc_jobs` still held
+ *
+ *   OCA\OpenCatalogi\Cron\DirectorySync
+ *   OCA\OpenCatalogi\Cron\RetentionEvaluation
+ *
+ * next to their `BackgroundJob` replacements, naming classes that no longer
+ * exist.
+ *
+ * WHY THE MOVE ALONE DOES NOT DO THIS. `appinfo/info.xml`'s `<job>` entries are
+ * a REGISTRATION instruction, not a description of state. On upgrade Nextcloud
+ * ADDS any job it does not already have; it never removes one whose class
+ * disappeared, because it cannot tell a renamed class from one that is merely
+ * unavailable this boot. So the rename leaves the instance holding both rows.
+ *
+ * The orphan is not inert. `\OC\BackgroundJob\JobList::buildJob()` cannot
+ * instantiate a class that does not exist, so every cron tick that reaches the
+ * row fails to build it, and that failure is logged rather than raised — the
+ * quiet kind of broken, on an instance where the replacement job runs fine and
+ * nothing looks wrong.
+ *
+ * Idempotent: `IJobList::remove()` on an absent class is a no-op, so a fresh
+ * install passes through unchanged and re-running costs one DELETE matching
+ * nothing.
+ */
+class RemoveRetiredCronJobs implements IRepairStep {
+
+	/**
+	 * The classes retired by the move, named in full and deliberately as
+	 * literals.
+	 *
+	 * String constants rather than `SomeClass::class` because these classes NO
+	 * LONGER EXIST — a `::class` reference would not compile, which is the
+	 * whole point of the list.
+	 *
+	 * `Broadcast` is included even though it was never registered in
+	 * `info.xml`: it lived in the same retired namespace, and an instance that
+	 * ever had it registered by hand would carry the same dead row. Removing a
+	 * registration that was never there costs nothing.
+	 *
+	 * @var string[]
+	 */
+	private const RETIRED_JOB_CLASSES = [
+		'OCA\OpenCatalogi\Cron\DirectorySync',
+		'OCA\OpenCatalogi\Cron\RetentionEvaluation',
+		'OCA\OpenCatalogi\Cron\Broadcast',
+	];
+
+	/**
+	 * @param IJobList        $jobList The background job list.
+	 * @param LoggerInterface $logger  The logger.
+	 */
+	public function __construct(
+		private IJobList $jobList,
+		private LoggerInterface $logger,
+	) {
+	}//end __construct()
+
+	/**
+	 * The step's name, as shown by `occ upgrade`.
+	 *
+	 * @return string The name.
+	 */
+	public function getName(): string {
+		return 'Remove background-job registrations for the retired OpenCatalogi\Cron namespace';
+	}//end getName()
+
+	/**
+	 * Remove each retired job registration.
+	 *
+	 * Never raises. A repair step that aborts the upgrade over a job row would
+	 * trade a dormant orphan for an instance that will not start, which is the
+	 * worse failure — so a removal that goes wrong is reported and the step
+	 * continues with the next class.
+	 *
+	 * @param IOutput $output The upgrade output.
+	 *
+	 * @return void
+	 */
+	public function run(IOutput $output): void {
+		foreach (self::RETIRED_JOB_CLASSES as $class) {
+			try {
+				$this->jobList->remove($class);
+				$output->info('Removed retired background job registration: ' . $class);
+			} catch (Throwable $e) {
+				// Reported, not raised — see the docblock above.
+				$this->logger->warning(
+					'[RemoveRetiredCronJobs] Could not remove ' . $class . ': ' . $e->getMessage(),
+					['app' => 'opencatalogi', 'exception' => $e]
+				);
+				$output->warning('Could not remove ' . $class . ': ' . $e->getMessage());
+			}
+		}
+
+	}//end run()
+}//end class

--- a/lib/Repair/RemoveRetiredCronJobs.php
+++ b/lib/Repair/RemoveRetiredCronJobs.php
@@ -1,13 +1,24 @@
 <?php
+/**
+ * Repair step for removing the background-job registrations left behind by the
+ * move out of the retired `OCA\OpenCatalogi\Cron` namespace.
+ *
+ * @category Repair
+ * @package  OCA\OpenCatalogi\Repair
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://www.OpenCatalogi.nl
+ */
 
 declare(strict_types=1);
-/**
- * @license EUPL-1.2
- * @copyright Copyright (c) 2026, Conduction B.V. <info@conduction.nl>
- *
- * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
- * SPDX-License-Identifier: EUPL-1.2
- */
 
 
 namespace OCA\OpenCatalogi\Repair;
@@ -47,6 +58,13 @@ use Throwable;
  * Idempotent: `IJobList::remove()` on an absent class is a no-op, so a fresh
  * install passes through unchanged and re-running costs one DELETE matching
  * nothing.
+ *
+ * @spec exclude No canonical spec covers the OCA\OpenCatalogi\Cron ->
+ *  OCA\OpenCatalogi\BackgroundJob move. ADR-100 Decision 3 is an architecture
+ *  record, not a capability spec, and the jobs' own behaviour is unchanged —
+ *  only where their classes live. Pointing this at dashboard/spec.md (which
+ *  covers what DirectorySync DOES) would claim conformance to a requirement
+ *  that says nothing about registration cleanup.
  */
 class RemoveRetiredCronJobs implements IRepairStep {
 
@@ -85,6 +103,9 @@ class RemoveRetiredCronJobs implements IRepairStep {
 	 * The step's name, as shown by `occ upgrade`.
 	 *
 	 * @return string The name.
+	 *
+	 * @spec exclude See the class docblock — no capability spec covers the
+	 *  namespace move this step cleans up after.
 	 */
 	public function getName(): string {
 		return 'Remove background-job registrations for the retired OpenCatalogi\Cron namespace';
@@ -101,6 +122,9 @@ class RemoveRetiredCronJobs implements IRepairStep {
 	 * @param IOutput $output The upgrade output.
 	 *
 	 * @return void
+	 *
+	 * @spec exclude See the class docblock — no capability spec covers the
+	 *  namespace move this step cleans up after.
 	 */
 	public function run(IOutput $output): void {
 		foreach (self::RETIRED_JOB_CLASSES as $class) {

--- a/tests/Unit/Repair/RemoveRetiredCronJobsTest.php
+++ b/tests/Unit/Repair/RemoveRetiredCronJobsTest.php
@@ -1,0 +1,170 @@
+<?php
+/**
+ * Unit tests for the RemoveRetiredCronJobs repair step.
+ *
+ * The step exists because #1119 moved this app's background jobs out of the
+ * `OCA\OpenCatalogi\Cron` namespace, and a class rename orphans its `oc_jobs`
+ * row: `info.xml`'s `<job>` entries ADD registrations on upgrade and never
+ * remove one whose class disappeared. Measured on a live instance carrying the
+ * merge — `oc_jobs` held `Cron\DirectorySync` and `Cron\RetentionEvaluation`
+ * beside their replacements.
+ *
+ * A repair step is exactly the kind of code that must fail loudly in tests and
+ * quietly in production: it runs during `occ upgrade`, so an exception here
+ * aborts an upgrade. These tests assert on WHICH strings are passed and on the
+ * continue-after-failure behaviour, because both are invisible at runtime — the
+ * step has no return value, and a step that removed the wrong names would look
+ * identical to one that worked.
+ *
+ * @category Test
+ * @package  OCA\OpenCatalogi\Tests
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Repair;
+
+use OCA\OpenCatalogi\Repair\RemoveRetiredCronJobs;
+use OCP\BackgroundJob\IJobList;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+
+/**
+ * @covers \OCA\OpenCatalogi\Repair\RemoveRetiredCronJobs
+ *
+ * @spec exclude No canonical spec covers the OCA\OpenCatalogi\Cron ->
+ *  OCA\OpenCatalogi\BackgroundJob move; ADR-100 Decision 3 is an architecture
+ *  record, not a capability spec. Pointing this at an existing spec would
+ *  report conformance to a requirement that says nothing about it.
+ */
+final class RemoveRetiredCronJobsTest extends TestCase {
+
+	/**
+	 * The step removes the retired classes, by their full OLD names.
+	 *
+	 * Asserts the ARGUMENTS, not the call count. The whole value of the step is
+	 * which strings it passes: a version that removed the NEW class names would
+	 * satisfy a count-only assertion while deleting the two registrations the
+	 * app actually depends on.
+	 *
+	 * @return void
+	 */
+	public function testRemovesTheRetiredClassesByName(): void {
+		$removed = [];
+
+		$jobList = $this->createMock(IJobList::class);
+		$jobList->method('remove')->willReturnCallback(
+			static function ($class) use (&$removed): void {
+				$removed[] = $class;
+			}
+		);
+
+		$step = new RemoveRetiredCronJobs($jobList, $this->createMock(LoggerInterface::class));
+		$step->run($this->createMock(IOutput::class));
+
+		$this->assertSame(
+			[
+				'OCA\OpenCatalogi\Cron\DirectorySync',
+				'OCA\OpenCatalogi\Cron\RetentionEvaluation',
+				'OCA\OpenCatalogi\Cron\Broadcast',
+			],
+			$removed,
+			'the step must remove the OLD fully-qualified names; removing the new ones would '
+			. 'delete the registrations the app depends on'
+		);
+
+	}//end testRemovesTheRetiredClassesByName()
+
+	/**
+	 * No surviving class name is touched.
+	 *
+	 * The failure this guards is a careless widening — a future edit that
+	 * removes by short name, or by a `Cron`-substring match, would take the
+	 * live `BackgroundJob\*` registrations with it and stop the app's real jobs
+	 * without any error.
+	 *
+	 * @return void
+	 */
+	public function testNeverRemovesASurvivingRegistration(): void {
+		$removed = [];
+
+		$jobList = $this->createMock(IJobList::class);
+		$jobList->method('remove')->willReturnCallback(
+			static function ($class) use (&$removed): void {
+				$removed[] = $class;
+			}
+		);
+
+		$step = new RemoveRetiredCronJobs($jobList, $this->createMock(LoggerInterface::class));
+		$step->run($this->createMock(IOutput::class));
+
+		foreach ($removed as $class) {
+			$this->assertStringNotContainsString(
+				'BackgroundJob',
+				$class,
+				'a live BackgroundJob registration must never be removed: ' . $class
+			);
+		}
+
+	}//end testNeverRemovesASurvivingRegistration()
+
+	/**
+	 * A failure on one class does not abort the step or the upgrade.
+	 *
+	 * A repair step that raises takes the whole `occ upgrade` with it. Trading
+	 * a dormant orphaned row for an instance that will not start is the worse
+	 * outcome, so the step reports and continues — and "continues" is exactly
+	 * the behaviour a later refactor would quietly drop.
+	 *
+	 * @return void
+	 */
+	public function testAFailureOnOneClassDoesNotStopTheRest(): void {
+		$attempted = [];
+
+		$jobList = $this->createMock(IJobList::class);
+		$jobList->method('remove')->willReturnCallback(
+			static function ($class) use (&$attempted): void {
+				$attempted[] = $class;
+				if (str_contains($class, 'DirectorySync') === true) {
+					throw new RuntimeException('database is gone');
+				}
+			}
+		);
+
+		$step = new RemoveRetiredCronJobs($jobList, $this->createMock(LoggerInterface::class));
+		$step->run($this->createMock(IOutput::class));
+
+		$this->assertContains(
+			'OCA\OpenCatalogi\Cron\RetentionEvaluation',
+			$attempted,
+			'a failure removing the first class must not skip the rest'
+		);
+
+	}//end testAFailureOnOneClassDoesNotStopTheRest()
+
+	/**
+	 * The step is a repair step and names itself.
+	 *
+	 * @return void
+	 */
+	public function testItIsARepairStepWithAName(): void {
+		$step = new RemoveRetiredCronJobs(
+			$this->createMock(IJobList::class),
+			$this->createMock(LoggerInterface::class)
+		);
+
+		$this->assertInstanceOf(IRepairStep::class, $step);
+		$this->assertNotSame('', trim($step->getName()));
+
+	}//end testItIsARepairStepWithAName()
+}//end class


### PR DESCRIPTION
**Measured on a live instance, not inferred.** After #1119 merged, that instance's `oc_jobs` still carried:

```
OCA\OpenCatalogi\Cron\DirectorySync
OCA\OpenCatalogi\Cron\RetentionEvaluation
```

next to their `BackgroundJob` replacements — rows naming classes that no longer exist. Found by querying the running Nextcloud, not by reading the diff.

## Why #1119 alone could not do this

`appinfo/info.xml`'s `<job>` entries are a **registration instruction, not a description of state**. On upgrade Nextcloud *adds* any job it does not already have; it never removes one whose class disappeared, because it cannot distinguish a renamed class from one that is merely unavailable this boot. So the rename leaves the instance holding **both** rows.

The orphan is not inert: `JobList` cannot instantiate a missing class, so every cron tick that reaches the row fails to build it and **logs rather than raises** — the quiet kind of broken, on an instance where the replacement job runs fine and nothing looks wrong.

## What the step does

Removes the retired classes. It also removes `Cron\Broadcast`, which `info.xml` never registered: it lived in the same retired namespace, and an instance that ever registered it by hand carries the same dead row. Removing a registration that was never there costs nothing.

Idempotent — a fresh install removes nothing — and it never raises: a repair step that aborts trades a dormant job row for an instance that will not start. Registered `post-migration` only, since a fresh install has no rows to remove.

## Tests

**4 tests, 7 assertions, green.** They assert *which strings are passed* rather than a call count — a step that removed the **new** class names would satisfy a count-only assertion while deleting the two registrations the app actually depends on. Plus an anti-widening arm asserting no surviving `BackgroundJob` registration is ever touched (the failure mode of a future "remove anything matching `Cron`" edit), and one pinning continue-after-failure.

## Fleet context

Same fix landing across every app in this refactor — `versioniq#231` carries it too, and learniq/hermiq need it next. Part of the 2026-08-25 fleet structure audit, **ADR-100 Decision 3**.
