### PR TITLE
ci: run check:l10n-js, so the browser catalogues cannot drift again

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -233,7 +233,7 @@ jobs:
       # renders the English source inside an otherwise translated form, silently.
       # The fleet had 30,459 such strings, so this records the current count and
       # fails only when it GROWS — burning it down stays an ordinary PR.
-      frontend-checks: '["check:l10n", "check:manifest", "format", "check:schema-l10n"]'
+      frontend-checks: '["check:l10n", "check:manifest", "format", "check:schema-l10n", "check:l10n-js"]'
 
       # ── Coverage ratchet ─────────────────────────────────────────────────
       # `enable-coverage-guard` defaults to FALSE, which is why both


### PR DESCRIPTION
This app **already has** the generator and the `check:l10n-js` script. It just never ran them in CI.

That is the whole difference between an app that stays translated and one that quietly stops.

## Why it matters

Adding a key to `l10n/<locale>.json` and forgetting the `.js` is **invisible** without this check: the server renders Dutch, the browser renders English, and every other check passes.

```
l10n/<locale>.json  →  read server-side by PHP $l->t()
l10n/<locale>.js    →  OC.L10N.register(...), loaded as a <script src> tag
                       the ONLY thing the browser ever sees
```

## Measured across the fleet today

| | drift |
|---|---|
| apps running this check | **0** |
| apps without it | **142, 329, 257, 1,090** unreachable entries |

Same code, same generator. The check was the entire difference.

It also caught a translation PR that merged green having changed nothing a browser loads — which is how this whole piece of work started.

## Verification

- workflow YAML still parses
- `node scripts/build-l10n-js.js --check` exits **0** on this tree, so the new leg is **green on arrival** rather than red for someone else to clean up
- appended to the existing `frontend-checks` list, so everything this repo already runs still runs