### PR TITLE
fix(repair): register CleanupOrphanDirectoryListings, which had never run

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -165,6 +165,27 @@ Doe een [featureverzoek](https://github.com/OpenCatalogi/.github/issues/new/choo
 				the step is idempotent either way.
 			-->
 			<step>OCA\OpenCatalogi\Repair\RemoveRetiredCronJobs</step>
+			<!--
+				Written but never registered, so it had never run once: a class that
+				exists is not a class that runs. gate-98 found it.
+
+				It removes directory listings whose `directory` field is empty or does
+				not point at an `/api/directory` endpoint — rows a since-fixed bug
+				created by storing the federation *publications* URL as a listing.
+				Those rows never sync again and just sit as stale garbage.
+
+				The delete is RECOVERABLE: it goes through OpenRegister's
+				ObjectService::deleteObject(), which soft-deletes — the scan itself
+				filters on `_deleted IS NULL`, so an already-removed row is skipped
+				rather than touched again. Idempotent by the same property: once the
+				store is clean it is a no-op. Listings are a cache of remote
+				directories, not authored content, so a wrongly-removed row comes back
+				on the next sync.
+
+				post-migration only: a fresh install has no stale rows to clean, and
+				the step is idempotent either way.
+			-->
+			<step>OCA\OpenCatalogi\Repair\CleanupOrphanDirectoryListings</step>
 		</post-migration>
 		<!--
 			Nextcloud runs migrateSchemaOnly() on a FIRST install, so NEITHER


### PR DESCRIPTION

A class that exists is not a class that runs. CleanupOrphanDirectoryListings
was complete -- constructor, per-register scan, tally, fail-soft error
handling -- and named nowhere in appinfo/info.xml, so Nextcloud never invoked
it and not one orphan listing was ever cleaned on any instance. gate-98
(repair-step-registration) found it.

What it cleans: rows a since-fixed bug created by storing the federation
*publications* URL in a listing's `directory` field. Those rows never sync
again and sit as stale garbage in the directory store.

Why registering it is safe:

  - The delete is RECOVERABLE. It goes through OpenRegister's
    ObjectService::deleteObject(), which soft-deletes; the scan itself
    filters on `_deleted IS NULL`, so a row already removed is skipped
    rather than touched again.
  - It is idempotent by that same property -- once the store is clean the
    scan returns nothing and the step is a no-op.
  - Listings are a CACHE of remote directories, not authored content, so a
    row removed in error returns on the next sync.
  - The predicate is the directory contract itself: `directory` is null, or
    does not contain `/api/directory`.

post-migration only: a fresh install has no stale rows to clean, and the step
is idempotent either way.

Found while chasing a gate-98 failure across the fleet. Five apps carried repair steps that were written and never registered; openregister's are fixed in #2923, integriq's in #1603, filinq's in #836, and shillinq's sixth turned out to be a *deliberate* hold that needed a gate escape hatch instead (.github#588). This is the last of the genuine ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)