### PR TITLE
feat(walkthrough): show where flows are edited, without asking anyone to build one

### DIFF
--- a/l10n/en.js
+++ b/l10n/en.js
@@ -920,7 +920,10 @@ OC.L10N.register(
         "WOO Sitemap": "WOO Sitemap",
         "Woo-index harvester readiness": "Woo-index harvester readiness",
         "Woo-index registration status": "Woo-index registration status",
-        "You need at least one catalog before you can create a publication. Create a catalog from the catalogs page first.": "You need at least one catalog before you can create a publication. Create a catalog from the catalogs page first."
+        "You need at least one catalog before you can create a publication. Create a catalog from the catalogs page first.": "You need at least one catalog before you can create a publication. Create a catalog from the catalogs page first.",
+        "Where the automation lives": "Where the automation lives",
+        "Flows are what happens without anyone clicking: a reminder before a deadline passes, a confirmation sent on submission. This is where you read and edit them — nothing to build now.": "Flows are what happens without anyone clicking: a reminder before a deadline passes, a confirmation sent on submission. This is where you read and edit them — nothing to build now.",
+        "Open Flows in the menu": "Open Flows in the menu"
     },
     "nplurals=2; plural=(n != 1);"
 )

--- a/l10n/en.json
+++ b/l10n/en.json
@@ -919,7 +919,10 @@
         "WOO Sitemap": "WOO Sitemap",
         "Woo-index harvester readiness": "Woo-index harvester readiness",
         "Woo-index registration status": "Woo-index registration status",
-        "You need at least one catalog before you can create a publication. Create a catalog from the catalogs page first.": "You need at least one catalog before you can create a publication. Create a catalog from the catalogs page first."
+        "You need at least one catalog before you can create a publication. Create a catalog from the catalogs page first.": "You need at least one catalog before you can create a publication. Create a catalog from the catalogs page first.",
+        "Where the automation lives": "Where the automation lives",
+        "Flows are what happens without anyone clicking: a reminder before a deadline passes, a confirmation sent on submission. This is where you read and edit them — nothing to build now.": "Flows are what happens without anyone clicking: a reminder before a deadline passes, a confirmation sent on submission. This is where you read and edit them — nothing to build now.",
+        "Open Flows in the menu": "Open Flows in the menu"
     },
     "plurals": {}
 }

--- a/l10n/nl.js
+++ b/l10n/nl.js
@@ -915,7 +915,10 @@ OC.L10N.register(
         "Glossary term": "Begrip",
         "Content blocks": "Inhoudsblokken",
         "Menu": "Menu",
-        "Flow": "Flow"
+        "Flow": "Flow",
+        "Where the automation lives": "Waar de automatisering zit",
+        "Flows are what happens without anyone clicking: a reminder before a deadline passes, a confirmation sent on submission. This is where you read and edit them — nothing to build now.": "Flows zijn wat er gebeurt zonder dat iemand klikt: een herinnering voordat een termijn verstrijkt, een bevestiging bij indiening. Hier lees en bewerk je ze — je hoeft nu niets te bouwen.",
+        "Open Flows in the menu": "Open Flows in het menu"
     },
     "nplurals=2; plural=(n != 1);"
 )

--- a/l10n/nl.json
+++ b/l10n/nl.json
@@ -914,7 +914,10 @@
         "Glossary term": "Begrip",
         "Content blocks": "Inhoudsblokken",
         "Menu": "Menu",
-        "Flow": "Flow"
+        "Flow": "Flow",
+        "Where the automation lives": "Waar de automatisering zit",
+        "Flows are what happens without anyone clicking: a reminder before a deadline passes, a confirmation sent on submission. This is where you read and edit them — nothing to build now.": "Flows zijn wat er gebeurt zonder dat iemand klikt: een herinnering voordat een termijn verstrijkt, een bevestiging bij indiening. Hier lees en bewerk je ze — je hoeft nu niets te bouwen.",
+        "Open Flows in the menu": "Open Flows in het menu"
     },
     "plurals": {}
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -211,7 +211,7 @@
 							"title": "Where the automation lives",
 							"body": "Flows are what happens without anyone clicking: a reminder before a deadline passes, a confirmation sent on submission. This is where you read and edit them — nothing to build now.",
 							"task": "Open Flows in the menu",
-							"target": {"kind": "nav-item", "ref": "FlowsMenu"},
+							"target": {"kind": "nav-item", "ref": "Flows"},
 							"advanceOn": {"type": "route-match", "route": "Flows"}
 						},
 					{

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://raw.githubusercontent.com/ConductionNL/nextcloud-vue/main/src/schemas/app-manifest-v2.schema.json",
-	"version": "2.5.0",
+	"version": "2.6.0",
 	"dependencies": [
 		"openregister"
 	],
@@ -202,6 +202,18 @@
 							"route": "Directory"
 						}
 					},
+						{
+							"id": "see-flows",
+							"sinceVersion": "2.6.0",
+							"placement": "right",
+							"optional": true,
+							"allowManualNext": true,
+							"title": "Where the automation lives",
+							"body": "Flows are what happens without anyone clicking: a reminder before a deadline passes, a confirmation sent on submission. This is where you read and edit them — nothing to build now.",
+							"task": "Open Flows in the menu",
+							"target": {"kind": "nav-item", "ref": "FlowsMenu"},
+							"advanceOn": {"type": "route-match", "route": "Flows"}
+						},
 					{
 						"id": "done",
 						"sinceVersion": "2.4.0",


### PR DESCRIPTION
This app ships a Flows page and its getting-started tour never mentions it, so the automation surface is reachable only by someone who already knows it is there. Adds one view-only stop pointing at it.

The stop is deliberately view-only: `optional: true`, `allowManualNext: true`, and a `route-match` advance. It shows where flows live and lets the user walk straight past — nothing gates the tour on having built one.

Measured across the 20 fleet manifests: **19 apps declare a walkthrough, 12 ship a flows page, and exactly one tour mentioned flows at all.** This is one of seven apps closing that gap, same step and copy in each.

`manifest.version` gets a minor bump because that is what `sinceVersion` is compared against (`useWalkthrough.composeSteps`) — a returning user whose recorded seen-version equals the old manifest version would otherwise never be shown the new step, silently.

Diff is two lines: the version, and the step.